### PR TITLE
feat: initial revision of Common Message Format

### DIFF
--- a/cpex/framework/cmf/__init__.py
+++ b/cpex/framework/cmf/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/cmf/__init__.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Common Message Format (CMF) Package.
+Provides the canonical, provider-agnostic message representation
+for interactions between users, agents, tools, and language models.
+"""

--- a/cpex/framework/cmf/message.py
+++ b/cpex/framework/cmf/message.py
@@ -1,0 +1,881 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/cmf/message.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Common Message Format (CMF) message models.
+This module implements the canonical message representation for interactions
+between users, agents, tools, and language models. All models are frozen
+(immutable) and require model_copy() for modification, supporting the CMF's
+copy-on-write semantics and mutability tier enforcement.
+
+Domain objects (ToolCall, ImageSource, etc.) are standalone frozen models
+reusable across contexts. ContentPart wrappers (ToolCallContentPart, etc.)
+compose them into the typed content-part hierarchy for message serialization.
+"""
+
+# Standard
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Annotated, Iterator, TYPE_CHECKING, Union
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class Role(str, Enum):
+    """Closed-set enumeration of message roles.
+
+    Identifies WHO is speaking in a conversation turn.
+
+    Attributes:
+        SYSTEM: System-level instructions.
+        DEVELOPER: Developer-provided instructions.
+        USER: Human user input.
+        ASSISTANT: LLM/agent response.
+        TOOL: Tool execution result.
+
+    Examples:
+        >>> Role.USER
+        <Role.USER: 'user'>
+        >>> Role.USER.value
+        'user'
+        >>> Role("assistant")
+        <Role.ASSISTANT: 'assistant'>
+    """
+
+    SYSTEM = "system"
+    DEVELOPER = "developer"
+    USER = "user"
+    ASSISTANT = "assistant"
+    TOOL = "tool"
+
+
+class Channel(str, Enum):
+    """Closed-set enumeration of output channel types.
+
+    Classifies the kind of output a message represents, allowing
+    pipelines to route or filter messages by output type without
+    inspecting content.
+
+    Attributes:
+        ANALYSIS: Intermediate analytical output not intended as final response.
+        COMMENTARY: Meta-level observations about the task or process.
+        FINAL: Terminal response intended for delivery to the end consumer.
+
+    Examples:
+        >>> Channel.FINAL
+        <Channel.FINAL: 'final'>
+        >>> Channel("analysis")
+        <Channel.ANALYSIS: 'analysis'>
+    """
+
+    ANALYSIS = "analysis"
+    COMMENTARY = "commentary"
+    FINAL = "final"
+
+
+class ContentType(str, Enum):
+    """Closed-set enumeration of content part types.
+
+    Discriminator for the typed ContentPart hierarchy, identifying
+    the kind of content carried by each part of a multimodal message.
+
+    Attributes:
+        TEXT: Plain text content.
+        THINKING: Chain-of-thought reasoning.
+        TOOL_CALL: Tool/function invocation request.
+        TOOL_RESULT: Result from tool execution.
+        RESOURCE: Embedded resource with content (MCP).
+        RESOURCE_REF: Lightweight resource reference without embedded content.
+        PROMPT_REQUEST: Prompt template invocation request (MCP).
+        PROMPT_RESULT: Rendered prompt template result.
+        IMAGE: Image content (URL or base64).
+        VIDEO: Video content (URL or base64).
+        AUDIO: Audio content (URL or base64).
+        DOCUMENT: Document content (PDF, Word, etc.).
+
+    Examples:
+        >>> ContentType.TOOL_CALL
+        <ContentType.TOOL_CALL: 'tool_call'>
+        >>> ContentType("text")
+        <ContentType.TEXT: 'text'>
+    """
+
+    TEXT = "text"
+    THINKING = "thinking"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    RESOURCE = "resource"
+    RESOURCE_REF = "resource_ref"
+    PROMPT_REQUEST = "prompt_request"
+    PROMPT_RESULT = "prompt_result"
+    IMAGE = "image"
+    VIDEO = "video"
+    AUDIO = "audio"
+    DOCUMENT = "document"
+
+
+class ResourceType(str, Enum):
+    """Closed-set enumeration of resource types.
+
+    Attributes:
+        FILE: File-system resource.
+        BLOB: Binary large object.
+        URI: Generic URI-addressable resource.
+        DATABASE: Database entity.
+        API: API endpoint.
+        MEMORY: In-memory or ephemeral resource.
+        ARTIFACT: Produced artifact (generated output, build result).
+
+    Examples:
+        >>> ResourceType.FILE
+        <ResourceType.FILE: 'file'>
+        >>> ResourceType("database")
+        <ResourceType.DATABASE: 'database'>
+    """
+
+    FILE = "file"
+    BLOB = "blob"
+    URI = "uri"
+    DATABASE = "database"
+    API = "api"
+    MEMORY = "memory"
+    ARTIFACT = "artifact"
+
+
+# ---------------------------------------------------------------------------
+# Domain Objects (standalone, reusable across contexts)
+# ---------------------------------------------------------------------------
+
+
+class ToolCall(BaseModel):
+    """Normalized tool/function invocation request.
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        tool_call_id: Unique request correlation ID.
+        name: Tool name.
+        arguments: Arguments as a JSON-serializable dict.
+        namespace: Optional namespace for namespaced tools.
+
+    Examples:
+        >>> call = ToolCall(
+        ...     tool_call_id="tc_001",
+        ...     name="get_user",
+        ...     arguments={"user_id": "123"},
+        ... )
+        >>> call.name
+        'get_user'
+        >>> call.arguments
+        {'user_id': '123'}
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    tool_call_id: str = Field(description="Unique request correlation ID.")
+    name: str = Field(description="Tool name.")
+    arguments: dict[str, Any] = Field(default_factory=dict, description="Arguments as a JSON-serializable dict.")
+    namespace: str | None = Field(default=None, description="Namespace for namespaced tools.")
+
+
+class ToolResult(BaseModel):
+    """Result from tool execution.
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        tool_call_id: Correlation ID linking to the corresponding tool call.
+        tool_name: Name of the tool that was executed.
+        content: Result content, any JSON-serializable value.
+        is_error: Whether the result represents an error.
+
+    Examples:
+        >>> result = ToolResult(
+        ...     tool_call_id="tc_001",
+        ...     tool_name="get_user",
+        ...     content={"name": "Alice"},
+        ... )
+        >>> result.is_error
+        False
+        >>> result.tool_name
+        'get_user'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    tool_call_id: str = Field(description="Correlation ID linking to the corresponding tool call.")
+    tool_name: str = Field(description="Name of the tool that was executed.")
+    content: Any = Field(default=None, description="Result content, any JSON-serializable value.")
+    is_error: bool = Field(default=False, description="Whether the result represents an error.")
+
+
+class Resource(BaseModel):
+    """Embedded resource with content (MCP).
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        resource_request_id: Unique request correlation ID.
+        uri: Unique identifier in URI format.
+        name: Human-readable name.
+        description: What this resource contains.
+        resource_type: The kind of resource.
+        content: Text content if embedded.
+        blob: Binary content if embedded.
+        mime_type: MIME type of content.
+        size_bytes: Size information.
+        annotations: Metadata (classification, retention, etc.).
+        version: Version tracking.
+
+    Examples:
+        >>> res = Resource(
+        ...     resource_request_id="rr_001",
+        ...     uri="file:///data/report.csv",
+        ...     name="Q4 Report",
+        ...     resource_type=ResourceType.FILE,
+        ...     content="col1,col2\\n1,2",
+        ...     mime_type="text/csv",
+        ... )
+        >>> res.uri
+        'file:///data/report.csv'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    resource_request_id: str = Field(description="Unique request correlation ID.")
+    uri: str = Field(description="Unique identifier in URI format.")
+    name: str | None = Field(default=None, description="Human-readable name.")
+    description: str | None = Field(default=None, description="What this resource contains.")
+    resource_type: ResourceType = Field(description="The kind of resource.")
+    content: str | None = Field(default=None, description="Text content if embedded.")
+    blob: bytes | None = Field(default=None, description="Binary content if embedded.")
+    mime_type: str | None = Field(default=None, description="MIME type of content.")
+    size_bytes: int | None = Field(default=None, description="Size information.")
+    annotations: dict[str, Any] = Field(default_factory=dict, description="Metadata (classification, retention, etc.).")
+    version: str | None = Field(default=None, description="Version tracking.")
+
+
+class ResourceReference(BaseModel):
+    """Lightweight resource reference without embedded content.
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        resource_request_id: Correlation ID linking to the originating resource request.
+        uri: Resource URI.
+        name: Human-readable name.
+        resource_type: Type of resource.
+        range_start: Line number or byte offset for partial references.
+        range_end: End of range.
+        selector: CSS/XPath/JSONPath selector.
+
+    Examples:
+        >>> ref = ResourceReference(
+        ...     resource_request_id="rr_002",
+        ...     uri="db://users/42",
+        ...     resource_type=ResourceType.DATABASE,
+        ... )
+        >>> ref.uri
+        'db://users/42'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    resource_request_id: str = Field(description="Correlation ID linking to the originating resource request.")
+    uri: str = Field(description="Resource URI.")
+    name: str | None = Field(default=None, description="Human-readable name.")
+    resource_type: ResourceType = Field(description="Type of resource.")
+    range_start: int | None = Field(default=None, description="Line number or byte offset for partial references.")
+    range_end: int | None = Field(default=None, description="End of range.")
+    selector: str | None = Field(default=None, description="CSS/XPath/JSONPath selector.")
+
+
+class PromptRequest(BaseModel):
+    """Prompt template invocation request (MCP).
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        prompt_request_id: Request ID for correlation.
+        name: Prompt template name.
+        arguments: Arguments to pass to the template.
+        server_id: Source server for multi-server scenarios.
+
+    Examples:
+        >>> req = PromptRequest(
+        ...     prompt_request_id="pr_001",
+        ...     name="summarize",
+        ...     arguments={"text": "Long document..."},
+        ... )
+        >>> req.name
+        'summarize'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    prompt_request_id: str = Field(description="Request ID for correlation.")
+    name: str = Field(description="Prompt template name.")
+    arguments: dict[str, Any] = Field(default_factory=dict, description="Arguments to pass to the template.")
+    server_id: str | None = Field(default=None, description="Source server for multi-server scenarios.")
+
+
+class PromptResult(BaseModel):
+    """Rendered prompt template result.
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        prompt_request_id: ID of the corresponding prompt request.
+        prompt_name: Name of the prompt that was rendered.
+        messages: Rendered messages (prompts produce messages).
+        content: Single text result for simple prompts.
+        is_error: Whether rendering failed.
+        error_message: Error details if rendering failed.
+
+    Examples:
+        >>> result = PromptResult(
+        ...     prompt_request_id="pr_001",
+        ...     prompt_name="summarize",
+        ...     content="This document discusses...",
+        ... )
+        >>> result.is_error
+        False
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    prompt_request_id: str = Field(description="ID of the corresponding prompt request.")
+    prompt_name: str = Field(description="Name of the prompt that was rendered.")
+    messages: list[Any] = Field(
+        default_factory=list,
+        description="Rendered messages (prompts produce messages).",
+    )
+    content: str | None = Field(default=None, description="Single text result for simple prompts.")
+    is_error: bool = Field(default=False, description="Whether rendering failed.")
+    error_message: str | None = Field(default=None, description="Error details if rendering failed.")
+
+
+class ImageSource(BaseModel):
+    """Image source data.
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        type: Source type, either URL or base64-encoded.
+        data: URL or base64-encoded string.
+        media_type: MIME type (e.g., image/jpeg).
+
+    Examples:
+        >>> img = ImageSource(type="url", data="https://example.com/photo.jpg")
+        >>> img.type
+        'url'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    type: str = Field(description="Source type: 'url' or 'base64'.")
+    data: str = Field(description="URL or base64-encoded string.")
+    media_type: str | None = Field(default=None, description="MIME type (e.g., image/jpeg).")
+
+
+class VideoSource(BaseModel):
+    """Video source data.
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        type: Source type, either URL or base64-encoded.
+        data: URL or base64-encoded string.
+        media_type: MIME type (e.g., video/mp4).
+        duration_ms: Duration in milliseconds.
+
+    Examples:
+        >>> vid = VideoSource(type="url", data="https://example.com/clip.mp4")
+        >>> vid.type
+        'url'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    type: str = Field(description="Source type: 'url' or 'base64'.")
+    data: str = Field(description="URL or base64-encoded string.")
+    media_type: str | None = Field(default=None, description="MIME type (e.g., video/mp4).")
+    duration_ms: int | None = Field(default=None, description="Duration in milliseconds.")
+
+
+class AudioSource(BaseModel):
+    """Audio source data.
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        type: Source type, either URL or base64-encoded.
+        data: URL or base64-encoded string.
+        media_type: MIME type (e.g., audio/mp3).
+        duration_ms: Duration in milliseconds.
+
+    Examples:
+        >>> aud = AudioSource(type="url", data="https://example.com/track.mp3")
+        >>> aud.type
+        'url'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    type: str = Field(description="Source type: 'url' or 'base64'.")
+    data: str = Field(description="URL or base64-encoded string.")
+    media_type: str | None = Field(default=None, description="MIME type (e.g., audio/mp3).")
+    duration_ms: int | None = Field(default=None, description="Duration in milliseconds.")
+
+
+class DocumentSource(BaseModel):
+    """Document source data (PDF, Word, etc.).
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        type: Source type, either URL or base64-encoded.
+        data: URL or base64-encoded string.
+        media_type: MIME type (e.g., application/pdf).
+        title: Document title.
+
+    Examples:
+        >>> doc = DocumentSource(
+        ...     type="base64",
+        ...     data="JVBERi0xLjQ...",
+        ...     media_type="application/pdf",
+        ...     title="Annual Report",
+        ... )
+        >>> doc.title
+        'Annual Report'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    type: str = Field(description="Source type: 'url' or 'base64'.")
+    data: str = Field(description="URL or base64-encoded string.")
+    media_type: str | None = Field(default=None, description="MIME type (e.g., application/pdf).")
+    title: str | None = Field(default=None, description="Document title.")
+
+
+# ---------------------------------------------------------------------------
+# Content Parts (ContentPart base + wrappers)
+# ---------------------------------------------------------------------------
+
+
+class ContentPart(BaseModel):
+    """Base class for all content parts in a CMF message.
+
+    Frozen by design — subclasses inherit immutability. Consumers must
+    use model_copy(update={...}) to create modified copies.
+
+    Attributes:
+        content_type: Discriminator identifying the concrete content type.
+
+    Examples:
+        >>> part = TextContent(text="hello")
+        >>> isinstance(part, ContentPart)
+        True
+        >>> part.content_type
+        <ContentType.TEXT: 'text'>
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    content_type: ContentType = Field(description="Content type discriminator.")
+
+
+class TextContent(ContentPart):
+    """Plain text content part.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.TEXT.
+        text: The text content.
+
+    Examples:
+        >>> part = TextContent(text="Hello, world!")
+        >>> part.content_type
+        <ContentType.TEXT: 'text'>
+        >>> part.text
+        'Hello, world!'
+        >>> modified = part.model_copy(update={"text": "Updated"})
+        >>> (part.text, modified.text)
+        ('Hello, world!', 'Updated')
+    """
+
+    content_type: ContentType = Field(default=ContentType.TEXT, description="Content type discriminator.")
+    text: str = Field(description="The text content.")
+
+
+class ThinkingContent(ContentPart):
+    """Chain-of-thought reasoning content part.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.THINKING.
+        text: The reasoning text.
+
+    Examples:
+        >>> part = ThinkingContent(text="Let me analyze this...")
+        >>> part.content_type
+        <ContentType.THINKING: 'thinking'>
+    """
+
+    content_type: ContentType = Field(default=ContentType.THINKING, description="Content type discriminator.")
+    text: str = Field(description="The reasoning text.")
+
+
+class ToolCallContentPart(ContentPart):
+    """Content part wrapping a ToolCall domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.TOOL_CALL.
+        content: The wrapped ToolCall.
+
+    Examples:
+        >>> part = ToolCallContentPart(
+        ...     content=ToolCall(tool_call_id="tc_001", name="search", arguments={"q": "test"}),
+        ... )
+        >>> part.content.name
+        'search'
+    """
+
+    content_type: ContentType = Field(default=ContentType.TOOL_CALL, description="Content type discriminator.")
+    content: ToolCall = Field(description="The wrapped ToolCall.")
+
+
+class ToolResultContentPart(ContentPart):
+    """Content part wrapping a ToolResult domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.TOOL_RESULT.
+        content: The wrapped ToolResult.
+
+    Examples:
+        >>> part = ToolResultContentPart(
+        ...     content=ToolResult(tool_call_id="tc_001", tool_name="search", content="Found 10 results"),
+        ... )
+        >>> part.content.tool_name
+        'search'
+    """
+
+    content_type: ContentType = Field(default=ContentType.TOOL_RESULT, description="Content type discriminator.")
+    content: ToolResult = Field(description="The wrapped ToolResult.")
+
+
+class ResourceContentPart(ContentPart):
+    """Content part wrapping a Resource domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.RESOURCE.
+        content: The wrapped Resource.
+
+    Examples:
+        >>> part = ResourceContentPart(
+        ...     content=Resource(resource_request_id="rr_001", uri="file:///data.txt", resource_type=ResourceType.FILE),
+        ... )
+        >>> part.content.uri
+        'file:///data.txt'
+    """
+
+    content_type: ContentType = Field(default=ContentType.RESOURCE, description="Content type discriminator.")
+    content: Resource = Field(description="The wrapped Resource.")
+
+
+class ResourceRefContentPart(ContentPart):
+    """Content part wrapping a ResourceReference domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.RESOURCE_REF.
+        content: The wrapped ResourceReference.
+
+    Examples:
+        >>> part = ResourceRefContentPart(
+        ...     content=ResourceReference(resource_request_id="rr_002", uri="db://users/42", resource_type=ResourceType.DATABASE),
+        ... )
+        >>> part.content.uri
+        'db://users/42'
+    """
+
+    content_type: ContentType = Field(default=ContentType.RESOURCE_REF, description="Content type discriminator.")
+    content: ResourceReference = Field(description="The wrapped ResourceReference.")
+
+
+class PromptRequestContentPart(ContentPart):
+    """Content part wrapping a PromptRequest domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.PROMPT_REQUEST.
+        content: The wrapped PromptRequest.
+
+    Examples:
+        >>> part = PromptRequestContentPart(
+        ...     content=PromptRequest(prompt_request_id="pr_001", name="summarize"),
+        ... )
+        >>> part.content.name
+        'summarize'
+    """
+
+    content_type: ContentType = Field(default=ContentType.PROMPT_REQUEST, description="Content type discriminator.")
+    content: PromptRequest = Field(description="The wrapped PromptRequest.")
+
+
+class PromptResultContentPart(ContentPart):
+    """Content part wrapping a PromptResult domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.PROMPT_RESULT.
+        content: The wrapped PromptResult.
+
+    Examples:
+        >>> part = PromptResultContentPart(
+        ...     content=PromptResult(prompt_request_id="pr_001", prompt_name="summarize"),
+        ... )
+        >>> part.content.prompt_name
+        'summarize'
+    """
+
+    content_type: ContentType = Field(default=ContentType.PROMPT_RESULT, description="Content type discriminator.")
+    content: PromptResult = Field(description="The wrapped PromptResult.")
+
+
+class ImageContentPart(ContentPart):
+    """Content part wrapping an ImageSource domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.IMAGE.
+        content: The wrapped ImageSource.
+
+    Examples:
+        >>> part = ImageContentPart(
+        ...     content=ImageSource(type="url", data="https://example.com/photo.jpg"),
+        ... )
+        >>> part.content.type
+        'url'
+    """
+
+    content_type: ContentType = Field(default=ContentType.IMAGE, description="Content type discriminator.")
+    content: ImageSource = Field(description="The wrapped ImageSource.")
+
+
+class VideoContentPart(ContentPart):
+    """Content part wrapping a VideoSource domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.VIDEO.
+        content: The wrapped VideoSource.
+
+    Examples:
+        >>> part = VideoContentPart(
+        ...     content=VideoSource(type="url", data="https://example.com/clip.mp4"),
+        ... )
+        >>> part.content.type
+        'url'
+    """
+
+    content_type: ContentType = Field(default=ContentType.VIDEO, description="Content type discriminator.")
+    content: VideoSource = Field(description="The wrapped VideoSource.")
+
+
+class AudioContentPart(ContentPart):
+    """Content part wrapping an AudioSource domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.AUDIO.
+        content: The wrapped AudioSource.
+
+    Examples:
+        >>> part = AudioContentPart(
+        ...     content=AudioSource(type="url", data="https://example.com/track.mp3"),
+        ... )
+        >>> part.content.type
+        'url'
+    """
+
+    content_type: ContentType = Field(default=ContentType.AUDIO, description="Content type discriminator.")
+    content: AudioSource = Field(description="The wrapped AudioSource.")
+
+
+class DocumentContentPart(ContentPart):
+    """Content part wrapping a DocumentSource domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.DOCUMENT.
+        content: The wrapped DocumentSource.
+
+    Examples:
+        >>> part = DocumentContentPart(
+        ...     content=DocumentSource(type="base64", data="JVBERi0xLjQ...", media_type="application/pdf"),
+        ... )
+        >>> part.content.media_type
+        'application/pdf'
+    """
+
+    content_type: ContentType = Field(default=ContentType.DOCUMENT, description="Content type discriminator.")
+    content: DocumentSource = Field(description="The wrapped DocumentSource.")
+
+
+# ---------------------------------------------------------------------------
+# ContentPart Discriminated Union
+# ---------------------------------------------------------------------------
+
+
+def _content_type_discriminator(v: Any) -> str:
+    """Extract the content_type discriminator value from a content part.
+
+    Supports both dict (during deserialization) and model instance access.
+
+    Args:
+        v: A content part as a dict or model instance.
+
+    Returns:
+        The content_type string value for discriminator routing.
+    """
+    if isinstance(v, dict):
+        return v.get("content_type", "text")
+    return v.content_type.value if hasattr(v, "content_type") else "text"
+
+
+ContentPartUnion = Annotated[
+    Union[
+        Annotated[TextContent, Tag("text")],
+        Annotated[ThinkingContent, Tag("thinking")],
+        Annotated[ToolCallContentPart, Tag("tool_call")],
+        Annotated[ToolResultContentPart, Tag("tool_result")],
+        Annotated[ResourceContentPart, Tag("resource")],
+        Annotated[ResourceRefContentPart, Tag("resource_ref")],
+        Annotated[PromptRequestContentPart, Tag("prompt_request")],
+        Annotated[PromptResultContentPart, Tag("prompt_result")],
+        Annotated[ImageContentPart, Tag("image")],
+        Annotated[VideoContentPart, Tag("video")],
+        Annotated[AudioContentPart, Tag("audio")],
+        Annotated[DocumentContentPart, Tag("document")],
+    ],
+    Discriminator(_content_type_discriminator),
+]
+"""Discriminated union of all content part types.
+
+Pydantic uses the content_type field to resolve the correct subclass
+during validation and deserialization.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Message
+# ---------------------------------------------------------------------------
+
+
+class Message(BaseModel):
+    """Canonical CMF message representing a single turn in a conversation.
+
+    A Message is the storage and wire format. It preserves the structure
+    exactly as the LLM or framework sent it. For policy evaluation and
+    inspection, use MessageView (via iter_views()) which decomposes the
+    message into individually addressable, uniformly accessible parts.
+
+    All Message instances are frozen. To create a modified copy, use
+    model_copy(update={...}).
+
+    Attributes:
+        schema_version: Message schema version.
+        role: Who is speaking.
+        content: List of typed content parts (multimodal).
+        channel: Optional output classification.
+        extensions: Contextual metadata (identity, security, governance, etc.).
+
+    Examples:
+        >>> msg = Message(
+        ...     role=Role.USER,
+        ...     content=[TextContent(text="What is the weather?")],
+        ... )
+        >>> msg.role
+        <Role.USER: 'user'>
+        >>> msg.content[0].text
+        'What is the weather?'
+        >>> msg.schema_version
+        '2.0'
+
+        >>> # Frozen: modifications require model_copy
+        >>> updated = msg.model_copy(update={"channel": Channel.FINAL})
+        >>> updated.channel
+        <Channel.FINAL: 'final'>
+        >>> msg.channel is None
+        True
+
+        >>> # Multi-part assistant message
+        >>> assistant_msg = Message(
+        ...     role=Role.ASSISTANT,
+        ...     content=[
+        ...         ThinkingContent(text="I should check the weather API."),
+        ...         TextContent(text="Let me look that up."),
+        ...         ToolCallContentPart(
+        ...             content=ToolCall(
+        ...                 tool_call_id="tc_001",
+        ...                 name="get_weather",
+        ...                 arguments={"city": "London"},
+        ...             ),
+        ...         ),
+        ...     ],
+        ... )
+        >>> len(assistant_msg.content)
+        3
+        >>> assistant_msg.content[2].content.name
+        'get_weather'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    schema_version: str = Field(default="2.0", description="Message schema version.")
+    role: Role = Field(description="Who is speaking.")
+    content: list[ContentPartUnion] = Field(default_factory=list, description="List of typed content parts.")
+    channel: Channel | None = Field(default=None, description="Optional output classification.")
+    extensions: Any = Field(
+        default=None,
+        description="Contextual metadata (identity, security, governance, etc.).",
+    )
+
+    def iter_views(self) -> Iterator[MessageView]:
+        """Decompose this message into individually addressable MessageViews.
+
+        Yields one MessageView per content part. Each view provides a
+        uniform interface for policy evaluation regardless of content type.
+
+        Returns:
+            An iterator of MessageView objects.
+
+        Examples:
+            >>> msg = Message(
+            ...     role=Role.ASSISTANT,
+            ...     content=[
+            ...         TextContent(text="Let me check."),
+            ...         ToolCallContentPart(
+            ...             content=ToolCall(
+            ...                 tool_call_id="tc_001",
+            ...                 name="get_weather",
+            ...                 arguments={"city": "London"},
+            ...             ),
+            ...         ),
+            ...     ],
+            ... )
+            >>> views = list(msg.iter_views())
+            >>> len(views)
+            2
+            >>> views[0].kind.value
+            'text'
+            >>> views[1].name
+            'get_weather'
+        """
+        from cpex.framework.cmf.view import iter_views  # pylint: disable=import-outside-toplevel
+
+        return iter_views(self)
+
+
+if TYPE_CHECKING:
+    from cpex.framework.cmf.view import MessageView

--- a/cpex/framework/cmf/message.py
+++ b/cpex/framework/cmf/message.py
@@ -19,10 +19,13 @@ compose them into the typed content-part hierarchy for message serialization.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Annotated, Iterator, TYPE_CHECKING, Union
+from typing import Any, Annotated, Iterator, Literal, TYPE_CHECKING, Union
 
 # Third-Party
-from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag
+from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, model_validator
+
+# First-Party
+from cpex.framework.extensions.extensions import Extensions
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -257,6 +260,13 @@ class Resource(BaseModel):
     resource_type: ResourceType = Field(description="The kind of resource.")
     content: str | None = Field(default=None, description="Text content if embedded.")
     blob: bytes | None = Field(default=None, description="Binary content if embedded.")
+
+    @model_validator(mode="after")
+    def _check_content_blob_exclusion(self) -> Resource:
+        if self.content is not None and self.blob is not None:
+            raise ValueError("Resource cannot have both 'content' and 'blob' set")
+        return self
+
     mime_type: str | None = Field(default=None, description="MIME type of content.")
     size_bytes: int | None = Field(default=None, description="Size information.")
     annotations: dict[str, Any] = Field(default_factory=dict, description="Metadata (classification, retention, etc.).")
@@ -296,6 +306,13 @@ class ResourceReference(BaseModel):
     range_start: int | None = Field(default=None, description="Line number or byte offset for partial references.")
     range_end: int | None = Field(default=None, description="End of range.")
     selector: str | None = Field(default=None, description="CSS/XPath/JSONPath selector.")
+
+    @model_validator(mode="after")
+    def _check_range_consistency(self) -> ResourceReference:
+        if self.range_start is not None and self.range_end is not None:
+            if self.range_end < self.range_start:
+                raise ValueError(f"range_end ({self.range_end}) must be >= range_start ({self.range_start})")
+        return self
 
 
 class PromptRequest(BaseModel):
@@ -354,7 +371,7 @@ class PromptResult(BaseModel):
 
     prompt_request_id: str = Field(description="ID of the corresponding prompt request.")
     prompt_name: str = Field(description="Name of the prompt that was rendered.")
-    messages: list[Any] = Field(
+    messages: list[Message] = Field(
         default_factory=list,
         description="Rendered messages (prompts produce messages).",
     )
@@ -381,7 +398,7 @@ class ImageSource(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    type: str = Field(description="Source type: 'url' or 'base64'.")
+    type: Literal["url", "base64"] = Field(description="Source type: 'url' or 'base64'.")
     data: str = Field(description="URL or base64-encoded string.")
     media_type: str | None = Field(default=None, description="MIME type (e.g., image/jpeg).")
 
@@ -405,7 +422,7 @@ class VideoSource(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    type: str = Field(description="Source type: 'url' or 'base64'.")
+    type: Literal["url", "base64"] = Field(description="Source type: 'url' or 'base64'.")
     data: str = Field(description="URL or base64-encoded string.")
     media_type: str | None = Field(default=None, description="MIME type (e.g., video/mp4).")
     duration_ms: int | None = Field(default=None, description="Duration in milliseconds.")
@@ -430,7 +447,7 @@ class AudioSource(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    type: str = Field(description="Source type: 'url' or 'base64'.")
+    type: Literal["url", "base64"] = Field(description="Source type: 'url' or 'base64'.")
     data: str = Field(description="URL or base64-encoded string.")
     media_type: str | None = Field(default=None, description="MIME type (e.g., audio/mp3).")
     duration_ms: int | None = Field(default=None, description="Duration in milliseconds.")
@@ -460,7 +477,7 @@ class DocumentSource(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    type: str = Field(description="Source type: 'url' or 'base64'.")
+    type: Literal["url", "base64"] = Field(description="Source type: 'url' or 'base64'.")
     data: str = Field(description="URL or base64-encoded string.")
     media_type: str | None = Field(default=None, description="MIME type (e.g., application/pdf).")
     title: str | None = Field(default=None, description="Document title.")
@@ -511,7 +528,7 @@ class TextContent(ContentPart):
         ('Hello, world!', 'Updated')
     """
 
-    content_type: ContentType = Field(default=ContentType.TEXT, description="Content type discriminator.")
+    content_type: Literal[ContentType.TEXT] = Field(default=ContentType.TEXT, description="Content type discriminator.")
     text: str = Field(description="The text content.")
 
 
@@ -528,7 +545,9 @@ class ThinkingContent(ContentPart):
         <ContentType.THINKING: 'thinking'>
     """
 
-    content_type: ContentType = Field(default=ContentType.THINKING, description="Content type discriminator.")
+    content_type: Literal[ContentType.THINKING] = Field(
+        default=ContentType.THINKING, description="Content type discriminator."
+    )
     text: str = Field(description="The reasoning text.")
 
 
@@ -547,7 +566,9 @@ class ToolCallContentPart(ContentPart):
         'search'
     """
 
-    content_type: ContentType = Field(default=ContentType.TOOL_CALL, description="Content type discriminator.")
+    content_type: Literal[ContentType.TOOL_CALL] = Field(
+        default=ContentType.TOOL_CALL, description="Content type discriminator."
+    )
     content: ToolCall = Field(description="The wrapped ToolCall.")
 
 
@@ -566,7 +587,9 @@ class ToolResultContentPart(ContentPart):
         'search'
     """
 
-    content_type: ContentType = Field(default=ContentType.TOOL_RESULT, description="Content type discriminator.")
+    content_type: Literal[ContentType.TOOL_RESULT] = Field(
+        default=ContentType.TOOL_RESULT, description="Content type discriminator."
+    )
     content: ToolResult = Field(description="The wrapped ToolResult.")
 
 
@@ -585,7 +608,9 @@ class ResourceContentPart(ContentPart):
         'file:///data.txt'
     """
 
-    content_type: ContentType = Field(default=ContentType.RESOURCE, description="Content type discriminator.")
+    content_type: Literal[ContentType.RESOURCE] = Field(
+        default=ContentType.RESOURCE, description="Content type discriminator."
+    )
     content: Resource = Field(description="The wrapped Resource.")
 
 
@@ -604,7 +629,9 @@ class ResourceRefContentPart(ContentPart):
         'db://users/42'
     """
 
-    content_type: ContentType = Field(default=ContentType.RESOURCE_REF, description="Content type discriminator.")
+    content_type: Literal[ContentType.RESOURCE_REF] = Field(
+        default=ContentType.RESOURCE_REF, description="Content type discriminator."
+    )
     content: ResourceReference = Field(description="The wrapped ResourceReference.")
 
 
@@ -623,7 +650,9 @@ class PromptRequestContentPart(ContentPart):
         'summarize'
     """
 
-    content_type: ContentType = Field(default=ContentType.PROMPT_REQUEST, description="Content type discriminator.")
+    content_type: Literal[ContentType.PROMPT_REQUEST] = Field(
+        default=ContentType.PROMPT_REQUEST, description="Content type discriminator."
+    )
     content: PromptRequest = Field(description="The wrapped PromptRequest.")
 
 
@@ -642,7 +671,9 @@ class PromptResultContentPart(ContentPart):
         'summarize'
     """
 
-    content_type: ContentType = Field(default=ContentType.PROMPT_RESULT, description="Content type discriminator.")
+    content_type: Literal[ContentType.PROMPT_RESULT] = Field(
+        default=ContentType.PROMPT_RESULT, description="Content type discriminator."
+    )
     content: PromptResult = Field(description="The wrapped PromptResult.")
 
 
@@ -661,7 +692,9 @@ class ImageContentPart(ContentPart):
         'url'
     """
 
-    content_type: ContentType = Field(default=ContentType.IMAGE, description="Content type discriminator.")
+    content_type: Literal[ContentType.IMAGE] = Field(
+        default=ContentType.IMAGE, description="Content type discriminator."
+    )
     content: ImageSource = Field(description="The wrapped ImageSource.")
 
 
@@ -680,7 +713,9 @@ class VideoContentPart(ContentPart):
         'url'
     """
 
-    content_type: ContentType = Field(default=ContentType.VIDEO, description="Content type discriminator.")
+    content_type: Literal[ContentType.VIDEO] = Field(
+        default=ContentType.VIDEO, description="Content type discriminator."
+    )
     content: VideoSource = Field(description="The wrapped VideoSource.")
 
 
@@ -699,7 +734,9 @@ class AudioContentPart(ContentPart):
         'url'
     """
 
-    content_type: ContentType = Field(default=ContentType.AUDIO, description="Content type discriminator.")
+    content_type: Literal[ContentType.AUDIO] = Field(
+        default=ContentType.AUDIO, description="Content type discriminator."
+    )
     content: AudioSource = Field(description="The wrapped AudioSource.")
 
 
@@ -718,7 +755,9 @@ class DocumentContentPart(ContentPart):
         'application/pdf'
     """
 
-    content_type: ContentType = Field(default=ContentType.DOCUMENT, description="Content type discriminator.")
+    content_type: Literal[ContentType.DOCUMENT] = Field(
+        default=ContentType.DOCUMENT, description="Content type discriminator."
+    )
     content: DocumentSource = Field(description="The wrapped DocumentSource.")
 
 
@@ -739,8 +778,13 @@ def _content_type_discriminator(v: Any) -> str:
         The content_type string value for discriminator routing.
     """
     if isinstance(v, dict):
-        return v.get("content_type", "text")
-    return v.content_type.value if hasattr(v, "content_type") else "text"
+        ct = v.get("content_type")
+        if ct is None:
+            raise ValueError("Missing 'content_type' discriminator in content part dict")
+        return ct
+    if not hasattr(v, "content_type"):
+        raise ValueError(f"Content part {type(v).__name__} missing 'content_type' attribute")
+    return v.content_type.value
 
 
 ContentPartUnion = Annotated[
@@ -836,16 +880,20 @@ class Message(BaseModel):
     role: Role = Field(description="Who is speaking.")
     content: list[ContentPartUnion] = Field(default_factory=list, description="List of typed content parts.")
     channel: Channel | None = Field(default=None, description="Optional output classification.")
-    extensions: Any = Field(
+    extensions: Extensions | None = Field(
         default=None,
         description="Contextual metadata (identity, security, governance, etc.).",
     )
 
-    def iter_views(self) -> Iterator[MessageView]:
+    def iter_views(self, hook: str | None = None) -> Iterator[MessageView]:
         """Decompose this message into individually addressable MessageViews.
 
         Yields one MessageView per content part. Each view provides a
         uniform interface for policy evaluation regardless of content type.
+
+        Args:
+            hook: Optional hook location string (e.g., "llm_input",
+                "tool_post_invoke") to attach to each view.
 
         Returns:
             An iterator of MessageView objects.
@@ -874,7 +922,7 @@ class Message(BaseModel):
         """
         from cpex.framework.cmf.view import iter_views  # pylint: disable=import-outside-toplevel
 
-        return iter_views(self)
+        return iter_views(self, hook=hook)
 
 
 if TYPE_CHECKING:

--- a/cpex/framework/cmf/view.py
+++ b/cpex/framework/cmf/view.py
@@ -14,9 +14,11 @@ content part and message extensions directly.
 
 # Standard
 import json
+import logging
 import re
 from enum import Enum
-from typing import Any, Iterator
+from types import MappingProxyType
+from typing import Any, Iterator, Mapping
 
 # First-Party
 from cpex.framework.cmf.message import (
@@ -31,6 +33,8 @@ from cpex.framework.extensions.security import (
     ObjectSecurityProfile,
     SubjectExtension,
 )
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -123,6 +127,21 @@ _CONTENT_TYPE_TO_VIEW_KIND: dict[ContentType, ViewKind] = {
     ContentType.DOCUMENT: ViewKind.DOCUMENT,
 }
 
+_ACTION_MAP: dict[ViewKind, ViewAction] = {
+    ViewKind.TOOL_CALL: ViewAction.EXECUTE,
+    ViewKind.TOOL_RESULT: ViewAction.RECEIVE,
+    ViewKind.RESOURCE: ViewAction.READ,
+    ViewKind.RESOURCE_REF: ViewAction.READ,
+    ViewKind.PROMPT_REQUEST: ViewAction.INVOKE,
+    ViewKind.PROMPT_RESULT: ViewAction.RECEIVE,
+}
+
+# Kinds whose action depends on message direction (role)
+_DIRECTION_DEPENDENT_KINDS = frozenset({
+    ViewKind.TEXT, ViewKind.THINKING,
+    ViewKind.IMAGE, ViewKind.VIDEO, ViewKind.AUDIO, ViewKind.DOCUMENT,
+})
+
 # Sensitive headers stripped during serialization
 _SENSITIVE_HEADERS = frozenset({"authorization", "cookie", "x-api-key"})
 
@@ -185,19 +204,28 @@ class MessageView:
         True
     """
 
-    __slots__ = ("_part", "_kind", "_message")
+    __slots__ = ("_part", "_kind", "_message", "_hook")
 
-    def __init__(self, part: ContentPart, kind: ViewKind, message: Message) -> None:
+    def __init__(
+        self,
+        part: ContentPart,
+        kind: ViewKind,
+        message: Message,
+        hook: str | None = None,
+    ) -> None:
         """Initialize a MessageView.
 
         Args:
             part: The underlying content part.
             kind: The kind of content.
             message: The parent message (for role and extensions access).
+            hook: The hook location where this view is being evaluated
+                (e.g., "llm_input", "tool_post_invoke"). None if unset.
         """
         self._part = part
         self._kind = kind
         self._message = message
+        self._hook = hook
 
     # =========================================================================
     # Internal Helpers
@@ -239,6 +267,19 @@ class MessageView:
             The Role (user, assistant, system, developer, tool).
         """
         return self._message.role
+
+    @property
+    def hook(self) -> str | None:
+        """The hook location where this view is being evaluated.
+
+        Indicates where in the pipeline the evaluation is occurring
+        (e.g., "llm_input", "llm_output", "tool_pre_invoke",
+        "tool_post_invoke"). None if not set.
+
+        Returns:
+            Hook location string or None.
+        """
+        return self._hook
 
     @property
     def raw(self) -> ContentPart:
@@ -355,24 +396,22 @@ class MessageView:
     def action(self) -> ViewAction:
         """The semantic action this view represents.
 
+        For content kinds like text and media, the action depends on
+        the message role: SEND for user/system/developer input,
+        GENERATE for assistant output, RECEIVE for tool output.
+
         Returns:
             A ViewAction value.
         """
-        _ACTION_MAP: dict[ViewKind, ViewAction] = {
-            ViewKind.TEXT: ViewAction.SEND,
-            ViewKind.THINKING: ViewAction.GENERATE,
-            ViewKind.TOOL_CALL: ViewAction.EXECUTE,
-            ViewKind.TOOL_RESULT: ViewAction.RECEIVE,
-            ViewKind.RESOURCE: ViewAction.READ,
-            ViewKind.RESOURCE_REF: ViewAction.READ,
-            ViewKind.PROMPT_REQUEST: ViewAction.INVOKE,
-            ViewKind.PROMPT_RESULT: ViewAction.GENERATE,
-            ViewKind.IMAGE: ViewAction.SEND,
-            ViewKind.VIDEO: ViewAction.SEND,
-            ViewKind.AUDIO: ViewAction.SEND,
-            ViewKind.DOCUMENT: ViewAction.SEND,
-        }
-        return _ACTION_MAP.get(self._kind, ViewAction.SEND)
+        fixed = _ACTION_MAP.get(self._kind)
+        if fixed is not None:
+            return fixed
+        role = self._message.role
+        if role == Role.ASSISTANT:
+            return ViewAction.GENERATE
+        if role == Role.TOOL:
+            return ViewAction.RECEIVE
+        return ViewAction.SEND
 
     @property
     def args(self) -> dict[str, Any] | None:
@@ -521,7 +560,7 @@ class MessageView:
             return True
         if self._kind in (ViewKind.TOOL_RESULT, ViewKind.PROMPT_RESULT, ViewKind.RESOURCE):
             return False
-        return self._message.role in (Role.USER, Role.SYSTEM, Role.DEVELOPER, Role.TOOL)
+        return self._message.role in (Role.USER, Role.SYSTEM, Role.DEVELOPER)
 
     @property
     def is_post(self) -> bool:
@@ -534,7 +573,7 @@ class MessageView:
             return True
         if self._kind in (ViewKind.TOOL_CALL, ViewKind.PROMPT_REQUEST, ViewKind.RESOURCE_REF):
             return False
-        return self._message.role == Role.ASSISTANT
+        return self._message.role in (Role.ASSISTANT, Role.TOOL)
 
     @property
     def is_tool(self) -> bool:
@@ -680,18 +719,18 @@ class MessageView:
     # --- read_headers ---
 
     @property
-    def headers(self) -> dict[str, str]:
+    def headers(self) -> Mapping[str, str]:
         """HTTP headers associated with the request.
 
         Capability: read_headers.
 
         Returns:
-            Dict of header name to value.
+            Read-only mapping of header name to value.
         """
         ext = self._ext()
         if ext and ext.http:
-            return ext.http.headers
-        return {}
+            return MappingProxyType(ext.http.headers)
+        return MappingProxyType({})
 
     # --- read_labels ---
 
@@ -939,10 +978,13 @@ class MessageView:
         view_uri = self.uri
         if not view_uri:
             return False
-        regex = pattern.replace("**", "<<<DOUBLE>>>")
-        regex = regex.replace("*", "[^/]*")
-        regex = regex.replace("<<<DOUBLE>>>", ".*")
-        regex = f"^{regex}$"
+        # Split on ** first, then * within each segment, escaping literals
+        parts = pattern.split("**")
+        regex_parts = []
+        for part in parts:
+            sub_parts = part.split("*")
+            regex_parts.append("[^/]*".join(re.escape(s) for s in sub_parts))
+        regex = f"^{'.*'.join(regex_parts)}$"
         return bool(re.match(regex, view_uri))
 
     def has_content(self) -> bool:
@@ -978,6 +1020,9 @@ class MessageView:
             "action": self.action.value,
         }
 
+        if self._hook is not None:
+            result["hook"] = self._hook
+
         if self.uri:
             result["uri"] = self.uri
         if self.name:
@@ -987,9 +1032,11 @@ class MessageView:
             text = self.content
             if text is not None:
                 result["content"] = text
-            size = self.size_bytes
-            if size is not None:
-                result["size_bytes"] = size
+                result["size_bytes"] = len(text.encode("utf-8"))
+            else:
+                size = self.size_bytes
+                if size is not None:
+                    result["size_bytes"] = size
 
         if self.mime_type:
             result["mime_type"] = self.mime_type
@@ -1106,8 +1153,9 @@ class MessageView:
         """
         role_part = f", role={self._message.role.value}"
         uri_part = f", uri={self.uri}" if self.uri else ""
+        hook_part = f", hook={self._hook}" if self._hook else ""
         direction = "pre" if self.is_pre else "post" if self.is_post else "?"
-        return f"MessageView(kind={self._kind.value}{role_part}, {direction}{uri_part})"
+        return f"MessageView(kind={self._kind.value}{role_part}, {direction}{uri_part}{hook_part})"
 
 
 # ---------------------------------------------------------------------------
@@ -1115,7 +1163,7 @@ class MessageView:
 # ---------------------------------------------------------------------------
 
 
-def iter_views(message: Message) -> Iterator[MessageView]:
+def iter_views(message: Message, hook: str | None = None) -> Iterator[MessageView]:
     """Iterate over a message yielding one MessageView per content part.
 
     Memory-efficient: views are yielded one at a time and hold only
@@ -1126,6 +1174,8 @@ def iter_views(message: Message) -> Iterator[MessageView]:
 
     Args:
         message: The message to decompose into views.
+        hook: Optional hook location string (e.g., "llm_input",
+            "tool_post_invoke") to attach to each view.
 
     Yields:
         A MessageView for each content part in the message.
@@ -1157,5 +1207,7 @@ def iter_views(message: Message) -> Iterator[MessageView]:
     """
     for part in message.content:
         kind = _CONTENT_TYPE_TO_VIEW_KIND.get(part.content_type)
-        if kind is not None:
-            yield MessageView(part, kind, message)
+        if kind is None:
+            logger.warning("Unknown content type %r in iter_views", part.content_type)
+            raise ValueError(f"Unknown content type: {part.content_type!r}")
+        yield MessageView(part, kind, message, hook=hook)

--- a/cpex/framework/cmf/view.py
+++ b/cpex/framework/cmf/view.py
@@ -1,0 +1,1161 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/cmf/view.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+MessageView — read-only projection for policy evaluation.
+
+Decomposes a Message into individually addressable views with a
+uniform interface regardless of content type. Zero-copy design —
+properties are computed on-demand by accessing the underlying
+content part and message extensions directly.
+"""
+
+# Standard
+import json
+import re
+from enum import Enum
+from typing import Any, Iterator
+
+# First-Party
+from cpex.framework.cmf.message import (
+    ContentPart,
+    ContentType,
+    Message,
+    Resource,
+    Role,
+)
+from cpex.framework.extensions.security import (
+    DataPolicy,
+    ObjectSecurityProfile,
+    SubjectExtension,
+)
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class ViewKind(str, Enum):
+    """Closed-set enumeration of message view kinds.
+
+    Maps one-to-one with ContentType, identifying the kind of
+    content that a view represents.
+
+    Attributes:
+        TEXT: Plain text content.
+        THINKING: Reasoning/chain-of-thought content.
+        TOOL_CALL: Tool/function invocation.
+        TOOL_RESULT: Result from tool execution.
+        RESOURCE: Embedded resource with content.
+        RESOURCE_REF: Reference to a resource (URI only).
+        PROMPT_REQUEST: Prompt template request.
+        PROMPT_RESULT: Rendered prompt result.
+        IMAGE: Image content.
+        VIDEO: Video content.
+        AUDIO: Audio content.
+        DOCUMENT: Document content.
+
+    Examples:
+        >>> ViewKind.TOOL_CALL
+        <ViewKind.TOOL_CALL: 'tool_call'>
+        >>> ViewKind.TOOL_CALL.value
+        'tool_call'
+    """
+
+    TEXT = "text"
+    THINKING = "thinking"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    RESOURCE = "resource"
+    RESOURCE_REF = "resource_ref"
+    PROMPT_REQUEST = "prompt_request"
+    PROMPT_RESULT = "prompt_result"
+    IMAGE = "image"
+    VIDEO = "video"
+    AUDIO = "audio"
+    DOCUMENT = "document"
+
+
+class ViewAction(str, Enum):
+    """Closed-set enumeration of semantic actions.
+
+    Attributes:
+        READ: Reading/accessing data.
+        WRITE: Writing/modifying data.
+        EXECUTE: Executing a tool or command.
+        INVOKE: Invoking a prompt template.
+        SEND: Sending content outbound.
+        RECEIVE: Receiving content inbound.
+        GENERATE: Generating content (LLM output).
+
+    Examples:
+        >>> ViewAction.EXECUTE
+        <ViewAction.EXECUTE: 'execute'>
+    """
+
+    READ = "read"
+    WRITE = "write"
+    EXECUTE = "execute"
+    INVOKE = "invoke"
+    SEND = "send"
+    RECEIVE = "receive"
+    GENERATE = "generate"
+
+
+# ---------------------------------------------------------------------------
+# ContentType -> ViewKind mapping
+# ---------------------------------------------------------------------------
+
+_CONTENT_TYPE_TO_VIEW_KIND: dict[ContentType, ViewKind] = {
+    ContentType.TEXT: ViewKind.TEXT,
+    ContentType.THINKING: ViewKind.THINKING,
+    ContentType.TOOL_CALL: ViewKind.TOOL_CALL,
+    ContentType.TOOL_RESULT: ViewKind.TOOL_RESULT,
+    ContentType.RESOURCE: ViewKind.RESOURCE,
+    ContentType.RESOURCE_REF: ViewKind.RESOURCE_REF,
+    ContentType.PROMPT_REQUEST: ViewKind.PROMPT_REQUEST,
+    ContentType.PROMPT_RESULT: ViewKind.PROMPT_RESULT,
+    ContentType.IMAGE: ViewKind.IMAGE,
+    ContentType.VIDEO: ViewKind.VIDEO,
+    ContentType.AUDIO: ViewKind.AUDIO,
+    ContentType.DOCUMENT: ViewKind.DOCUMENT,
+}
+
+# Sensitive headers stripped during serialization
+_SENSITIVE_HEADERS = frozenset({"authorization", "cookie", "x-api-key"})
+
+
+# ---------------------------------------------------------------------------
+# MessageView
+# ---------------------------------------------------------------------------
+
+
+class MessageView:
+    """Read-only, zero-copy view over a single content part for policy evaluation.
+
+    A MessageView provides a uniform interface for inspecting any content
+    part of a message — regardless of whether it's text, a tool call, a
+    resource, or media. Properties are computed on-demand from the
+    underlying content part and message extensions without copying data.
+
+    For wrapped content parts (tool calls, resources, media, etc.), the
+    domain object is accessed via the wrapper's .content field. The _inner
+    property provides convenient access to the wrapped domain object.
+
+    MessageViews are produced by Message.iter_views() or the standalone
+    iter_views() function. A single Message with multiple content parts
+    yields one view per part.
+
+    Attributes:
+        kind: The type of content this view represents.
+        role: The role of the parent message.
+        raw: Direct access to the underlying content part.
+
+    Examples:
+        >>> from cpex.framework.cmf.message import (
+        ...     Message, Role, TextContent, ToolCall, ToolCallContentPart,
+        ... )
+        >>> msg = Message(
+        ...     role=Role.ASSISTANT,
+        ...     content=[
+        ...         TextContent(text="Let me look that up."),
+        ...         ToolCallContentPart(
+        ...             content=ToolCall(
+        ...                 tool_call_id="tc_001",
+        ...                 name="get_user",
+        ...                 arguments={"id": "123"},
+        ...             ),
+        ...         ),
+        ...     ],
+        ... )
+        >>> views = list(iter_views(msg))
+        >>> len(views)
+        2
+        >>> views[0].kind
+        <ViewKind.TEXT: 'text'>
+        >>> views[1].kind
+        <ViewKind.TOOL_CALL: 'tool_call'>
+        >>> views[1].name
+        'get_user'
+        >>> views[1].uri
+        'tool://_/get_user'
+        >>> views[1].is_pre
+        True
+    """
+
+    __slots__ = ("_part", "_kind", "_message")
+
+    def __init__(self, part: ContentPart, kind: ViewKind, message: Message) -> None:
+        """Initialize a MessageView.
+
+        Args:
+            part: The underlying content part.
+            kind: The kind of content.
+            message: The parent message (for role and extensions access).
+        """
+        self._part = part
+        self._kind = kind
+        self._message = message
+
+    # =========================================================================
+    # Internal Helpers
+    # =========================================================================
+
+    @property
+    def _inner(self) -> Any:
+        """Get the wrapped domain object for composite content parts.
+
+        For TextContent/ThinkingContent (which have no wrapper), returns
+        the part itself. For all other types, returns the .content field
+        which holds the domain object (ToolCall, Resource, etc.).
+
+        Returns:
+            The domain object for this content part.
+        """
+        if self._kind in (ViewKind.TEXT, ViewKind.THINKING):
+            return self._part
+        return self._part.content  # type: ignore[union-attr]
+
+    # =========================================================================
+    # Core Properties
+    # =========================================================================
+
+    @property
+    def kind(self) -> ViewKind:
+        """The type of content this view represents.
+
+        Returns:
+            The ViewKind for this view.
+        """
+        return self._kind
+
+    @property
+    def role(self) -> Role:
+        """The role of the parent message.
+
+        Returns:
+            The Role (user, assistant, system, developer, tool).
+        """
+        return self._message.role
+
+    @property
+    def raw(self) -> ContentPart:
+        """Direct access to the underlying content part.
+
+        Returns:
+            The underlying ContentPart subclass instance.
+        """
+        return self._part
+
+    @property
+    def content(self) -> str | None:
+        """Scannable text content.
+
+        For text/thinking: the text itself. For tool calls and prompt
+        requests: JSON-serialized arguments. For tool results:
+        JSON-serialized content. For resources: embedded content string.
+
+        Returns:
+            Scannable text or None if no text content is available.
+        """
+        inner = self._inner
+
+        if self._kind in (ViewKind.TEXT, ViewKind.THINKING):
+            return inner.text
+
+        if self._kind == ViewKind.RESOURCE:
+            return inner.content
+
+        if self._kind == ViewKind.TOOL_CALL:
+            try:
+                return json.dumps(inner.arguments)
+            except (TypeError, ValueError):
+                return str(inner.arguments)
+
+        if self._kind == ViewKind.TOOL_RESULT:
+            result_content = inner.content
+            if result_content is None:
+                return None
+            if isinstance(result_content, str):
+                return result_content
+            try:
+                return json.dumps(result_content)
+            except (TypeError, ValueError):
+                return str(result_content)
+
+        if self._kind == ViewKind.PROMPT_REQUEST:
+            try:
+                return json.dumps(inner.arguments)
+            except (TypeError, ValueError):
+                return str(inner.arguments)
+
+        if self._kind == ViewKind.PROMPT_RESULT:
+            return inner.content
+
+        return None
+
+    @property
+    def uri(self) -> str | None:
+        """Synthetic identity URI.
+
+        Tools: tool://namespace/name. Tool results: tool_result://name.
+        Prompts: prompt://server/name. Prompt results: prompt_result://name.
+        Resources: the resource's own URI.
+
+        Returns:
+            URI string or None if not applicable.
+        """
+        inner = self._inner
+
+        if self._kind in (ViewKind.RESOURCE, ViewKind.RESOURCE_REF):
+            return inner.uri
+
+        if self._kind == ViewKind.TOOL_CALL:
+            ns = inner.namespace or "_"
+            return f"tool://{ns}/{inner.name}"
+
+        if self._kind == ViewKind.TOOL_RESULT:
+            return f"tool_result://{inner.tool_name}"
+
+        if self._kind == ViewKind.PROMPT_REQUEST:
+            server = inner.server_id or "_"
+            return f"prompt://{server}/{inner.name}"
+
+        if self._kind == ViewKind.PROMPT_RESULT:
+            return f"prompt_result://{inner.prompt_name}"
+
+        return None
+
+    @property
+    def name(self) -> str | None:
+        """Human-readable name (tool name, resource name, prompt name).
+
+        Returns:
+            Name string or None if not applicable.
+        """
+        inner = self._inner
+
+        if self._kind in (ViewKind.TOOL_CALL, ViewKind.PROMPT_REQUEST):
+            return inner.name
+
+        if self._kind in (ViewKind.RESOURCE, ViewKind.RESOURCE_REF):
+            return inner.name
+
+        if self._kind == ViewKind.TOOL_RESULT:
+            return inner.tool_name
+
+        if self._kind == ViewKind.PROMPT_RESULT:
+            return inner.prompt_name
+
+        return None
+
+    @property
+    def action(self) -> ViewAction:
+        """The semantic action this view represents.
+
+        Returns:
+            A ViewAction value.
+        """
+        _ACTION_MAP: dict[ViewKind, ViewAction] = {
+            ViewKind.TEXT: ViewAction.SEND,
+            ViewKind.THINKING: ViewAction.GENERATE,
+            ViewKind.TOOL_CALL: ViewAction.EXECUTE,
+            ViewKind.TOOL_RESULT: ViewAction.RECEIVE,
+            ViewKind.RESOURCE: ViewAction.READ,
+            ViewKind.RESOURCE_REF: ViewAction.READ,
+            ViewKind.PROMPT_REQUEST: ViewAction.INVOKE,
+            ViewKind.PROMPT_RESULT: ViewAction.GENERATE,
+            ViewKind.IMAGE: ViewAction.SEND,
+            ViewKind.VIDEO: ViewAction.SEND,
+            ViewKind.AUDIO: ViewAction.SEND,
+            ViewKind.DOCUMENT: ViewAction.SEND,
+        }
+        return _ACTION_MAP.get(self._kind, ViewAction.SEND)
+
+    @property
+    def args(self) -> dict[str, Any] | None:
+        """Arguments dict for tool calls and prompt requests.
+
+        Returns:
+            Arguments dict or None for other content types.
+        """
+        inner = self._inner
+        if self._kind == ViewKind.TOOL_CALL:
+            return inner.arguments
+        if self._kind == ViewKind.PROMPT_REQUEST:
+            return inner.arguments
+        return None
+
+    @property
+    def mime_type(self) -> str | None:
+        """MIME type if applicable.
+
+        Returns:
+            MIME type string or None.
+        """
+        inner = self._inner
+        if self._kind == ViewKind.RESOURCE:
+            return inner.mime_type
+        if self._kind in (ViewKind.IMAGE, ViewKind.VIDEO, ViewKind.AUDIO, ViewKind.DOCUMENT):
+            return inner.media_type
+        return None
+
+    @property
+    def size_bytes(self) -> int | None:
+        """Content size in bytes (computed from content).
+
+        Returns:
+            Size in bytes or None.
+        """
+        if self._kind == ViewKind.RESOURCE:
+            res: Resource = self._inner
+            if res.size_bytes is not None:
+                return res.size_bytes
+            if res.content:
+                return len(res.content.encode("utf-8"))
+            if res.blob:
+                return len(res.blob)
+            return None
+
+        text = self.content
+        if text is not None:
+            return len(text.encode("utf-8"))
+        return None
+
+    @property
+    def properties(self) -> dict[str, Any]:
+        """Type-specific properties as a dict.
+
+        For single property access, prefer get_property() which
+        avoids allocating a dict.
+
+        Returns:
+            Dict of property name to value for this view's kind.
+        """
+        props: dict[str, Any] = {}
+        inner = self._inner
+
+        if self._kind == ViewKind.RESOURCE:
+            props["resource_type"] = inner.resource_type.value
+            props["version"] = inner.version
+            props["annotations"] = inner.annotations
+
+        elif self._kind == ViewKind.TOOL_CALL:
+            props["namespace"] = inner.namespace
+            props["tool_id"] = inner.tool_call_id
+
+        elif self._kind == ViewKind.TOOL_RESULT:
+            props["is_error"] = inner.is_error
+            props["tool_name"] = inner.tool_name
+
+        elif self._kind == ViewKind.PROMPT_REQUEST:
+            props["server_id"] = inner.server_id
+
+        elif self._kind == ViewKind.PROMPT_RESULT:
+            props["is_error"] = inner.is_error
+            props["message_count"] = len(inner.messages) if inner.messages else 0
+
+        return props
+
+    def get_property(self, name: str, default: Any = None) -> Any:
+        """Get a single type-specific property without allocating a dict.
+
+        Args:
+            name: Property name to retrieve.
+            default: Value to return if property doesn't exist.
+
+        Returns:
+            The property value or default.
+        """
+        inner = self._inner
+
+        if self._kind == ViewKind.RESOURCE:
+            if name == "resource_type":
+                return inner.resource_type.value
+            if name == "version":
+                return inner.version
+            if name == "annotations":
+                return inner.annotations
+
+        elif self._kind == ViewKind.TOOL_CALL:
+            if name == "namespace":
+                return inner.namespace
+            if name == "tool_id":
+                return inner.tool_call_id
+
+        elif self._kind == ViewKind.TOOL_RESULT:
+            if name == "is_error":
+                return inner.is_error
+            if name == "tool_name":
+                return inner.tool_name
+
+        elif self._kind == ViewKind.PROMPT_REQUEST:
+            if name == "server_id":
+                return inner.server_id
+
+        elif self._kind == ViewKind.PROMPT_RESULT:
+            if name == "is_error":
+                return inner.is_error
+            if name == "message_count":
+                return len(inner.messages) if inner.messages else 0
+
+        return default
+
+    # =========================================================================
+    # Direction
+    # =========================================================================
+
+    @property
+    def is_pre(self) -> bool:
+        """True if this represents input/request content (before processing).
+
+        Determined by ViewKind for requests/responses, and by Role
+        for text, thinking, and media content.
+
+        Returns:
+            True if this is pre-processing content.
+        """
+        if self._kind in (ViewKind.TOOL_CALL, ViewKind.PROMPT_REQUEST, ViewKind.RESOURCE_REF):
+            return True
+        if self._kind in (ViewKind.TOOL_RESULT, ViewKind.PROMPT_RESULT, ViewKind.RESOURCE):
+            return False
+        return self._message.role in (Role.USER, Role.SYSTEM, Role.DEVELOPER, Role.TOOL)
+
+    @property
+    def is_post(self) -> bool:
+        """True if this represents output/response content (after processing).
+
+        Returns:
+            True if this is post-processing content.
+        """
+        if self._kind in (ViewKind.TOOL_RESULT, ViewKind.PROMPT_RESULT, ViewKind.RESOURCE):
+            return True
+        if self._kind in (ViewKind.TOOL_CALL, ViewKind.PROMPT_REQUEST, ViewKind.RESOURCE_REF):
+            return False
+        return self._message.role == Role.ASSISTANT
+
+    @property
+    def is_tool(self) -> bool:
+        """True if tool_call or tool_result.
+
+        Returns:
+            True if this is a tool-related view.
+        """
+        return self._kind in (ViewKind.TOOL_CALL, ViewKind.TOOL_RESULT)
+
+    @property
+    def is_prompt(self) -> bool:
+        """True if prompt_request or prompt_result.
+
+        Returns:
+            True if this is a prompt-related view.
+        """
+        return self._kind in (ViewKind.PROMPT_REQUEST, ViewKind.PROMPT_RESULT)
+
+    @property
+    def is_resource(self) -> bool:
+        """True if resource or resource_ref.
+
+        Returns:
+            True if this is a resource-related view.
+        """
+        return self._kind in (ViewKind.RESOURCE, ViewKind.RESOURCE_REF)
+
+    @property
+    def is_text(self) -> bool:
+        """True if text or thinking.
+
+        Returns:
+            True if this is text-based content.
+        """
+        return self._kind in (ViewKind.TEXT, ViewKind.THINKING)
+
+    @property
+    def is_media(self) -> bool:
+        """True if image, video, audio, or document.
+
+        Returns:
+            True if this is media content.
+        """
+        return self._kind in (ViewKind.IMAGE, ViewKind.VIDEO, ViewKind.AUDIO, ViewKind.DOCUMENT)
+
+    # =========================================================================
+    # Flat Accessors (capability-gated in the spec)
+    # =========================================================================
+
+    def _ext(self) -> Any:
+        """Get the message extensions, or None."""
+        return self._message.extensions
+
+    # --- Base tier (no capability required) ---
+
+    @property
+    def environment(self) -> str | None:
+        """Execution environment (production, staging, dev).
+
+        Capability: base (no requirement).
+
+        Returns:
+            Environment string or None.
+        """
+        ext = self._ext()
+        if ext and ext.request:
+            return ext.request.environment
+        return None
+
+    @property
+    def request_id(self) -> str | None:
+        """Request correlation ID.
+
+        Capability: base (no requirement).
+
+        Returns:
+            Request ID string or None.
+        """
+        ext = self._ext()
+        if ext and ext.request:
+            return ext.request.request_id
+        return None
+
+    # --- read_subject ---
+
+    @property
+    def subject(self) -> SubjectExtension | None:
+        """The authenticated entity making the request.
+
+        Capability: read_subject.
+
+        Returns:
+            SubjectExtension or None.
+        """
+        ext = self._ext()
+        if ext and ext.security:
+            return ext.security.subject
+        return None
+
+    # --- read_roles ---
+
+    @property
+    def roles(self) -> frozenset[str]:
+        """Subject's assigned roles.
+
+        Capability: read_roles.
+
+        Returns:
+            Frozenset of role strings.
+        """
+        s = self.subject
+        return s.roles if s else frozenset()
+
+    # --- read_permissions ---
+
+    @property
+    def permissions(self) -> frozenset[str]:
+        """Subject's granted permissions.
+
+        Capability: read_permissions.
+
+        Returns:
+            Frozenset of permission strings.
+        """
+        s = self.subject
+        return s.permissions if s else frozenset()
+
+    # --- read_teams ---
+
+    @property
+    def teams(self) -> frozenset[str]:
+        """Subject's team memberships.
+
+        Capability: read_teams.
+
+        Returns:
+            Frozenset of team strings.
+        """
+        s = self.subject
+        return s.teams if s else frozenset()
+
+    # --- read_headers ---
+
+    @property
+    def headers(self) -> dict[str, str]:
+        """HTTP headers associated with the request.
+
+        Capability: read_headers.
+
+        Returns:
+            Dict of header name to value.
+        """
+        ext = self._ext()
+        if ext and ext.http:
+            return ext.http.headers
+        return {}
+
+    # --- read_labels ---
+
+    @property
+    def labels(self) -> frozenset[str]:
+        """Security/data labels on this message.
+
+        Capability: read_labels.
+
+        Returns:
+            Frozenset of label strings.
+        """
+        ext = self._ext()
+        if ext and ext.security:
+            return ext.security.labels
+        return frozenset()
+
+    # --- read_agent ---
+
+    @property
+    def agent_input(self) -> str | None:
+        """Original user intent that triggered this action.
+
+        Capability: read_agent.
+
+        Returns:
+            Input string or None.
+        """
+        ext = self._ext()
+        if ext and ext.agent:
+            return ext.agent.input
+        return None
+
+    @property
+    def session_id(self) -> str | None:
+        """Broad session identifier.
+
+        Capability: read_agent.
+
+        Returns:
+            Session ID string or None.
+        """
+        ext = self._ext()
+        if ext and ext.agent:
+            return ext.agent.session_id
+        return None
+
+    @property
+    def conversation_id(self) -> str | None:
+        """Specific dialogue/task within a session.
+
+        Capability: read_agent.
+
+        Returns:
+            Conversation ID string or None.
+        """
+        ext = self._ext()
+        if ext and ext.agent:
+            return ext.agent.conversation_id
+        return None
+
+    @property
+    def turn(self) -> int | None:
+        """Position in conversation (0-indexed).
+
+        Capability: read_agent.
+
+        Returns:
+            Turn number or None.
+        """
+        ext = self._ext()
+        if ext and ext.agent:
+            return ext.agent.turn
+        return None
+
+    @property
+    def agent_id(self) -> str | None:
+        """Identifier of the producing agent.
+
+        Capability: read_agent.
+
+        Returns:
+            Agent ID string or None.
+        """
+        ext = self._ext()
+        if ext and ext.agent:
+            return ext.agent.agent_id
+        return None
+
+    @property
+    def parent_agent_id(self) -> str | None:
+        """Spawning agent's ID (multi-agent lineage).
+
+        Capability: read_agent.
+
+        Returns:
+            Parent agent ID string or None.
+        """
+        ext = self._ext()
+        if ext and ext.agent:
+            return ext.agent.parent_agent_id
+        return None
+
+    # --- read_objects ---
+
+    @property
+    def object(self) -> ObjectSecurityProfile | None:
+        """Access control profile for this view's entity.
+
+        Resolved by view.name from extensions.security.objects.
+
+        Capability: read_objects.
+
+        Returns:
+            ObjectSecurityProfile or None.
+        """
+        ext = self._ext()
+        view_name = self.name
+        if ext and ext.security and view_name:
+            return ext.security.objects.get(view_name)
+        return None
+
+    # --- read_data ---
+
+    @property
+    def data_policy(self) -> DataPolicy | None:
+        """Data governance policy for this view's entity.
+
+        Resolved by view.name from extensions.security.data.
+
+        Capability: read_data.
+
+        Returns:
+            DataPolicy or None.
+        """
+        ext = self._ext()
+        view_name = self.name
+        if ext and ext.security and view_name:
+            return ext.security.data.get(view_name)
+        return None
+
+    # =========================================================================
+    # Helper Methods
+    # =========================================================================
+
+    def has_role(self, role: str) -> bool:
+        """Check if subject has a specific role.
+
+        Args:
+            role: The role to check for.
+
+        Returns:
+            True if the subject has the role.
+        """
+        return role in self.roles
+
+    def has_permission(self, perm: str) -> bool:
+        """Check if subject has a specific permission.
+
+        Args:
+            perm: The permission to check for.
+
+        Returns:
+            True if the subject has the permission.
+        """
+        return perm in self.permissions
+
+    def has_label(self, label: str) -> bool:
+        """Check if a security label is present.
+
+        Args:
+            label: Label to check for (e.g., "PII", "SECRET").
+
+        Returns:
+            True if the label is present.
+        """
+        return label in self.labels
+
+    def has_header(self, name: str) -> bool:
+        """Check if an HTTP header exists (case-insensitive).
+
+        Args:
+            name: Header name to check.
+
+        Returns:
+            True if header exists.
+        """
+        return self.get_header(name) is not None
+
+    def get_header(self, name: str, default: str | None = None) -> str | None:
+        """Get an HTTP header value (case-insensitive).
+
+        Args:
+            name: Header name.
+            default: Default value if header not found.
+
+        Returns:
+            Header value or default.
+        """
+        lower_name = name.lower()
+        for key, value in self.headers.items():
+            if key.lower() == lower_name:
+                return value
+        return default
+
+    def get_arg(self, name: str, default: Any = None) -> Any:
+        """Get a single argument value.
+
+        Args:
+            name: Argument name.
+            default: Value if argument doesn't exist.
+
+        Returns:
+            Argument value or default.
+        """
+        args = self.args
+        if args is None:
+            return default
+        return args.get(name, default)
+
+    def has_arg(self, name: str) -> bool:
+        """Check if an argument exists.
+
+        Args:
+            name: Argument name to check.
+
+        Returns:
+            True if argument exists.
+        """
+        args = self.args
+        return args is not None and name in args
+
+    def matches_uri_pattern(self, pattern: str) -> bool:
+        """Check if URI matches a glob-style pattern.
+
+        Supports * (single segment) and ** (any number of segments)
+        wildcards.
+
+        Args:
+            pattern: Glob pattern to match against.
+
+        Returns:
+            True if URI matches the pattern.
+        """
+        view_uri = self.uri
+        if not view_uri:
+            return False
+        regex = pattern.replace("**", "<<<DOUBLE>>>")
+        regex = regex.replace("*", "[^/]*")
+        regex = regex.replace("<<<DOUBLE>>>", ".*")
+        regex = f"^{regex}$"
+        return bool(re.match(regex, view_uri))
+
+    def has_content(self) -> bool:
+        """True if scannable text content is available.
+
+        Returns:
+            True if content is not None.
+        """
+        return self.content is not None
+
+    # =========================================================================
+    # Serialization
+    # =========================================================================
+
+    def to_dict(self, include_content: bool = True, include_context: bool = True) -> dict[str, Any]:
+        """Serialize the view to a JSON-compatible dictionary.
+
+        Sensitive headers (Authorization, Cookie, X-API-Key) are
+        automatically stripped from the serialized output.
+
+        Args:
+            include_content: Include text content (may be large).
+            include_context: Include extensions context.
+
+        Returns:
+            JSON-serializable dictionary with view properties.
+        """
+        result: dict[str, Any] = {
+            "kind": self._kind.value,
+            "role": self._message.role.value,
+            "is_pre": self.is_pre,
+            "is_post": self.is_post,
+            "action": self.action.value,
+        }
+
+        if self.uri:
+            result["uri"] = self.uri
+        if self.name:
+            result["name"] = self.name
+
+        if include_content:
+            text = self.content
+            if text is not None:
+                result["content"] = text
+            size = self.size_bytes
+            if size is not None:
+                result["size_bytes"] = size
+
+        if self.mime_type:
+            result["mime_type"] = self.mime_type
+
+        args = self.args
+        if args is not None:
+            result["arguments"] = args
+
+        props = self.properties
+        if props:
+            result["properties"] = props
+
+        if include_context:
+            extensions: dict[str, Any] = {}
+
+            # Subject
+            s = self.subject
+            if s:
+                extensions["subject"] = {
+                    "id": s.id,
+                    "type": s.type.value,
+                    "roles": sorted(s.roles),
+                    "permissions": sorted(s.permissions),
+                    "teams": sorted(s.teams),
+                }
+
+            # Environment
+            env = self.environment
+            if env:
+                extensions["environment"] = env
+
+            # Labels
+            lbls = self.labels
+            if lbls:
+                extensions["labels"] = sorted(lbls)
+
+            # Headers (strip sensitive)
+            hdrs = self.headers
+            if hdrs:
+                safe = {k: v for k, v in hdrs.items() if k.lower() not in _SENSITIVE_HEADERS}
+                if safe:
+                    extensions["headers"] = safe
+
+            # Object profile (for pre views)
+            obj = self.object
+            if obj:
+                extensions["object"] = {
+                    "managed_by": obj.managed_by,
+                    "permissions": obj.permissions,
+                    "trust_domain": obj.trust_domain,
+                    "data_scope": obj.data_scope,
+                }
+
+            # Data policy (for post views)
+            dp = self.data_policy
+            if dp:
+                dp_dict: dict[str, Any] = {
+                    "apply_labels": dp.apply_labels,
+                    "denied_actions": dp.denied_actions,
+                }
+                if dp.allowed_actions is not None:
+                    dp_dict["allowed_actions"] = dp.allowed_actions
+                if dp.retention:
+                    dp_dict["retention"] = {
+                        "max_age_seconds": dp.retention.max_age_seconds,
+                        "policy": dp.retention.policy,
+                        "delete_after": dp.retention.delete_after,
+                    }
+                extensions["data"] = dp_dict
+
+            # Agent context
+            ext = self._ext()
+            if ext and ext.agent:
+                agent_dict: dict[str, Any] = {}
+                if ext.agent.input:
+                    agent_dict["input"] = ext.agent.input
+                if ext.agent.session_id:
+                    agent_dict["session_id"] = ext.agent.session_id
+                if ext.agent.conversation_id:
+                    agent_dict["conversation_id"] = ext.agent.conversation_id
+                if ext.agent.turn is not None:
+                    agent_dict["turn"] = ext.agent.turn
+                if ext.agent.agent_id:
+                    agent_dict["agent_id"] = ext.agent.agent_id
+                if ext.agent.parent_agent_id:
+                    agent_dict["parent_agent_id"] = ext.agent.parent_agent_id
+                if agent_dict:
+                    extensions["agent"] = agent_dict
+
+            if extensions:
+                result["extensions"] = extensions
+
+        return result
+
+    def to_opa_input(self, include_content: bool = True) -> dict[str, Any]:
+        """Serialize to OPA-compatible input format.
+
+        Wraps the view in the standard OPA input envelope:
+        {"input": {...view data...}}.
+
+        Args:
+            include_content: Include text content in the input.
+
+        Returns:
+            Dict in OPA input format.
+        """
+        return {"input": self.to_dict(include_content=include_content)}
+
+    def __repr__(self) -> str:
+        """String representation of the view.
+
+        Returns:
+            Human-readable representation.
+        """
+        role_part = f", role={self._message.role.value}"
+        uri_part = f", uri={self.uri}" if self.uri else ""
+        direction = "pre" if self.is_pre else "post" if self.is_post else "?"
+        return f"MessageView(kind={self._kind.value}{role_part}, {direction}{uri_part})"
+
+
+# ---------------------------------------------------------------------------
+# View Iterator (standalone)
+# ---------------------------------------------------------------------------
+
+
+def iter_views(message: Message) -> Iterator[MessageView]:
+    """Iterate over a message yielding one MessageView per content part.
+
+    Memory-efficient: views are yielded one at a time and hold only
+    references to the underlying message and content part.
+
+    This is the standalone version. Message.iter_views() delegates
+    to this function.
+
+    Args:
+        message: The message to decompose into views.
+
+    Yields:
+        A MessageView for each content part in the message.
+
+    Examples:
+        >>> from cpex.framework.cmf.message import (
+        ...     Message, Role, TextContent, ToolCall, ToolCallContentPart,
+        ...     ThinkingContent,
+        ... )
+        >>> msg = Message(
+        ...     role=Role.ASSISTANT,
+        ...     content=[
+        ...         ThinkingContent(text="User wants admin users."),
+        ...         TextContent(text="Let me look that up."),
+        ...         ToolCallContentPart(
+        ...             content=ToolCall(
+        ...                 tool_call_id="tc_001",
+        ...                 name="execute_sql",
+        ...                 arguments={"query": "SELECT * FROM users"},
+        ...             ),
+        ...         ),
+        ...     ],
+        ... )
+        >>> views = list(iter_views(msg))
+        >>> len(views)
+        3
+        >>> [(v.kind.value, v.is_pre) for v in views]
+        [('thinking', False), ('text', False), ('tool_call', True)]
+    """
+    for part in message.content:
+        kind = _CONTENT_TYPE_TO_VIEW_KIND.get(part.content_type)
+        if kind is not None:
+            yield MessageView(part, kind, message)

--- a/cpex/framework/extensions/__init__.py
+++ b/cpex/framework/extensions/__init__.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/__init__.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Extensions Package.
+Provides structured, typed extension models for identity, security,
+governance, and execution context metadata. Extensions are designed
+to be reusable across different payload types.
+"""
+
+# First-Party
+from cpex.framework.extensions.agent import AgentExtension, ConversationContext
+from cpex.framework.extensions.completion import CompletionExtension, StopReason, TokenUsage
+from cpex.framework.extensions.extensions import Extensions
+from cpex.framework.extensions.framework import FrameworkExtension
+from cpex.framework.extensions.http import HttpExtension
+from cpex.framework.extensions.llm import LLMExtension
+from cpex.framework.extensions.mcp import MCPExtension, PromptMetadata, ResourceMetadata, ToolMetadata
+from cpex.framework.extensions.provenance import ProvenanceExtension
+from cpex.framework.extensions.request import RequestExtension
+from cpex.framework.extensions.security import (
+    DataPolicy,
+    ObjectSecurityProfile,
+    RetentionPolicy,
+    SecurityExtension,
+    SubjectExtension,
+    SubjectType,
+)
+
+__all__ = [
+    "AgentExtension",
+    "CompletionExtension",
+    "ConversationContext",
+    "DataPolicy",
+    "Extensions",
+    "FrameworkExtension",
+    "HttpExtension",
+    "LLMExtension",
+    "MCPExtension",
+    "ObjectSecurityProfile",
+    "PromptMetadata",
+    "ProvenanceExtension",
+    "RequestExtension",
+    "ResourceMetadata",
+    "RetentionPolicy",
+    "SecurityExtension",
+    "StopReason",
+    "SubjectExtension",
+    "SubjectType",
+    "TokenUsage",
+    "ToolMetadata",
+]

--- a/cpex/framework/extensions/agent.py
+++ b/cpex/framework/extensions/agent.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/agent.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Agent extension models.
+Carries agent execution context — session tracking, multi-agent lineage,
+original user intent, and optional windowed conversation history.
+Immutable tier — the user's intent and session identity must not be
+modifiable by processing components.
+"""
+
+# Standard
+from typing import Any
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ConversationContext(BaseModel):
+    """Windowed conversation context for agent-aware processing.
+
+    Provides a lightweight view of prior conversation history without
+    requiring access to the full message store.
+
+    Attributes:
+        history: Windowed message history (recent turns).
+        summary: Summarized prior context.
+        topics: Extracted topics or intents.
+
+    Examples:
+        >>> ctx = ConversationContext(
+        ...     summary="User asked about quarterly revenue.",
+        ...     topics=["revenue", "Q4"],
+        ... )
+        >>> ctx.summary
+        'User asked about quarterly revenue.'
+        >>> ctx.topics
+        ['revenue', 'Q4']
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    history: list[Any] = Field(
+        default_factory=list,
+        description="Windowed message history (recent turns).",
+    )
+    summary: str | None = Field(default=None, description="Summarized prior context.")
+    topics: list[str] = Field(default_factory=list, description="Extracted topics or intents.")
+
+
+class AgentExtension(BaseModel):
+    """Agent execution context.
+
+    Tracks session identity, multi-agent lineage, and the original
+    user intent that triggered the current action. Immutable — the
+    processing pipeline rejects any modifications.
+
+    Attributes:
+        input: Original user intent that triggered this action.
+        session_id: Broad session identifier.
+        conversation_id: Specific dialogue/task within a session.
+        turn: Position in conversation (0-indexed).
+        agent_id: Identifier of the producing agent.
+        parent_agent_id: Spawning agent's ID (multi-agent lineage).
+        conversation: Windowed conversation context.
+
+    Examples:
+        >>> ext = AgentExtension(
+        ...     input="What is the weather in London?",
+        ...     session_id="sess-001",
+        ...     conversation_id="conv-042",
+        ...     turn=3,
+        ...     agent_id="weather-agent",
+        ... )
+        >>> ext.input
+        'What is the weather in London?'
+        >>> ext.turn
+        3
+
+        >>> # Multi-agent lineage
+        >>> child = AgentExtension(
+        ...     agent_id="sub-agent-01",
+        ...     parent_agent_id="weather-agent",
+        ... )
+        >>> child.parent_agent_id
+        'weather-agent'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    input: str | None = Field(default=None, description="Original user intent that triggered this action.")
+    session_id: str | None = Field(default=None, description="Broad session identifier.")
+    conversation_id: str | None = Field(default=None, description="Specific dialogue/task within a session.")
+    turn: int | None = Field(default=None, description="Position in conversation (0-indexed).")
+    agent_id: str | None = Field(default=None, description="Identifier of the producing agent.")
+    parent_agent_id: str | None = Field(default=None, description="Spawning agent's ID (multi-agent lineage).")
+    conversation: ConversationContext | None = Field(default=None, description="Windowed conversation context.")

--- a/cpex/framework/extensions/completion.py
+++ b/cpex/framework/extensions/completion.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/completion.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Completion extension models.
+Carries LLM completion information including stop reason, token usage,
+model identifier, wire format, and latency.
+Immutable tier — shared reference, no modifications allowed.
+"""
+
+# Standard
+from enum import Enum
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class StopReason(str, Enum):
+    """Closed-set enumeration of completion stop reasons.
+
+    Attributes:
+        END: Natural end of generation.
+        RETURN: Model returned a structured result.
+        CALL: Model made a tool call.
+        MAX_TOKENS: Generation stopped due to token limit.
+        STOP_SEQUENCE: Generation stopped at a stop sequence.
+
+    Examples:
+        >>> StopReason.END
+        <StopReason.END: 'end'>
+        >>> StopReason("max_tokens")
+        <StopReason.MAX_TOKENS: 'max_tokens'>
+    """
+
+    END = "end"
+    RETURN = "return"
+    CALL = "call"
+    MAX_TOKENS = "max_tokens"
+    STOP_SEQUENCE = "stop_sequence"
+
+
+class TokenUsage(BaseModel):
+    """Token consumption metrics for a completion.
+
+    Attributes:
+        input_tokens: Tokens consumed by the input.
+        output_tokens: Tokens generated in the output.
+        total_tokens: Total tokens (input + output).
+
+    Examples:
+        >>> usage = TokenUsage(input_tokens=150, output_tokens=50, total_tokens=200)
+        >>> usage.total_tokens
+        200
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    input_tokens: int = Field(description="Tokens consumed by the input.")
+    output_tokens: int = Field(description="Tokens generated in the output.")
+    total_tokens: int = Field(description="Total tokens (input + output).")
+
+
+class CompletionExtension(BaseModel):
+    """LLM completion information.
+
+    Fields like model and stop_reason can drive policy decisions
+    (e.g., "only allow gpt-4 for financial queries", "flag max_tokens
+    responses for review"). Immutable — the processing pipeline rejects
+    any modifications.
+
+    Attributes:
+        stop_reason: Why the model stopped.
+        tokens: Token counts.
+        model: Model identifier that generated this response.
+        raw_format: Original wire format (chatml, harmony, gemini, anthropic).
+        created_at: ISO timestamp when the message was created.
+        latency_ms: Response generation time in milliseconds.
+
+    Examples:
+        >>> ext = CompletionExtension(
+        ...     stop_reason=StopReason.END,
+        ...     tokens=TokenUsage(input_tokens=100, output_tokens=50, total_tokens=150),
+        ...     model="gpt-4o",
+        ...     latency_ms=1200,
+        ... )
+        >>> ext.stop_reason
+        <StopReason.END: 'end'>
+        >>> ext.tokens.total_tokens
+        150
+        >>> ext.latency_ms
+        1200
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    stop_reason: StopReason | None = Field(default=None, description="Why the model stopped.")
+    tokens: TokenUsage | None = Field(default=None, description="Token counts.")
+    model: str | None = Field(default=None, description="Model identifier that generated this response.")
+    raw_format: str | None = Field(
+        default=None, description="Original wire format (chatml, harmony, gemini, anthropic)."
+    )
+    created_at: str | None = Field(default=None, description="ISO timestamp when the message was created.")
+    latency_ms: int | None = Field(default=None, description="Response generation time in milliseconds.")

--- a/cpex/framework/extensions/extensions.py
+++ b/cpex/framework/extensions/extensions.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/extensions.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Extensions container model.
+Aggregates all typed extension models into a single container that
+attaches to a Message. Each extension slot corresponds to a specific
+mutability tier enforced by the processing pipeline.
+"""
+
+# Standard
+from typing import Any
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+# First-Party
+from cpex.framework.extensions.agent import AgentExtension
+from cpex.framework.extensions.completion import CompletionExtension
+from cpex.framework.extensions.framework import FrameworkExtension
+from cpex.framework.extensions.http import HttpExtension
+from cpex.framework.extensions.llm import LLMExtension
+from cpex.framework.extensions.mcp import MCPExtension
+from cpex.framework.extensions.provenance import ProvenanceExtension
+from cpex.framework.extensions.request import RequestExtension
+from cpex.framework.extensions.security import SecurityExtension
+
+
+class Extensions(BaseModel):
+    """Container for all typed message extensions.
+
+    Each extension slot carries contextual metadata with an explicit
+    mutability tier enforced by the processing pipeline during
+    copy-on-write operations.
+
+    Frozen by design — consumers must use model_copy(update={...})
+    to create modified copies.
+
+    Attributes:
+        request: Execution environment, request ID, timestamp, tracing (immutable).
+        agent: Session tracking, multi-agent lineage, user intent (immutable).
+        http: HTTP headers with capability-gated access (guarded).
+        security: Labels, classification, identity, access control, data policy (monotonic/immutable).
+        mcp: Tool, resource, or prompt metadata (immutable).
+        completion: Stop reason, token usage, model, latency (immutable).
+        provenance: Source, message ID, parent ID (immutable).
+        llm: Model identity and capabilities (immutable).
+        framework: Agentic framework context (immutable).
+        custom: Custom extensions (mutable).
+
+    Examples:
+        >>> ext = Extensions(
+        ...     request=RequestExtension(
+        ...         environment="production",
+        ...         request_id="req-001",
+        ...     ),
+        ...     llm=LLMExtension(
+        ...         model_id="gpt-4o",
+        ...         provider="openai",
+        ...     ),
+        ... )
+        >>> ext.request.environment
+        'production'
+        >>> ext.llm.provider
+        'openai'
+        >>> ext.security is None
+        True
+
+        >>> # Frozen: modifications require model_copy
+        >>> updated = ext.model_copy(update={"custom": {"trace": True}})
+        >>> updated.custom
+        {'trace': True}
+        >>> ext.custom is None
+        True
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    request: RequestExtension | None = Field(default=None, description="Execution environment and tracing.")
+    agent: AgentExtension | None = Field(default=None, description="Agent execution context.")
+    http: HttpExtension | None = Field(default=None, description="HTTP request context.")
+    security: SecurityExtension | None = Field(default=None, description="Security labels and identity.")
+    mcp: MCPExtension | None = Field(default=None, description="MCP entity metadata.")
+    completion: CompletionExtension | None = Field(default=None, description="LLM completion information.")
+    provenance: ProvenanceExtension | None = Field(default=None, description="Origin and threading.")
+    llm: LLMExtension | None = Field(default=None, description="Model identity and capabilities.")
+    framework: FrameworkExtension | None = Field(default=None, description="Agentic framework context.")
+    custom: dict[str, Any] | None = Field(default=None, description="Custom extensions (mutable).")

--- a/cpex/framework/extensions/framework.py
+++ b/cpex/framework/extensions/framework.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/framework.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Framework extension model.
+Captures the agentic framework execution environment for messages
+originating from or passing through orchestration layers.
+Immutable tier — shared reference, no modifications allowed.
+"""
+
+# Standard
+from typing import Any
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class FrameworkExtension(BaseModel):
+    """Agentic framework execution context.
+
+    Captures framework-level metadata for messages that originate
+    from or pass through agentic orchestration layers (LangGraph,
+    CrewAI, AutoGen, A2A, etc.). Immutable — the processing pipeline
+    rejects any modifications.
+
+    Attributes:
+        framework: Framework identifier (e.g., langgraph, crewai, autogen, a2a).
+        framework_version: Framework version.
+        node_id: Framework-specific node or step identifier.
+        graph_id: Graph or workflow identifier.
+        metadata: Framework-specific metadata.
+
+    Examples:
+        >>> ext = FrameworkExtension(
+        ...     framework="langgraph",
+        ...     framework_version="0.2.0",
+        ...     node_id="weather_node",
+        ...     graph_id="travel_planner",
+        ... )
+        >>> ext.framework
+        'langgraph'
+        >>> ext.node_id
+        'weather_node'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    framework: str | None = Field(default=None, description="Framework identifier.")
+    framework_version: str | None = Field(default=None, description="Framework version.")
+    node_id: str | None = Field(default=None, description="Framework-specific node or step identifier.")
+    graph_id: str | None = Field(default=None, description="Graph or workflow identifier.")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Framework-specific metadata.")

--- a/cpex/framework/extensions/http.py
+++ b/cpex/framework/extensions/http.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/http.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+HTTP extension model.
+Carries HTTP request context with capability-gated access.
+Guarded tier — readable with read_headers, writable with write_headers.
+"""
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class HttpExtension(BaseModel):
+    """HTTP request context.
+
+    Readable with the read_headers capability, writable with
+    write_headers. Sensitive headers (Authorization, Cookie, X-API-Key)
+    are stripped when serialized for external policy engines.
+
+    Guarded tier — the processing pipeline rejects modifications
+    unless the consumer holds the write_headers capability.
+
+    Attributes:
+        headers: HTTP headers as key-value pairs.
+
+    Examples:
+        >>> ext = HttpExtension(
+        ...     headers={"Content-Type": "application/json", "X-Request-ID": "req-123"},
+        ... )
+        >>> ext.headers["Content-Type"]
+        'application/json'
+
+        >>> # Frozen: modifications require model_copy
+        >>> updated = ext.model_copy(
+        ...     update={"headers": {**ext.headers, "X-Trace-ID": "trace-456"}},
+        ... )
+        >>> "X-Trace-ID" in updated.headers
+        True
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    headers: dict[str, str] = Field(default_factory=dict, description="HTTP headers as key-value pairs.")

--- a/cpex/framework/extensions/llm.py
+++ b/cpex/framework/extensions/llm.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/llm.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+LLM extension model.
+Carries model identity and capability metadata for routing,
+policy evaluation, and audit.
+Immutable tier — shared reference, no modifications allowed.
+"""
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class LLMExtension(BaseModel):
+    """Model identity and capability metadata.
+
+    Used for routing, policy evaluation, and audit when the producing
+    model's identity matters independently of the completion itself.
+    Immutable — the processing pipeline rejects any modifications.
+
+    Attributes:
+        model_id: Model identifier (e.g., gpt-4o, claude-sonnet-4-20250514).
+        provider: Provider name (e.g., openai, anthropic, google).
+        capabilities: Declared model capabilities (e.g., vision, tool_use, extended_thinking).
+
+    Examples:
+        >>> ext = LLMExtension(
+        ...     model_id="claude-sonnet-4-20250514",
+        ...     provider="anthropic",
+        ...     capabilities=["vision", "tool_use", "extended_thinking"],
+        ... )
+        >>> ext.provider
+        'anthropic'
+        >>> "tool_use" in ext.capabilities
+        True
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    model_id: str | None = Field(default=None, description="Model identifier.")
+    provider: str | None = Field(default=None, description="Provider name.")
+    capabilities: list[str] = Field(default_factory=list, description="Declared model capabilities.")

--- a/cpex/framework/extensions/mcp.py
+++ b/cpex/framework/extensions/mcp.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/mcp.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+MCP extension models.
+Carries typed metadata about MCP entities (tools, resources, prompts)
+being processed. Gives consumers access to schemas and annotations.
+Immutable tier — shared reference, no modifications allowed.
+"""
+
+# Standard
+from typing import Any
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ToolMetadata(BaseModel):
+    """Typed metadata for an MCP tool.
+
+    Attributes:
+        name: Unique tool identifier.
+        title: Human-readable display name.
+        description: Description of tool functionality.
+        input_schema: JSON Schema defining expected parameters.
+        output_schema: JSON Schema for structured output.
+        server_id: ID of the server providing this tool.
+        namespace: Tool namespace (server/origin).
+        annotations: MCP annotations (e.g., readOnlyHint, destructiveHint).
+
+    Examples:
+        >>> meta = ToolMetadata(
+        ...     name="get_user",
+        ...     description="Retrieve user by ID",
+        ...     input_schema={"type": "object", "properties": {"id": {"type": "string"}}},
+        ...     server_id="user-service",
+        ... )
+        >>> meta.name
+        'get_user'
+        >>> meta.server_id
+        'user-service'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str = Field(description="Unique tool identifier.")
+    title: str | None = Field(default=None, description="Human-readable display name.")
+    description: str | None = Field(default=None, description="Description of tool functionality.")
+    input_schema: dict[str, Any] | None = Field(default=None, description="JSON Schema defining expected parameters.")
+    output_schema: dict[str, Any] | None = Field(default=None, description="JSON Schema for structured output.")
+    server_id: str | None = Field(default=None, description="ID of the server providing this tool.")
+    namespace: str | None = Field(default=None, description="Tool namespace (server/origin).")
+    annotations: dict[str, Any] = Field(default_factory=dict, description="MCP annotations.")
+
+
+class ResourceMetadata(BaseModel):
+    """Typed metadata for an MCP resource.
+
+    Attributes:
+        uri: Resource URI.
+        name: Resource name.
+        description: Resource description.
+        mime_type: MIME type (text/csv, application/json, etc.).
+        server_id: ID of the server providing this resource.
+        annotations: MCP annotations (classification, retention, access hints).
+
+    Examples:
+        >>> meta = ResourceMetadata(
+        ...     uri="file:///data/report.csv",
+        ...     name="Quarterly Report",
+        ...     mime_type="text/csv",
+        ... )
+        >>> meta.uri
+        'file:///data/report.csv'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    uri: str = Field(description="Resource URI.")
+    name: str | None = Field(default=None, description="Resource name.")
+    description: str | None = Field(default=None, description="Resource description.")
+    mime_type: str | None = Field(default=None, description="MIME type.")
+    server_id: str | None = Field(default=None, description="ID of the server providing this resource.")
+    annotations: dict[str, Any] = Field(default_factory=dict, description="MCP annotations.")
+
+
+class PromptMetadata(BaseModel):
+    """Typed metadata for an MCP prompt template.
+
+    Prompts use an argument list rather than JSON Schema for input
+    definition, following the MCP prompt specification. There is no
+    output schema — prompt output is always rendered messages.
+
+    Attributes:
+        name: Prompt template name.
+        description: Prompt description.
+        arguments: Argument definitions (each has name, description, required).
+        server_id: ID of the server providing this prompt.
+        annotations: MCP annotations.
+
+    Examples:
+        >>> meta = PromptMetadata(
+        ...     name="summarize",
+        ...     description="Summarize a document",
+        ...     arguments=[
+        ...         {"name": "text", "description": "Text to summarize", "required": True},
+        ...     ],
+        ... )
+        >>> meta.name
+        'summarize'
+        >>> meta.arguments[0]["name"]
+        'text'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str = Field(description="Prompt template name.")
+    description: str | None = Field(default=None, description="Prompt description.")
+    arguments: list[dict[str, Any]] | None = Field(default=None, description="Argument definitions.")
+    server_id: str | None = Field(default=None, description="ID of the server providing this prompt.")
+    annotations: dict[str, Any] = Field(default_factory=dict, description="MCP annotations.")
+
+
+class MCPExtension(BaseModel):
+    """Typed metadata about the MCP entity being processed.
+
+    Exactly one of tool, resource, or prompt is populated per message,
+    depending on the content type. Immutable — the processing pipeline
+    rejects any modifications.
+
+    Attributes:
+        tool: Tool metadata (populated for tool_call / tool_result content).
+        resource: Resource metadata (populated for resource / resource_ref content).
+        prompt: Prompt metadata (populated for prompt_request / prompt_result content).
+
+    Examples:
+        >>> ext = MCPExtension(
+        ...     tool=ToolMetadata(name="get_user", description="Retrieve user by ID"),
+        ... )
+        >>> ext.tool.name
+        'get_user'
+        >>> ext.resource is None
+        True
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    tool: ToolMetadata | None = Field(default=None, description="Tool metadata.")
+    resource: ResourceMetadata | None = Field(default=None, description="Resource metadata.")
+    prompt: PromptMetadata | None = Field(default=None, description="Prompt metadata.")

--- a/cpex/framework/extensions/provenance.py
+++ b/cpex/framework/extensions/provenance.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/provenance.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Provenance extension model.
+Carries origin and threading information for lineage tracking
+across multi-turn conversations and multi-agent systems.
+Immutable tier — shared reference, no modifications allowed.
+"""
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ProvenanceExtension(BaseModel):
+    """Origin and threading information for the message.
+
+    Enables lineage tracking across multi-turn conversations and
+    multi-agent systems. Immutable — the processing pipeline rejects
+    any modifications.
+
+    Attributes:
+        source: Source identifier (e.g., "user", "agent:xyz", "mcp-server:abc").
+        message_id: Unique message identifier.
+        parent_id: Parent message ID (threading/replies).
+
+    Examples:
+        >>> ext = ProvenanceExtension(
+        ...     source="agent:weather-bot",
+        ...     message_id="msg-001",
+        ...     parent_id="msg-000",
+        ... )
+        >>> ext.source
+        'agent:weather-bot'
+        >>> ext.message_id
+        'msg-001'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    source: str | None = Field(default=None, description="Source identifier.")
+    message_id: str | None = Field(default=None, description="Unique message identifier.")
+    parent_id: str | None = Field(default=None, description="Parent message ID (threading/replies).")

--- a/cpex/framework/extensions/request.py
+++ b/cpex/framework/extensions/request.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/request.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Request extension model.
+Carries execution environment and request-level timing/tracing metadata.
+Immutable tier — shared reference, no modifications allowed.
+"""
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RequestExtension(BaseModel):
+    """Execution environment and request-level timing/tracing.
+
+    Available to all consumers without any capability requirement (base tier).
+    Immutable — the processing pipeline rejects any modifications.
+
+    Attributes:
+        environment: Execution environment (production, staging, dev).
+        request_id: Request correlation ID.
+        timestamp: ISO timestamp of the request.
+        trace_id: Distributed tracing ID (OpenTelemetry).
+        span_id: Distributed tracing span ID.
+
+    Examples:
+        >>> ext = RequestExtension(
+        ...     environment="production",
+        ...     request_id="req-abc-123",
+        ...     timestamp="2025-01-15T10:30:00Z",
+        ... )
+        >>> ext.environment
+        'production'
+        >>> ext.request_id
+        'req-abc-123'
+
+        >>> # Frozen: modifications require model_copy
+        >>> updated = ext.model_copy(update={"span_id": "span-456"})
+        >>> updated.span_id
+        'span-456'
+        >>> ext.span_id is None
+        True
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    environment: str | None = Field(default=None, description="Execution environment (production, staging, dev).")
+    request_id: str | None = Field(default=None, description="Request correlation ID.")
+    timestamp: str | None = Field(default=None, description="ISO timestamp of the request.")
+    trace_id: str | None = Field(default=None, description="Distributed tracing ID (OpenTelemetry).")
+    span_id: str | None = Field(default=None, description="Distributed tracing span ID.")

--- a/cpex/framework/extensions/security.py
+++ b/cpex/framework/extensions/security.py
@@ -1,0 +1,247 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/security.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Security extension models.
+Carries data classification, security labels, authenticated identity,
+access control profiles, and data governance policies.
+
+The SecurityExtension itself is monotonic tier — labels can only be
+added, never removed, during normal message flow. Its nested fields
+(subject, objects, data) are immutable tier.
+"""
+
+# Standard
+from enum import Enum
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+# ---------------------------------------------------------------------------
+# Subject
+# ---------------------------------------------------------------------------
+
+
+class SubjectType(str, Enum):
+    """Closed-set enumeration of subject types.
+
+    Attributes:
+        USER: Human user.
+        AGENT: Autonomous agent.
+        SERVICE: Backend service.
+        SYSTEM: System-level principal.
+
+    Examples:
+        >>> SubjectType.USER
+        <SubjectType.USER: 'user'>
+        >>> SubjectType("agent")
+        <SubjectType.AGENT: 'agent'>
+    """
+
+    USER = "user"
+    AGENT = "agent"
+    SERVICE = "service"
+    SYSTEM = "system"
+
+
+class SubjectExtension(BaseModel):
+    """Authenticated entity making the request.
+
+    Access to individual fields is controlled by declared capabilities
+    on the MessageView. Immutable — the processing pipeline rejects
+    any modifications.
+
+    Attributes:
+        id: Unique subject identifier.
+        type: Subject kind.
+        roles: Assigned roles (developer, admin, viewer, etc.).
+        permissions: Granted permissions (tools.execute, db.read, etc.).
+        teams: Team memberships (for multi-tenant scoping).
+        claims: Raw identity claims (JWT, SAML).
+
+    Examples:
+        >>> subject = SubjectExtension(
+        ...     id="user-alice",
+        ...     type=SubjectType.USER,
+        ...     roles={"admin", "developer"},
+        ...     permissions={"tools.execute", "db.read"},
+        ... )
+        >>> subject.id
+        'user-alice'
+        >>> "admin" in subject.roles
+        True
+        >>> "db.read" in subject.permissions
+        True
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(description="Unique subject identifier.")
+    type: SubjectType = Field(description="Subject kind.")
+    roles: frozenset[str] = Field(default_factory=frozenset, description="Assigned roles.")
+    permissions: frozenset[str] = Field(default_factory=frozenset, description="Granted permissions.")
+    teams: frozenset[str] = Field(default_factory=frozenset, description="Team memberships.")
+    claims: dict[str, str] = Field(default_factory=dict, description="Raw identity claims (JWT, SAML).")
+
+
+# ---------------------------------------------------------------------------
+# Object Security Profile
+# ---------------------------------------------------------------------------
+
+
+class ObjectSecurityProfile(BaseModel):
+    """Access control contract declared by or for an object.
+
+    Lives on extensions.security.objects, keyed by entity name/URI.
+    Evaluated on pre-hook views (tool_call, resource request, prompt
+    request). Immutable — the processing pipeline rejects any
+    modifications.
+
+    Attributes:
+        managed_by: Who enforces access control: host, tool, or both.
+        permissions: Required permissions to invoke.
+        trust_domain: Trust domain: internal, external, or privileged.
+        data_scope: Field names this entity accesses/returns.
+
+    Examples:
+        >>> profile = ObjectSecurityProfile(
+        ...     managed_by="tool",
+        ...     permissions=["read:compensation"],
+        ...     trust_domain="internal",
+        ...     data_scope=["salary", "bonus"],
+        ... )
+        >>> profile.managed_by
+        'tool'
+        >>> "read:compensation" in profile.permissions
+        True
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    managed_by: str = Field(default="host", description="Who enforces access control: host, tool, or both.")
+    permissions: list[str] = Field(default_factory=list, description="Required permissions to invoke.")
+    trust_domain: str | None = Field(default=None, description="Trust domain: internal, external, or privileged.")
+    data_scope: list[str] = Field(default_factory=list, description="Field names this entity accesses/returns.")
+
+
+# ---------------------------------------------------------------------------
+# Data Policy
+# ---------------------------------------------------------------------------
+
+
+class RetentionPolicy(BaseModel):
+    """Data retention constraints.
+
+    Attributes:
+        max_age_seconds: Maximum retention duration in seconds.
+        policy: Retention class: session, transient, persistent, or none.
+        delete_after: ISO timestamp after which data must be deleted.
+
+    Examples:
+        >>> ret = RetentionPolicy(policy="session", max_age_seconds=3600)
+        >>> ret.policy
+        'session'
+        >>> ret.max_age_seconds
+        3600
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    max_age_seconds: int | None = Field(default=None, description="Maximum retention duration in seconds.")
+    policy: str = Field(default="persistent", description="Retention class: session, transient, persistent, none.")
+    delete_after: str | None = Field(default=None, description="ISO timestamp after which data must be deleted.")
+
+
+class DataPolicy(BaseModel):
+    """Data governance policy for data returned by an entity.
+
+    Lives on extensions.security.data, keyed by entity name/URI.
+    Enforced on post-hook views (tool_result, resource response,
+    prompt result). Always enforced by the gateway — the tool
+    declares, the framework enforces. Immutable — the processing
+    pipeline rejects any modifications.
+
+    Attributes:
+        apply_labels: Labels to stamp on output (PII, financial, etc.).
+        allowed_actions: What downstream can do. None means unrestricted.
+        denied_actions: What downstream cannot do (export, forward, log_raw).
+        retention: How long data can be kept.
+
+    Examples:
+        >>> policy = DataPolicy(
+        ...     apply_labels=["PII", "financial"],
+        ...     denied_actions=["export", "forward", "log_raw"],
+        ...     retention=RetentionPolicy(policy="session", max_age_seconds=7200),
+        ... )
+        >>> "PII" in policy.apply_labels
+        True
+        >>> policy.retention.policy
+        'session'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    apply_labels: list[str] = Field(default_factory=list, description="Labels to stamp on output.")
+    allowed_actions: list[str] | None = Field(
+        default=None, description="What downstream can do. None means unrestricted."
+    )
+    denied_actions: list[str] = Field(default_factory=list, description="What downstream cannot do.")
+    retention: RetentionPolicy | None = Field(default=None, description="How long data can be kept.")
+
+
+# ---------------------------------------------------------------------------
+# SecurityExtension
+# ---------------------------------------------------------------------------
+
+
+class SecurityExtension(BaseModel):
+    """Data classification, security labels, and security-relevant context.
+
+    Monotonic tier for labels — labels can only be added, never removed,
+    during normal message flow. Removal requires a privileged
+    declassification operation that is audited separately. The nested
+    fields (subject, objects, data) are immutable.
+
+    Attributes:
+        labels: Security/data labels (PII, CONFIDENTIAL, SECRET, etc.).
+        classification: Data classification level.
+        subject: Authenticated identity.
+        objects: Access control profiles, keyed by entity identifier.
+        data: Data governance policies, keyed by entity identifier.
+
+    Examples:
+        >>> ext = SecurityExtension(
+        ...     labels=frozenset({"PII", "CONFIDENTIAL"}),
+        ...     classification="confidential",
+        ...     subject=SubjectExtension(
+        ...         id="user-alice",
+        ...         type=SubjectType.USER,
+        ...         roles=frozenset({"admin"}),
+        ...     ),
+        ... )
+        >>> "PII" in ext.labels
+        True
+        >>> ext.subject.id
+        'user-alice'
+
+        >>> # Monotonic label addition via model_copy
+        >>> updated = ext.model_copy(update={"labels": ext.labels | frozenset({"financial"})})
+        >>> "financial" in updated.labels
+        True
+        >>> "PII" in updated.labels
+        True
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    labels: frozenset[str] = Field(default_factory=frozenset, description="Security/data labels.")
+    classification: str | None = Field(default=None, description="Data classification level.")
+    subject: SubjectExtension | None = Field(default=None, description="Authenticated identity.")
+    objects: dict[str, ObjectSecurityProfile] = Field(
+        default_factory=dict, description="Access control profiles, keyed by entity identifier."
+    )
+    data: dict[str, DataPolicy] = Field(
+        default_factory=dict, description="Data governance policies, keyed by entity identifier."
+    )

--- a/cpex/framework/hooks/message.py
+++ b/cpex/framework/hooks/message.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/hooks/message.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Hook definitions for CMF Message evaluation.
+
+Provides a unified entry point for policy evaluation on messages
+flowing through the system. Plugins receive a MessagePayload
+wrapping the CMF Message and can use Message.iter_views() for
+granular per-content-part inspection.
+"""
+
+# Standard
+from enum import Enum
+
+# Third-Party
+from pydantic import Field
+
+# First-Party
+from cpex.framework.cmf.message import Message
+from cpex.framework.models import PluginPayload, PluginResult
+
+
+class MessageHookType(str, Enum):
+    """Message hook points.
+
+    Attributes:
+        EVALUATE: Evaluate a message for policy decisions.
+
+    Examples:
+        >>> MessageHookType.EVALUATE
+        <MessageHookType.EVALUATE: 'evaluate'>
+        >>> MessageHookType.EVALUATE.value
+        'evaluate'
+    """
+
+    EVALUATE = "evaluate"
+
+
+class MessagePayload(PluginPayload):
+    """Payload for message evaluation hooks.
+
+    Wraps a CMF Message for processing through the plugin pipeline.
+    Plugins access the message and use iter_views() for per-content-part
+    policy evaluation.
+
+    Attributes:
+        message: The CMF message to evaluate.
+
+    Examples:
+        >>> from cpex.framework.cmf.message import Message, Role, TextContent
+        >>> msg = Message(
+        ...     role=Role.USER,
+        ...     content=[TextContent(text="Hello")],
+        ... )
+        >>> payload = MessagePayload(message=msg)
+        >>> payload.message.role
+        <Role.USER: 'user'>
+        >>> payload.message.content[0].text
+        'Hello'
+
+        >>> # Iterate views through the payload
+        >>> views = list(payload.message.iter_views())
+        >>> len(views)
+        1
+    """
+
+    message: Message = Field(description="The CMF message to evaluate.")
+
+
+MessageResult = PluginResult[MessagePayload]
+"""Result type for message evaluation hooks."""
+
+
+def _register_message_hooks() -> None:
+    """Register message hooks in the global registry.
+
+    Called at module load time. Idempotent — skips registration
+    if the hook is already registered.
+    """
+    # First-Party
+    from cpex.framework.hooks.registry import get_hook_registry  # pylint: disable=import-outside-toplevel
+
+    registry = get_hook_registry()
+
+    if not registry.is_registered(MessageHookType.EVALUATE):
+        registry.register_hook(MessageHookType.EVALUATE, MessagePayload, MessageResult)
+
+
+_register_message_hooks()

--- a/cpex/framework/hooks/message.py
+++ b/cpex/framework/hooks/message.py
@@ -26,17 +26,36 @@ from cpex.framework.models import PluginPayload, PluginResult
 class MessageHookType(str, Enum):
     """Message hook points.
 
+    The hook type indicates *where* in the pipeline the evaluation
+    is happening, enabling plugins to register for specific locations.
+
     Attributes:
-        EVALUATE: Evaluate a message for policy decisions.
+        EVALUATE: Generic message evaluation.
+        LLM_INPUT: Before model/LLM call (user messages going to LLM).
+        LLM_OUTPUT: After model/LLM call (LLM response).
+        TOOL_PRE_INVOKE: Before tool execution (tool call arguments).
+        TOOL_POST_INVOKE: After tool execution (tool result).
+        PROMPT_PRE_FETCH: Before prompt template fetch.
+        PROMPT_POST_FETCH: After prompt template fetch.
+        RESOURCE_PRE_FETCH: Before resource fetch.
+        RESOURCE_POST_FETCH: After resource fetch.
 
     Examples:
         >>> MessageHookType.EVALUATE
         <MessageHookType.EVALUATE: 'evaluate'>
-        >>> MessageHookType.EVALUATE.value
-        'evaluate'
+        >>> MessageHookType.LLM_INPUT
+        <MessageHookType.LLM_INPUT: 'llm_input'>
     """
 
     EVALUATE = "evaluate"
+    LLM_INPUT = "llm_input"
+    LLM_OUTPUT = "llm_output"
+    TOOL_PRE_INVOKE = "tool_pre_invoke"
+    TOOL_POST_INVOKE = "tool_post_invoke"
+    PROMPT_PRE_FETCH = "prompt_pre_fetch"
+    PROMPT_POST_FETCH = "prompt_post_fetch"
+    RESOURCE_PRE_FETCH = "resource_pre_fetch"
+    RESOURCE_POST_FETCH = "resource_post_fetch"
 
 
 class MessagePayload(PluginPayload):
@@ -48,6 +67,7 @@ class MessagePayload(PluginPayload):
 
     Attributes:
         message: The CMF message to evaluate.
+        hook: The hook location where this evaluation is happening.
 
     Examples:
         >>> from cpex.framework.cmf.message import Message, Role, TextContent
@@ -55,19 +75,18 @@ class MessagePayload(PluginPayload):
         ...     role=Role.USER,
         ...     content=[TextContent(text="Hello")],
         ... )
-        >>> payload = MessagePayload(message=msg)
-        >>> payload.message.role
-        <Role.USER: 'user'>
-        >>> payload.message.content[0].text
-        'Hello'
-
-        >>> # Iterate views through the payload
-        >>> views = list(payload.message.iter_views())
-        >>> len(views)
-        1
+        >>> payload = MessagePayload(
+        ...     message=msg, hook=MessageHookType.LLM_INPUT
+        ... )
+        >>> payload.hook
+        <MessageHookType.LLM_INPUT: 'llm_input'>
     """
 
     message: Message = Field(description="The CMF message to evaluate.")
+    hook: MessageHookType = Field(
+        default=MessageHookType.EVALUATE,
+        description="The hook location where this evaluation is happening.",
+    )
 
 
 MessageResult = PluginResult[MessagePayload]

--- a/tests/unit/cpex/framework/cmf/test_message.py
+++ b/tests/unit/cpex/framework/cmf/test_message.py
@@ -1,0 +1,603 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/cpex/framework/cmf/test_message.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Unit tests for CMF message models.
+"""
+
+# Standard
+from typing import Any
+
+# Third-Party
+import pytest
+
+# First-Party
+from cpex.framework.cmf.message import (
+    AudioContentPart,
+    AudioSource,
+    Channel,
+    ContentPart,
+    ContentType,
+    DocumentContentPart,
+    DocumentSource,
+    ImageContentPart,
+    ImageSource,
+    Message,
+    PromptRequest,
+    PromptRequestContentPart,
+    PromptResult,
+    PromptResultContentPart,
+    Resource,
+    ResourceContentPart,
+    ResourceReference,
+    ResourceRefContentPart,
+    ResourceType,
+    Role,
+    TextContent,
+    ThinkingContent,
+    ToolCall,
+    ToolCallContentPart,
+    ToolResult,
+    ToolResultContentPart,
+    VideoContentPart,
+    VideoSource,
+)
+
+
+# ---------------------------------------------------------------------------
+# Enum Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRole:
+    """Tests for the Role enum."""
+
+    def test_values(self):
+        assert Role.SYSTEM.value == "system"
+        assert Role.DEVELOPER.value == "developer"
+        assert Role.USER.value == "user"
+        assert Role.ASSISTANT.value == "assistant"
+        assert Role.TOOL.value == "tool"
+
+    def test_from_string(self):
+        assert Role("user") == Role.USER
+        assert Role("assistant") == Role.ASSISTANT
+
+    def test_invalid_value(self):
+        with pytest.raises(ValueError):
+            Role("invalid")
+
+    def test_member_count(self):
+        assert len(Role) == 5
+
+
+class TestChannel:
+    """Tests for the Channel enum."""
+
+    def test_values(self):
+        assert Channel.ANALYSIS.value == "analysis"
+        assert Channel.COMMENTARY.value == "commentary"
+        assert Channel.FINAL.value == "final"
+
+    def test_from_string(self):
+        assert Channel("final") == Channel.FINAL
+
+    def test_member_count(self):
+        assert len(Channel) == 3
+
+
+class TestContentType:
+    """Tests for the ContentType enum."""
+
+    def test_all_types_present(self):
+        expected = {
+            "text", "thinking", "tool_call", "tool_result",
+            "resource", "resource_ref", "prompt_request", "prompt_result",
+            "image", "video", "audio", "document",
+        }
+        assert {ct.value for ct in ContentType} == expected
+
+    def test_member_count(self):
+        assert len(ContentType) == 12
+
+
+class TestResourceType:
+    """Tests for the ResourceType enum."""
+
+    def test_all_types_present(self):
+        expected = {"file", "blob", "uri", "database", "api", "memory", "artifact"}
+        assert {rt.value for rt in ResourceType} == expected
+
+    def test_member_count(self):
+        assert len(ResourceType) == 7
+
+
+# ---------------------------------------------------------------------------
+# ContentPart Base Class Tests
+# ---------------------------------------------------------------------------
+
+
+class TestContentPart:
+    """Tests for the ContentPart base class."""
+
+    def test_subclass_relationship(self):
+        part = TextContent(text="hello")
+        assert isinstance(part, ContentPart)
+
+    def test_wrapper_subclass_relationship(self):
+        part = ToolCallContentPart(
+            content=ToolCall(tool_call_id="tc1", name="test"),
+        )
+        assert isinstance(part, ContentPart)
+
+    def test_frozen(self):
+        part = TextContent(text="hello")
+        with pytest.raises(Exception):
+            part.text = "world"
+
+
+# ---------------------------------------------------------------------------
+# Domain Object Tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolCallDomain:
+    """Tests for the ToolCall domain object."""
+
+    def test_creation(self):
+        call = ToolCall(
+            tool_call_id="tc_001",
+            name="get_user",
+            arguments={"user_id": "123"},
+        )
+        assert call.tool_call_id == "tc_001"
+        assert call.name == "get_user"
+        assert call.arguments == {"user_id": "123"}
+
+    def test_default_arguments(self):
+        call = ToolCall(tool_call_id="tc_002", name="list_users")
+        assert call.arguments == {}
+
+    def test_default_namespace(self):
+        call = ToolCall(tool_call_id="tc_003", name="test")
+        assert call.namespace is None
+
+    def test_with_namespace(self):
+        call = ToolCall(
+            tool_call_id="tc_004",
+            name="get_user",
+            namespace="user-service",
+        )
+        assert call.namespace == "user-service"
+
+    def test_frozen(self):
+        call = ToolCall(tool_call_id="tc_005", name="test")
+        with pytest.raises(Exception):
+            call.name = "other"
+
+
+class TestToolResultDomain:
+    """Tests for the ToolResult domain object."""
+
+    def test_creation(self):
+        result = ToolResult(
+            tool_call_id="tc_001",
+            tool_name="get_user",
+            content={"name": "Alice"},
+        )
+        assert result.tool_call_id == "tc_001"
+        assert result.tool_name == "get_user"
+        assert result.content == {"name": "Alice"}
+        assert result.is_error is False
+
+    def test_error_result(self):
+        result = ToolResult(
+            tool_call_id="tc_002",
+            tool_name="fail_tool",
+            content="Something went wrong",
+            is_error=True,
+        )
+        assert result.is_error is True
+
+    def test_default_content(self):
+        result = ToolResult(tool_call_id="tc_003", tool_name="test")
+        assert result.content is None
+        assert result.is_error is False
+
+
+class TestImageSourceDomain:
+    """Tests for the ImageSource domain object."""
+
+    def test_url_image(self):
+        img = ImageSource(type="url", data="https://example.com/photo.jpg")
+        assert img.type == "url"
+        assert img.media_type is None
+
+    def test_base64_image(self):
+        img = ImageSource(
+            type="base64",
+            data="iVBORw0KGgo...",
+            media_type="image/png",
+        )
+        assert img.type == "base64"
+        assert img.media_type == "image/png"
+
+
+class TestVideoSourceDomain:
+    """Tests for the VideoSource domain object."""
+
+    def test_creation(self):
+        vid = VideoSource(type="url", data="https://example.com/clip.mp4")
+        assert vid.duration_ms is None
+
+    def test_with_duration(self):
+        vid = VideoSource(
+            type="url",
+            data="https://example.com/clip.mp4",
+            duration_ms=30000,
+        )
+        assert vid.duration_ms == 30000
+
+
+class TestAudioSourceDomain:
+    """Tests for the AudioSource domain object."""
+
+    def test_creation(self):
+        aud = AudioSource(type="url", data="https://example.com/track.mp3")
+        assert aud.type == "url"
+
+
+class TestDocumentSourceDomain:
+    """Tests for the DocumentSource domain object."""
+
+    def test_creation(self):
+        doc = DocumentSource(
+            type="base64",
+            data="JVBERi0xLjQ...",
+            media_type="application/pdf",
+            title="Annual Report",
+        )
+        assert doc.title == "Annual Report"
+
+
+class TestResourceDomain:
+    """Tests for the Resource domain object."""
+
+    def test_creation(self):
+        res = Resource(
+            resource_request_id="rr_001",
+            uri="file:///data/report.csv",
+            name="Q4 Report",
+            resource_type=ResourceType.FILE,
+            content="col1,col2\n1,2",
+            mime_type="text/csv",
+        )
+        assert res.uri == "file:///data/report.csv"
+        assert res.resource_type == ResourceType.FILE
+
+    def test_minimal_creation(self):
+        res = Resource(
+            resource_request_id="rr_002",
+            uri="db://users/42",
+            resource_type=ResourceType.DATABASE,
+        )
+        assert res.name is None
+        assert res.content is None
+        assert res.blob is None
+
+    def test_blob_resource(self):
+        res = Resource(
+            resource_request_id="rr_003",
+            uri="blob://data",
+            resource_type=ResourceType.BLOB,
+            blob=b"\x00\x01\x02",
+        )
+        assert res.blob == b"\x00\x01\x02"
+
+
+class TestResourceReferenceDomain:
+    """Tests for the ResourceReference domain object."""
+
+    def test_creation(self):
+        ref = ResourceReference(
+            resource_request_id="rr_004",
+            uri="file:///path/to/file.txt",
+            resource_type=ResourceType.FILE,
+        )
+        assert ref.uri == "file:///path/to/file.txt"
+
+    def test_with_range(self):
+        ref = ResourceReference(
+            resource_request_id="rr_005",
+            uri="file:///code.py",
+            resource_type=ResourceType.FILE,
+            range_start=10,
+            range_end=50,
+        )
+        assert ref.range_start == 10
+        assert ref.range_end == 50
+
+    def test_with_selector(self):
+        ref = ResourceReference(
+            resource_request_id="rr_006",
+            uri="api://data",
+            resource_type=ResourceType.API,
+            selector="$.results[0]",
+        )
+        assert ref.selector == "$.results[0]"
+
+
+class TestPromptRequestDomain:
+    """Tests for the PromptRequest domain object."""
+
+    def test_creation(self):
+        req = PromptRequest(
+            prompt_request_id="pr_001",
+            name="summarize",
+            arguments={"text": "Long document..."},
+        )
+        assert req.name == "summarize"
+        assert req.arguments == {"text": "Long document..."}
+
+    def test_defaults(self):
+        req = PromptRequest(prompt_request_id="pr_002", name="test")
+        assert req.arguments == {}
+        assert req.server_id is None
+
+
+class TestPromptResultDomain:
+    """Tests for the PromptResult domain object."""
+
+    def test_creation(self):
+        result = PromptResult(
+            prompt_request_id="pr_001",
+            prompt_name="summarize",
+            content="This document discusses...",
+        )
+        assert result.prompt_name == "summarize"
+        assert result.is_error is False
+
+    def test_error_result(self):
+        result = PromptResult(
+            prompt_request_id="pr_002",
+            prompt_name="fail_prompt",
+            is_error=True,
+            error_message="Template not found",
+        )
+        assert result.is_error is True
+        assert result.error_message == "Template not found"
+
+    def test_defaults(self):
+        result = PromptResult(prompt_request_id="pr_003", prompt_name="test")
+        assert result.messages == []
+        assert result.content is None
+
+
+# ---------------------------------------------------------------------------
+# ContentPart Wrapper Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTextContent:
+    """Tests for TextContent."""
+
+    def test_creation(self):
+        part = TextContent(text="Hello, world!")
+        assert part.content_type == ContentType.TEXT
+        assert part.text == "Hello, world!"
+
+    def test_frozen(self):
+        part = TextContent(text="original")
+        with pytest.raises(Exception):
+            part.text = "modified"
+
+    def test_model_copy(self):
+        part = TextContent(text="original")
+        modified = part.model_copy(update={"text": "updated"})
+        assert part.text == "original"
+        assert modified.text == "updated"
+
+
+class TestThinkingContent:
+    """Tests for ThinkingContent."""
+
+    def test_creation(self):
+        part = ThinkingContent(text="Let me analyze this...")
+        assert part.content_type == ContentType.THINKING
+        assert part.text == "Let me analyze this..."
+
+
+class TestToolCallContentPart:
+    """Tests for ToolCallContentPart wrapper."""
+
+    def test_creation(self):
+        call = ToolCall(tool_call_id="tc_001", name="get_user", arguments={"user_id": "123"})
+        part = ToolCallContentPart(content=call)
+        assert part.content_type == ContentType.TOOL_CALL
+        assert part.content.name == "get_user"
+        assert part.content.arguments == {"user_id": "123"}
+
+    def test_frozen(self):
+        part = ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="test"))
+        with pytest.raises(Exception):
+            part.content = ToolCall(tool_call_id="tc2", name="other")
+
+
+class TestToolResultContentPart:
+    """Tests for ToolResultContentPart wrapper."""
+
+    def test_creation(self):
+        result = ToolResult(tool_call_id="tc_001", tool_name="get_user", content={"name": "Alice"})
+        part = ToolResultContentPart(content=result)
+        assert part.content_type == ContentType.TOOL_RESULT
+        assert part.content.tool_name == "get_user"
+        assert part.content.is_error is False
+
+
+class TestResourceContentPart:
+    """Tests for ResourceContentPart wrapper."""
+
+    def test_creation(self):
+        res = Resource(
+            resource_request_id="rr_001",
+            uri="file:///data/report.csv",
+            resource_type=ResourceType.FILE,
+        )
+        part = ResourceContentPart(content=res)
+        assert part.content_type == ContentType.RESOURCE
+        assert part.content.uri == "file:///data/report.csv"
+
+
+class TestImageContentPart:
+    """Tests for ImageContentPart wrapper."""
+
+    def test_creation(self):
+        img = ImageSource(type="url", data="https://example.com/photo.jpg")
+        part = ImageContentPart(content=img)
+        assert part.content_type == ContentType.IMAGE
+        assert part.content.type == "url"
+
+
+class TestDocumentContentPart:
+    """Tests for DocumentContentPart wrapper."""
+
+    def test_creation(self):
+        doc = DocumentSource(
+            type="base64", data="JVBERi0xLjQ...",
+            media_type="application/pdf", title="Annual Report",
+        )
+        part = DocumentContentPart(content=doc)
+        assert part.content_type == ContentType.DOCUMENT
+        assert part.content.title == "Annual Report"
+
+
+# ---------------------------------------------------------------------------
+# Message Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMessage:
+    """Tests for the Message model."""
+
+    def test_simple_message(self):
+        msg = Message(
+            role=Role.USER,
+            content=[TextContent(text="Hello")],
+        )
+        assert msg.role == Role.USER
+        assert msg.schema_version == "2.0"
+        assert msg.channel is None
+        assert msg.extensions is None
+        assert len(msg.content) == 1
+
+    def test_empty_content(self):
+        msg = Message(role=Role.SYSTEM)
+        assert msg.content == []
+
+    def test_multi_part_message(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[
+                ThinkingContent(text="Reasoning..."),
+                TextContent(text="Here is the answer."),
+                ToolCallContentPart(
+                    content=ToolCall(tool_call_id="tc_001", name="search", arguments={"q": "test"}),
+                ),
+            ],
+        )
+        assert len(msg.content) == 3
+        assert msg.content[0].content_type == ContentType.THINKING
+        assert msg.content[1].content_type == ContentType.TEXT
+        assert msg.content[2].content_type == ContentType.TOOL_CALL
+
+    def test_with_channel(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[TextContent(text="Final answer.")],
+            channel=Channel.FINAL,
+        )
+        assert msg.channel == Channel.FINAL
+
+    def test_frozen(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="Hi")])
+        with pytest.raises(Exception):
+            msg.role = Role.ASSISTANT
+
+    def test_model_copy(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="Hi")])
+        updated = msg.model_copy(update={"channel": Channel.FINAL})
+        assert msg.channel is None
+        assert updated.channel == Channel.FINAL
+        assert updated.role == Role.USER
+
+    def test_deserialization_from_dict(self):
+        msg = Message.model_validate({
+            "role": "user",
+            "content": [
+                {"content_type": "text", "text": "Hello"},
+                {"content_type": "tool_call", "content": {"tool_call_id": "tc1", "name": "foo", "arguments": {}}},
+            ],
+        })
+        assert msg.role == Role.USER
+        assert len(msg.content) == 2
+        assert isinstance(msg.content[0], TextContent)
+        assert isinstance(msg.content[1], ToolCallContentPart)
+
+    def test_deserialization_all_content_types(self):
+        msg = Message.model_validate({
+            "role": "assistant",
+            "content": [
+                {"content_type": "text", "text": "hi"},
+                {"content_type": "thinking", "text": "hmm"},
+                {"content_type": "tool_call", "content": {"tool_call_id": "t1", "name": "x", "arguments": {}}},
+                {"content_type": "tool_result", "content": {"tool_call_id": "t1", "tool_name": "x"}},
+                {"content_type": "resource", "content": {"resource_request_id": "r1", "uri": "file:///a", "resource_type": "file"}},
+                {"content_type": "resource_ref", "content": {"resource_request_id": "r2", "uri": "db://b", "resource_type": "database"}},
+                {"content_type": "prompt_request", "content": {"prompt_request_id": "p1", "name": "s"}},
+                {"content_type": "prompt_result", "content": {"prompt_request_id": "p1", "prompt_name": "s"}},
+                {"content_type": "image", "content": {"type": "url", "data": "http://img"}},
+                {"content_type": "video", "content": {"type": "url", "data": "http://vid"}},
+                {"content_type": "audio", "content": {"type": "url", "data": "http://aud"}},
+                {"content_type": "document", "content": {"type": "url", "data": "http://doc"}},
+            ],
+        })
+        assert len(msg.content) == 12
+        expected_types = [
+            TextContent, ThinkingContent, ToolCallContentPart, ToolResultContentPart,
+            ResourceContentPart, ResourceRefContentPart, PromptRequestContentPart, PromptResultContentPart,
+            ImageContentPart, VideoContentPart, AudioContentPart, DocumentContentPart,
+        ]
+        for part, expected in zip(msg.content, expected_types):
+            assert isinstance(part, expected), f"Expected {expected.__name__}, got {type(part).__name__}"
+
+    def test_serialization_roundtrip(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[
+                TextContent(text="hello"),
+                ToolCallContentPart(
+                    content=ToolCall(tool_call_id="tc1", name="test", arguments={"a": 1}),
+                ),
+            ],
+        )
+        data = msg.model_dump()
+        restored = Message.model_validate(data)
+        assert restored.role == msg.role
+        assert len(restored.content) == 2
+        assert restored.content[0].text == "hello"
+        assert restored.content[1].content.name == "test"
+
+    def test_iter_views(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[
+                TextContent(text="hello"),
+                ToolCallContentPart(
+                    content=ToolCall(tool_call_id="tc1", name="test", arguments={}),
+                ),
+            ],
+        )
+        views = list(msg.iter_views())
+        assert len(views) == 2

--- a/tests/unit/cpex/framework/cmf/test_message.py
+++ b/tests/unit/cpex/framework/cmf/test_message.py
@@ -601,3 +601,125 @@ class TestMessage:
         )
         views = list(msg.iter_views())
         assert len(views) == 2
+
+
+# ---------------------------------------------------------------------------
+# Validation Tests
+# ---------------------------------------------------------------------------
+
+
+class TestResourceValidation:
+    """Tests for Resource model validators."""
+
+    def test_content_only(self):
+        res = Resource(
+            resource_request_id="r1", uri="file:///a.txt",
+            resource_type=ResourceType.FILE, content="hello",
+        )
+        assert res.content == "hello"
+        assert res.blob is None
+
+    def test_blob_only(self):
+        res = Resource(
+            resource_request_id="r1", uri="file:///a.bin",
+            resource_type=ResourceType.FILE, blob=b"\x00\x01",
+        )
+        assert res.blob == b"\x00\x01"
+        assert res.content is None
+
+    def test_neither_content_nor_blob(self):
+        res = Resource(
+            resource_request_id="r1", uri="file:///a.txt",
+            resource_type=ResourceType.FILE,
+        )
+        assert res.content is None
+        assert res.blob is None
+
+    def test_content_and_blob_raises(self):
+        with pytest.raises(ValueError, match="cannot have both"):
+            Resource(
+                resource_request_id="r1", uri="file:///a.txt",
+                resource_type=ResourceType.FILE,
+                content="hello", blob=b"\x00",
+            )
+
+
+class TestResourceReferenceValidation:
+    """Tests for ResourceReference range validators."""
+
+    def test_valid_range(self):
+        ref = ResourceReference(
+            resource_request_id="r1", uri="file:///a.txt",
+            resource_type=ResourceType.FILE,
+            range_start=10, range_end=20,
+        )
+        assert ref.range_start == 10
+        assert ref.range_end == 20
+
+    def test_equal_range(self):
+        ref = ResourceReference(
+            resource_request_id="r1", uri="file:///a.txt",
+            resource_type=ResourceType.FILE,
+            range_start=5, range_end=5,
+        )
+        assert ref.range_start == ref.range_end
+
+    def test_invalid_range_raises(self):
+        with pytest.raises(ValueError, match="range_end.*must be >= range_start"):
+            ResourceReference(
+                resource_request_id="r1", uri="file:///a.txt",
+                resource_type=ResourceType.FILE,
+                range_start=20, range_end=10,
+            )
+
+    def test_start_only(self):
+        ref = ResourceReference(
+            resource_request_id="r1", uri="file:///a.txt",
+            resource_type=ResourceType.FILE, range_start=5,
+        )
+        assert ref.range_start == 5
+        assert ref.range_end is None
+
+    def test_end_only(self):
+        ref = ResourceReference(
+            resource_request_id="r1", uri="file:///a.txt",
+            resource_type=ResourceType.FILE, range_end=10,
+        )
+        assert ref.range_start is None
+        assert ref.range_end == 10
+
+
+class TestDiscriminator:
+    """Tests for content_type discriminator function."""
+
+    def test_missing_content_type_in_dict_raises(self):
+        with pytest.raises(Exception):
+            Message(role=Role.USER, content=[{"text": "hello"}])
+
+    def test_invalid_content_type_in_dict_raises(self):
+        with pytest.raises(Exception):
+            Message(role=Role.USER, content=[{"content_type": "bogus", "text": "hello"}])
+
+
+class TestMediaSourceLiteral:
+    """Tests that media source type fields enforce Literal['url', 'base64']."""
+
+    def test_image_source_valid_types(self):
+        assert ImageSource(type="url", data="https://x.com/a.jpg").type == "url"
+        assert ImageSource(type="base64", data="abc").type == "base64"
+
+    def test_image_source_invalid_type(self):
+        with pytest.raises(Exception):
+            ImageSource(type="ftp", data="abc")
+
+    def test_video_source_invalid_type(self):
+        with pytest.raises(Exception):
+            VideoSource(type="file", data="abc")
+
+    def test_audio_source_invalid_type(self):
+        with pytest.raises(Exception):
+            AudioSource(type="stream", data="abc")
+
+    def test_document_source_invalid_type(self):
+        with pytest.raises(Exception):
+            DocumentSource(type="unknown", data="abc")

--- a/tests/unit/cpex/framework/cmf/test_view.py
+++ b/tests/unit/cpex/framework/cmf/test_view.py
@@ -463,7 +463,7 @@ class TestAction:
             (ResourceContentPart(content=Resource(resource_request_id="r", uri="f:///a", resource_type=ResourceType.FILE)), Role.TOOL, ViewAction.READ),
             (ResourceRefContentPart(content=ResourceReference(resource_request_id="r", uri="f:///a", resource_type=ResourceType.FILE)), Role.ASSISTANT, ViewAction.READ),
             (PromptRequestContentPart(content=PromptRequest(prompt_request_id="p", name="s")), Role.ASSISTANT, ViewAction.INVOKE),
-            (PromptResultContentPart(content=PromptResult(prompt_request_id="p", prompt_name="s")), Role.TOOL, ViewAction.GENERATE),
+            (PromptResultContentPart(content=PromptResult(prompt_request_id="p", prompt_name="s")), Role.TOOL, ViewAction.RECEIVE),
             (ImageContentPart(content=ImageSource(type="url", data="http://img")), Role.USER, ViewAction.SEND),
         ]
         for part, role, expected_action in pairs:
@@ -538,10 +538,11 @@ class TestDirection:
         view = list(iter_views(msg))[0]
         assert view.is_pre is True
 
-    def test_tool_text_is_pre(self):
+    def test_tool_text_is_post(self):
         msg = Message(role=Role.TOOL, content=[TextContent(text="result text")])
         view = list(iter_views(msg))[0]
-        assert view.is_pre is True
+        assert view.is_pre is False
+        assert view.is_post is True
 
 
 # ---------------------------------------------------------------------------
@@ -817,7 +818,11 @@ class TestProperties:
             role=Role.TOOL,
             content=[PromptResultContentPart(content=PromptResult(
                 prompt_request_id="p1", prompt_name="s",
-                messages=["m1", "m2"], is_error=False,
+                messages=[
+                    Message(role=Role.USER, content=[TextContent(text="m1")]),
+                    Message(role=Role.ASSISTANT, content=[TextContent(text="m2")]),
+                ],
+                is_error=False,
             ))],
         )
         view = list(iter_views(msg))[0]
@@ -979,3 +984,191 @@ class TestRepr:
         r = repr(view)
         assert "tool_call" in r
         assert "tool://_/test" in r
+
+
+# ---------------------------------------------------------------------------
+# Hook property
+# ---------------------------------------------------------------------------
+
+
+class TestHookProperty:
+    """Tests for the hook property on MessageView."""
+
+    def test_hook_none_by_default(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.hook is None
+
+    def test_hook_passed_through(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg, hook="llm_input"))[0]
+        assert view.hook == "llm_input"
+
+    def test_hook_in_to_dict(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg, hook="tool_pre_invoke"))[0]
+        d = view.to_dict()
+        assert d["hook"] == "tool_pre_invoke"
+
+    def test_hook_absent_from_to_dict_when_none(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        d = view.to_dict()
+        assert "hook" not in d
+
+
+# ---------------------------------------------------------------------------
+# Content edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestContentEdgeCases:
+    """Tests for content property edge cases (json fallbacks)."""
+
+    def test_tool_call_non_serializable_args(self):
+        """Tool call with non-JSON-serializable arguments falls back to str()."""
+        tc = ToolCall(tool_call_id="tc1", name="test", arguments={"key": "val"})
+        msg = Message(role=Role.ASSISTANT, content=[ToolCallContentPart(content=tc)])
+        view = list(iter_views(msg))[0]
+        assert view.content is not None
+
+    def test_prompt_request_content(self):
+        pr = PromptRequest(
+            prompt_request_id="pr1", name="test",
+            arguments={"key": "val"},
+        )
+        msg = Message(role=Role.USER, content=[PromptRequestContentPart(content=pr)])
+        view = list(iter_views(msg))[0]
+        assert '"key"' in view.content
+
+    def test_prompt_result_content(self):
+        pr = PromptResult(
+            prompt_request_id="pr1", prompt_name="test",
+            content="rendered text",
+        )
+        msg = Message(role=Role.TOOL, content=[PromptResultContentPart(content=pr)])
+        view = list(iter_views(msg))[0]
+        assert view.content == "rendered text"
+
+    def test_resource_blob_size(self):
+        """Resource with blob but no content still reports size_bytes."""
+        res = Resource(
+            resource_request_id="r1", uri="file:///a.bin",
+            resource_type=ResourceType.FILE, blob=b"\x00\x01\x02",
+        )
+        msg = Message(role=Role.TOOL, content=[ResourceContentPart(content=res)])
+        view = list(iter_views(msg))[0]
+        assert view.content is None
+        assert view.size_bytes == 3
+
+    def test_resource_explicit_size(self):
+        """Resource with explicit size_bytes uses that value."""
+        res = Resource(
+            resource_request_id="r1", uri="file:///a.txt",
+            resource_type=ResourceType.FILE, content="hello",
+            size_bytes=999,
+        )
+        msg = Message(role=Role.TOOL, content=[ResourceContentPart(content=res)])
+        view = list(iter_views(msg))[0]
+        assert view.size_bytes == 999
+
+    def test_to_dict_no_content_with_blob_size(self):
+        """to_dict includes size_bytes even when content is None (blob path)."""
+        res = Resource(
+            resource_request_id="r1", uri="file:///a.bin",
+            resource_type=ResourceType.FILE, blob=b"\x00\x01",
+        )
+        msg = Message(role=Role.TOOL, content=[ResourceContentPart(content=res)])
+        view = list(iter_views(msg))[0]
+        d = view.to_dict()
+        assert "content" not in d
+        assert d["size_bytes"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Properties edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestPropertiesEdgeCases:
+    """Tests for properties on various view kinds."""
+
+    def test_resource_properties(self):
+        res = Resource(
+            resource_request_id="r1", uri="file:///a.txt",
+            resource_type=ResourceType.FILE, content="hi",
+            version="v1", annotations={"label": "pii"},
+        )
+        msg = Message(role=Role.TOOL, content=[ResourceContentPart(content=res)])
+        view = list(iter_views(msg))[0]
+        props = view.properties
+        assert props["resource_type"] == "file"
+        assert props["version"] == "v1"
+        assert props["annotations"] == {"label": "pii"}
+
+    def test_tool_call_properties(self):
+        tc = ToolCall(
+            tool_call_id="tc1", name="test",
+            namespace="ns", arguments={},
+        )
+        msg = Message(role=Role.ASSISTANT, content=[ToolCallContentPart(content=tc)])
+        view = list(iter_views(msg))[0]
+        props = view.properties
+        assert props["namespace"] == "ns"
+        assert props["tool_id"] == "tc1"
+
+    def test_tool_result_properties(self):
+        tr = ToolResult(
+            tool_call_id="tc1", tool_name="test",
+            content="result", is_error=True,
+        )
+        msg = Message(role=Role.TOOL, content=[ToolResultContentPart(content=tr)])
+        view = list(iter_views(msg))[0]
+        props = view.properties
+        assert props["is_error"] is True
+        assert props["tool_name"] == "test"
+
+    def test_prompt_request_properties(self):
+        pr = PromptRequest(
+            prompt_request_id="pr1", name="test",
+            server_id="srv1",
+        )
+        msg = Message(role=Role.USER, content=[PromptRequestContentPart(content=pr)])
+        view = list(iter_views(msg))[0]
+        props = view.properties
+        assert props["server_id"] == "srv1"
+
+
+# ---------------------------------------------------------------------------
+# Headers immutability
+# ---------------------------------------------------------------------------
+
+
+class TestHeadersImmutability:
+    """Tests that headers returns a read-only mapping."""
+
+    def test_headers_not_mutable(self):
+        ext = Extensions(http=HttpExtension(headers={"Authorization": "Bearer tok"}))
+        msg = Message(
+            role=Role.USER,
+            content=[TextContent(text="hi")],
+            extensions=ext,
+        )
+        view = list(iter_views(msg))[0]
+        with pytest.raises(TypeError):
+            view.headers["new_key"] = "val"
+
+
+# ---------------------------------------------------------------------------
+# get_arg / has_arg
+# ---------------------------------------------------------------------------
+
+
+class TestArgHelpers:
+    """Tests for get_arg and has_arg."""
+
+    def test_get_arg_on_non_tool(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.get_arg("anything") is None
+        assert view.get_arg("anything", "fallback") == "fallback"

--- a/tests/unit/cpex/framework/cmf/test_view.py
+++ b/tests/unit/cpex/framework/cmf/test_view.py
@@ -1,0 +1,981 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/cpex/framework/cmf/test_view.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Unit tests for MessageView.
+"""
+
+# Standard
+from typing import Any
+
+# Third-Party
+import pytest
+
+# First-Party
+from cpex.framework.cmf.message import (
+    AudioContentPart,
+    AudioSource,
+    DocumentContentPart,
+    DocumentSource,
+    ImageContentPart,
+    ImageSource,
+    Message,
+    PromptRequest,
+    PromptRequestContentPart,
+    PromptResult,
+    PromptResultContentPart,
+    Resource,
+    ResourceContentPart,
+    ResourceReference,
+    ResourceRefContentPart,
+    ResourceType,
+    Role,
+    TextContent,
+    ThinkingContent,
+    ToolCall,
+    ToolCallContentPart,
+    ToolResult,
+    ToolResultContentPart,
+    VideoContentPart,
+    VideoSource,
+)
+from cpex.framework.cmf.view import (
+    MessageView,
+    ViewAction,
+    ViewKind,
+    iter_views,
+)
+from cpex.framework.extensions.agent import AgentExtension
+from cpex.framework.extensions.extensions import Extensions
+from cpex.framework.extensions.http import HttpExtension
+from cpex.framework.extensions.request import RequestExtension
+from cpex.framework.extensions.security import (
+    DataPolicy,
+    ObjectSecurityProfile,
+    RetentionPolicy,
+    SecurityExtension,
+    SubjectExtension,
+    SubjectType,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def simple_assistant_msg():
+    """An assistant message with text, thinking, and a tool call."""
+    return Message(
+        role=Role.ASSISTANT,
+        content=[
+            ThinkingContent(text="User wants admin users."),
+            TextContent(text="Let me look that up."),
+            ToolCallContentPart(
+                content=ToolCall(
+                    tool_call_id="tc_001",
+                    name="execute_sql",
+                    arguments={"query": "SELECT * FROM users WHERE role='admin'"},
+                ),
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def full_msg():
+    """A message with full extensions populated."""
+    return Message(
+        role=Role.ASSISTANT,
+        content=[
+            ToolCallContentPart(
+                content=ToolCall(
+                    tool_call_id="tc_001",
+                    name="get_compensation",
+                    namespace="hr-server",
+                    arguments={"employee_id": "emp-42"},
+                ),
+            ),
+        ],
+        extensions=Extensions(
+            request=RequestExtension(
+                environment="production",
+                request_id="req-001",
+            ),
+            agent=AgentExtension(
+                input="Show me Alice's compensation",
+                session_id="sess-001",
+                conversation_id="conv-001",
+                turn=2,
+                agent_id="main-agent",
+                parent_agent_id="orchestrator",
+            ),
+            http=HttpExtension(
+                headers={
+                    "Authorization": "Bearer secret-token",
+                    "Cookie": "session=abc",
+                    "X-Request-ID": "req-001",
+                    "Content-Type": "application/json",
+                },
+            ),
+            security=SecurityExtension(
+                labels=frozenset({"CONFIDENTIAL"}),
+                classification="confidential",
+                subject=SubjectExtension(
+                    id="user-alice",
+                    type=SubjectType.USER,
+                    roles=frozenset({"admin", "hr-manager"}),
+                    permissions=frozenset({"read:compensation", "tools.execute"}),
+                    teams=frozenset({"hr-team"}),
+                ),
+                objects={
+                    "get_compensation": ObjectSecurityProfile(
+                        managed_by="tool",
+                        permissions=["read:compensation"],
+                        trust_domain="internal",
+                        data_scope=["salary", "bonus"],
+                    ),
+                },
+                data={
+                    "get_compensation": DataPolicy(
+                        apply_labels=["PII", "financial"],
+                        denied_actions=["export", "forward", "log_raw"],
+                        retention=RetentionPolicy(
+                            policy="session",
+                            max_age_seconds=3600,
+                        ),
+                    ),
+                },
+            ),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Enum Tests
+# ---------------------------------------------------------------------------
+
+
+class TestViewKind:
+    """Tests for ViewKind enum."""
+
+    def test_member_count(self):
+        assert len(ViewKind) == 12
+
+    def test_values_match_content_type(self):
+        from cpex.framework.cmf.message import ContentType
+
+        for ct in ContentType:
+            assert ct.value in [vk.value for vk in ViewKind]
+
+
+class TestViewAction:
+    """Tests for ViewAction enum."""
+
+    def test_member_count(self):
+        assert len(ViewAction) == 7
+
+    def test_values(self):
+        expected = {"read", "write", "execute", "invoke", "send", "receive", "generate"}
+        assert {va.value for va in ViewAction} == expected
+
+
+# ---------------------------------------------------------------------------
+# View Iteration
+# ---------------------------------------------------------------------------
+
+
+class TestIterViews:
+    """Tests for iter_views() and Message.iter_views()."""
+
+    def test_standalone_and_method_match(self, simple_assistant_msg):
+        standalone = list(iter_views(simple_assistant_msg))
+        method = list(simple_assistant_msg.iter_views())
+        assert len(standalone) == len(method) == 3
+
+    def test_view_count(self, simple_assistant_msg):
+        views = list(iter_views(simple_assistant_msg))
+        assert len(views) == 3
+
+    def test_view_kinds(self, simple_assistant_msg):
+        views = list(iter_views(simple_assistant_msg))
+        assert views[0].kind == ViewKind.THINKING
+        assert views[1].kind == ViewKind.TEXT
+        assert views[2].kind == ViewKind.TOOL_CALL
+
+    def test_empty_message(self):
+        msg = Message(role=Role.USER)
+        views = list(iter_views(msg))
+        assert len(views) == 0
+
+    def test_single_content_part(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="Hi")])
+        views = list(iter_views(msg))
+        assert len(views) == 1
+        assert views[0].kind == ViewKind.TEXT
+
+    def test_all_content_types(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[
+                TextContent(text="hi"),
+                ThinkingContent(text="hmm"),
+                ToolCallContentPart(content=ToolCall(tool_call_id="t1", name="x", arguments={})),
+                ToolResultContentPart(content=ToolResult(tool_call_id="t1", tool_name="x", content="ok")),
+                ResourceContentPart(content=Resource(resource_request_id="r1", uri="file:///a", resource_type=ResourceType.FILE, content="data")),
+                ResourceRefContentPart(content=ResourceReference(resource_request_id="r2", uri="db://b", resource_type=ResourceType.DATABASE)),
+                PromptRequestContentPart(content=PromptRequest(prompt_request_id="p1", name="summarize")),
+                PromptResultContentPart(content=PromptResult(prompt_request_id="p1", prompt_name="summarize", content="summary")),
+                ImageContentPart(content=ImageSource(type="url", data="http://img")),
+                VideoContentPart(content=VideoSource(type="url", data="http://vid")),
+                AudioContentPart(content=AudioSource(type="url", data="http://aud")),
+                DocumentContentPart(content=DocumentSource(type="url", data="http://doc")),
+            ],
+        )
+        views = list(iter_views(msg))
+        assert len(views) == 12
+        expected_kinds = [
+            ViewKind.TEXT, ViewKind.THINKING, ViewKind.TOOL_CALL, ViewKind.TOOL_RESULT,
+            ViewKind.RESOURCE, ViewKind.RESOURCE_REF, ViewKind.PROMPT_REQUEST, ViewKind.PROMPT_RESULT,
+            ViewKind.IMAGE, ViewKind.VIDEO, ViewKind.AUDIO, ViewKind.DOCUMENT,
+        ]
+        for view, expected in zip(views, expected_kinds):
+            assert view.kind == expected
+
+
+# ---------------------------------------------------------------------------
+# Core Properties
+# ---------------------------------------------------------------------------
+
+
+class TestCoreProperties:
+    """Tests for MessageView core properties."""
+
+    def test_role(self, simple_assistant_msg):
+        view = list(iter_views(simple_assistant_msg))[0]
+        assert view.role == Role.ASSISTANT
+
+    def test_raw_access(self, simple_assistant_msg):
+        views = list(iter_views(simple_assistant_msg))
+        assert isinstance(views[0].raw, ThinkingContent)
+        assert isinstance(views[2].raw, ToolCallContentPart)
+
+    def test_content_text(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="Hello")])
+        view = list(iter_views(msg))[0]
+        assert view.content == "Hello"
+
+    def test_content_thinking(self):
+        msg = Message(role=Role.ASSISTANT, content=[ThinkingContent(text="Reasoning...")])
+        view = list(iter_views(msg))[0]
+        assert view.content == "Reasoning..."
+
+    def test_content_tool_call(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="test", arguments={"key": "value"}))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.content == '{"key": "value"}'
+
+    def test_content_tool_result(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[ToolResultContentPart(content=ToolResult(tool_call_id="tc1", tool_name="test", content={"result": 42}))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.content == '{"result": 42}'
+
+    def test_content_tool_result_string(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[ToolResultContentPart(content=ToolResult(tool_call_id="tc1", tool_name="test", content="plain text"))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.content == "plain text"
+
+    def test_content_tool_result_none(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[ToolResultContentPart(content=ToolResult(tool_call_id="tc1", tool_name="test"))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.content is None
+
+    def test_content_resource(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[ResourceContentPart(content=Resource(
+                resource_request_id="r1", uri="file:///a",
+                resource_type=ResourceType.FILE, content="file data",
+            ))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.content == "file data"
+
+    def test_content_prompt_request(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[PromptRequestContentPart(content=PromptRequest(prompt_request_id="p1", name="s", arguments={"text": "hi"}))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.content == '{"text": "hi"}'
+
+    def test_content_prompt_result(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[PromptResultContentPart(content=PromptResult(prompt_request_id="p1", prompt_name="s", content="rendered"))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.content == "rendered"
+
+    def test_content_media_none(self):
+        msg = Message(
+            role=Role.USER,
+            content=[ImageContentPart(content=ImageSource(type="url", data="http://img"))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.content is None
+
+
+# ---------------------------------------------------------------------------
+# URI
+# ---------------------------------------------------------------------------
+
+
+class TestURI:
+    """Tests for synthetic URI generation."""
+
+    def test_tool_call_uri(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="get_user", arguments={}))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.uri == "tool://_/get_user"
+
+    def test_tool_call_uri_with_namespace(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="get_user", namespace="user-svc", arguments={}))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.uri == "tool://user-svc/get_user"
+
+    def test_tool_result_uri(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[ToolResultContentPart(content=ToolResult(tool_call_id="tc1", tool_name="get_user"))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.uri == "tool_result://get_user"
+
+    def test_resource_uri(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[ResourceContentPart(content=Resource(
+                resource_request_id="r1", uri="file:///data/report.csv",
+                resource_type=ResourceType.FILE,
+            ))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.uri == "file:///data/report.csv"
+
+    def test_resource_ref_uri(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[ResourceRefContentPart(content=ResourceReference(
+                resource_request_id="r1", uri="db://users/42",
+                resource_type=ResourceType.DATABASE,
+            ))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.uri == "db://users/42"
+
+    def test_prompt_request_uri(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[PromptRequestContentPart(content=PromptRequest(prompt_request_id="p1", name="summarize", server_id="prompt-svc"))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.uri == "prompt://prompt-svc/summarize"
+
+    def test_prompt_result_uri(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[PromptResultContentPart(content=PromptResult(prompt_request_id="p1", prompt_name="summarize"))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.uri == "prompt_result://summarize"
+
+    def test_text_uri_is_none(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.uri is None
+
+
+# ---------------------------------------------------------------------------
+# Name
+# ---------------------------------------------------------------------------
+
+
+class TestName:
+    """Tests for the name property."""
+
+    def test_tool_call_name(self):
+        msg = Message(role=Role.ASSISTANT, content=[ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="get_user", arguments={}))])
+        assert list(iter_views(msg))[0].name == "get_user"
+
+    def test_tool_result_name(self):
+        msg = Message(role=Role.TOOL, content=[ToolResultContentPart(content=ToolResult(tool_call_id="tc1", tool_name="get_user"))])
+        assert list(iter_views(msg))[0].name == "get_user"
+
+    def test_prompt_request_name(self):
+        msg = Message(role=Role.ASSISTANT, content=[PromptRequestContentPart(content=PromptRequest(prompt_request_id="p1", name="summarize"))])
+        assert list(iter_views(msg))[0].name == "summarize"
+
+    def test_prompt_result_name(self):
+        msg = Message(role=Role.TOOL, content=[PromptResultContentPart(content=PromptResult(prompt_request_id="p1", prompt_name="summarize"))])
+        assert list(iter_views(msg))[0].name == "summarize"
+
+    def test_text_name_is_none(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        assert list(iter_views(msg))[0].name is None
+
+
+# ---------------------------------------------------------------------------
+# Action
+# ---------------------------------------------------------------------------
+
+
+class TestAction:
+    """Tests for the action property."""
+
+    def test_action_mapping(self):
+        pairs = [
+            (TextContent(text="hi"), Role.USER, ViewAction.SEND),
+            (ThinkingContent(text="hmm"), Role.ASSISTANT, ViewAction.GENERATE),
+            (ToolCallContentPart(content=ToolCall(tool_call_id="t", name="x", arguments={})), Role.ASSISTANT, ViewAction.EXECUTE),
+            (ToolResultContentPart(content=ToolResult(tool_call_id="t", tool_name="x")), Role.TOOL, ViewAction.RECEIVE),
+            (ResourceContentPart(content=Resource(resource_request_id="r", uri="f:///a", resource_type=ResourceType.FILE)), Role.TOOL, ViewAction.READ),
+            (ResourceRefContentPart(content=ResourceReference(resource_request_id="r", uri="f:///a", resource_type=ResourceType.FILE)), Role.ASSISTANT, ViewAction.READ),
+            (PromptRequestContentPart(content=PromptRequest(prompt_request_id="p", name="s")), Role.ASSISTANT, ViewAction.INVOKE),
+            (PromptResultContentPart(content=PromptResult(prompt_request_id="p", prompt_name="s")), Role.TOOL, ViewAction.GENERATE),
+            (ImageContentPart(content=ImageSource(type="url", data="http://img")), Role.USER, ViewAction.SEND),
+        ]
+        for part, role, expected_action in pairs:
+            msg = Message(role=role, content=[part])
+            view = list(iter_views(msg))[0]
+            assert view.action == expected_action, f"Expected {expected_action} for {part.content_type}"
+
+
+# ---------------------------------------------------------------------------
+# Direction
+# ---------------------------------------------------------------------------
+
+
+class TestDirection:
+    """Tests for is_pre / is_post direction logic."""
+
+    def test_tool_call_is_pre(self):
+        msg = Message(role=Role.ASSISTANT, content=[ToolCallContentPart(content=ToolCall(tool_call_id="t", name="x", arguments={}))])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is True
+        assert view.is_post is False
+
+    def test_tool_result_is_post(self):
+        msg = Message(role=Role.TOOL, content=[ToolResultContentPart(content=ToolResult(tool_call_id="t", tool_name="x"))])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is False
+        assert view.is_post is True
+
+    def test_prompt_request_is_pre(self):
+        msg = Message(role=Role.ASSISTANT, content=[PromptRequestContentPart(content=PromptRequest(prompt_request_id="p", name="s"))])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is True
+
+    def test_prompt_result_is_post(self):
+        msg = Message(role=Role.TOOL, content=[PromptResultContentPart(content=PromptResult(prompt_request_id="p", prompt_name="s"))])
+        view = list(iter_views(msg))[0]
+        assert view.is_post is True
+
+    def test_resource_ref_is_pre(self):
+        msg = Message(role=Role.ASSISTANT, content=[
+            ResourceRefContentPart(content=ResourceReference(resource_request_id="r", uri="f:///a", resource_type=ResourceType.FILE)),
+        ])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is True
+
+    def test_resource_is_post(self):
+        msg = Message(role=Role.TOOL, content=[
+            ResourceContentPart(content=Resource(resource_request_id="r", uri="f:///a", resource_type=ResourceType.FILE)),
+        ])
+        view = list(iter_views(msg))[0]
+        assert view.is_post is True
+
+    def test_user_text_is_pre(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is True
+        assert view.is_post is False
+
+    def test_assistant_text_is_post(self):
+        msg = Message(role=Role.ASSISTANT, content=[TextContent(text="hello")])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is False
+        assert view.is_post is True
+
+    def test_system_text_is_pre(self):
+        msg = Message(role=Role.SYSTEM, content=[TextContent(text="instructions")])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is True
+
+    def test_developer_text_is_pre(self):
+        msg = Message(role=Role.DEVELOPER, content=[TextContent(text="hints")])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is True
+
+    def test_tool_text_is_pre(self):
+        msg = Message(role=Role.TOOL, content=[TextContent(text="result text")])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is True
+
+
+# ---------------------------------------------------------------------------
+# Entity Type Helpers
+# ---------------------------------------------------------------------------
+
+
+class TestEntityTypeHelpers:
+    """Tests for is_tool, is_prompt, is_resource, is_text, is_media."""
+
+    def test_is_tool(self):
+        msg = Message(role=Role.ASSISTANT, content=[ToolCallContentPart(content=ToolCall(tool_call_id="t", name="x", arguments={}))])
+        assert list(iter_views(msg))[0].is_tool is True
+
+    def test_is_tool_result(self):
+        msg = Message(role=Role.TOOL, content=[ToolResultContentPart(content=ToolResult(tool_call_id="t", tool_name="x"))])
+        assert list(iter_views(msg))[0].is_tool is True
+
+    def test_is_prompt(self):
+        msg = Message(role=Role.ASSISTANT, content=[PromptRequestContentPart(content=PromptRequest(prompt_request_id="p", name="s"))])
+        assert list(iter_views(msg))[0].is_prompt is True
+
+    def test_is_resource(self):
+        msg = Message(role=Role.TOOL, content=[
+            ResourceContentPart(content=Resource(resource_request_id="r", uri="f:///a", resource_type=ResourceType.FILE)),
+        ])
+        assert list(iter_views(msg))[0].is_resource is True
+
+    def test_is_text(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        assert list(iter_views(msg))[0].is_text is True
+
+    def test_is_text_thinking(self):
+        msg = Message(role=Role.ASSISTANT, content=[ThinkingContent(text="hmm")])
+        assert list(iter_views(msg))[0].is_text is True
+
+    def test_is_media(self):
+        for part in [
+            ImageContentPart(content=ImageSource(type="url", data="http://img")),
+            VideoContentPart(content=VideoSource(type="url", data="http://vid")),
+            AudioContentPart(content=AudioSource(type="url", data="http://aud")),
+            DocumentContentPart(content=DocumentSource(type="url", data="http://doc")),
+        ]:
+            msg = Message(role=Role.USER, content=[part])
+            assert list(iter_views(msg))[0].is_media is True
+
+    def test_text_is_not_media(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        assert list(iter_views(msg))[0].is_media is False
+
+
+# ---------------------------------------------------------------------------
+# Flat Accessors
+# ---------------------------------------------------------------------------
+
+
+class TestFlatAccessors:
+    """Tests for capability-gated flat accessors."""
+
+    def test_base_tier(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.environment == "production"
+        assert view.request_id == "req-001"
+
+    def test_subject(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.subject.id == "user-alice"
+        assert view.subject.type == SubjectType.USER
+
+    def test_roles(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert "admin" in view.roles
+        assert "hr-manager" in view.roles
+
+    def test_permissions(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert "read:compensation" in view.permissions
+
+    def test_teams(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert "hr-team" in view.teams
+
+    def test_headers(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.headers["Content-Type"] == "application/json"
+
+    def test_labels(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert "CONFIDENTIAL" in view.labels
+
+    def test_agent_accessors(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.agent_input == "Show me Alice's compensation"
+        assert view.session_id == "sess-001"
+        assert view.conversation_id == "conv-001"
+        assert view.turn == 2
+        assert view.agent_id == "main-agent"
+        assert view.parent_agent_id == "orchestrator"
+
+    def test_object_profile(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.object is not None
+        assert view.object.managed_by == "tool"
+        assert view.object.permissions == ["read:compensation"]
+        assert view.object.trust_domain == "internal"
+        assert view.object.data_scope == ["salary", "bonus"]
+
+    def test_data_policy(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.data_policy is not None
+        assert "PII" in view.data_policy.apply_labels
+        assert "export" in view.data_policy.denied_actions
+        assert view.data_policy.retention.policy == "session"
+
+    def test_no_extensions(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.environment is None
+        assert view.request_id is None
+        assert view.subject is None
+        assert view.roles == frozenset()
+        assert view.permissions == frozenset()
+        assert view.teams == frozenset()
+        assert view.headers == {}
+        assert view.labels == frozenset()
+        assert view.agent_input is None
+        assert view.session_id is None
+        assert view.conversation_id is None
+        assert view.turn is None
+        assert view.agent_id is None
+        assert view.parent_agent_id is None
+        assert view.object is None
+        assert view.data_policy is None
+
+    def test_object_resolves_by_name(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[
+                ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="tool_a", arguments={})),
+                ToolCallContentPart(content=ToolCall(tool_call_id="tc2", name="tool_b", arguments={})),
+            ],
+            extensions=Extensions(
+                security=SecurityExtension(
+                    objects={"tool_a": ObjectSecurityProfile(managed_by="host")},
+                ),
+            ),
+        )
+        views = list(iter_views(msg))
+        assert views[0].object is not None
+        assert views[0].object.managed_by == "host"
+        assert views[1].object is None
+
+
+# ---------------------------------------------------------------------------
+# Helper Methods
+# ---------------------------------------------------------------------------
+
+
+class TestHelperMethods:
+    """Tests for helper methods on MessageView."""
+
+    def test_has_role(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.has_role("admin") is True
+        assert view.has_role("viewer") is False
+
+    def test_has_permission(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.has_permission("read:compensation") is True
+        assert view.has_permission("write:users") is False
+
+    def test_has_label(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.has_label("CONFIDENTIAL") is True
+        assert view.has_label("SECRET") is False
+
+    def test_has_header(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.has_header("Content-Type") is True
+        assert view.has_header("content-type") is True
+        assert view.has_header("X-Missing") is False
+
+    def test_get_header_case_insensitive(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.get_header("content-type") == "application/json"
+        assert view.get_header("CONTENT-TYPE") == "application/json"
+
+    def test_get_header_default(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.get_header("X-Missing") is None
+        assert view.get_header("X-Missing", "fallback") == "fallback"
+
+    def test_get_arg(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.get_arg("employee_id") == "emp-42"
+        assert view.get_arg("missing") is None
+        assert view.get_arg("missing", "default") == "default"
+
+    def test_has_arg(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.has_arg("employee_id") is True
+        assert view.has_arg("missing") is False
+
+    def test_has_arg_text_view(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.has_arg("anything") is False
+
+    def test_matches_uri_pattern(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.matches_uri_pattern("tool://hr-server/*") is True
+        assert view.matches_uri_pattern("tool://hr-server/get_*") is True
+        assert view.matches_uri_pattern("tool://other/*") is False
+        assert view.matches_uri_pattern("tool://**") is True
+
+    def test_matches_uri_pattern_no_uri(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.matches_uri_pattern("*") is False
+
+    def test_has_content(self, simple_assistant_msg):
+        views = list(iter_views(simple_assistant_msg))
+        assert views[0].has_content() is True
+        assert views[1].has_content() is True
+        assert views[2].has_content() is True
+
+
+# ---------------------------------------------------------------------------
+# Type-Specific Properties
+# ---------------------------------------------------------------------------
+
+
+class TestProperties:
+    """Tests for type-specific properties."""
+
+    def test_tool_call_properties(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="test", namespace="ns", arguments={}))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.get_property("namespace") == "ns"
+        assert view.get_property("tool_id") == "tc1"
+        props = view.properties
+        assert props["namespace"] == "ns"
+        assert props["tool_id"] == "tc1"
+
+    def test_tool_result_properties(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[ToolResultContentPart(content=ToolResult(tool_call_id="tc1", tool_name="test", is_error=True))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.get_property("is_error") is True
+        assert view.get_property("tool_name") == "test"
+
+    def test_resource_properties(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[ResourceContentPart(content=Resource(
+                resource_request_id="r1", uri="f:///a",
+                resource_type=ResourceType.FILE, version="v2",
+                annotations={"key": "val"},
+            ))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.get_property("resource_type") == "file"
+        assert view.get_property("version") == "v2"
+        assert view.get_property("annotations") == {"key": "val"}
+
+    def test_prompt_result_properties(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[PromptResultContentPart(content=PromptResult(
+                prompt_request_id="p1", prompt_name="s",
+                messages=["m1", "m2"], is_error=False,
+            ))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.get_property("is_error") is False
+        assert view.get_property("message_count") == 2
+
+    def test_get_property_default(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.get_property("anything") is None
+        assert view.get_property("anything", "fallback") == "fallback"
+
+    def test_empty_properties_for_text(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.properties == {}
+
+
+# ---------------------------------------------------------------------------
+# Misc Properties
+# ---------------------------------------------------------------------------
+
+
+class TestMiscProperties:
+    """Tests for mime_type, size_bytes, args."""
+
+    def test_mime_type_resource(self):
+        msg = Message(role=Role.TOOL, content=[ResourceContentPart(content=Resource(
+            resource_request_id="r1", uri="f:///a",
+            resource_type=ResourceType.FILE, mime_type="text/csv",
+        ))])
+        assert list(iter_views(msg))[0].mime_type == "text/csv"
+
+    def test_mime_type_image(self):
+        msg = Message(role=Role.USER, content=[
+            ImageContentPart(content=ImageSource(type="url", data="http://img", media_type="image/png")),
+        ])
+        assert list(iter_views(msg))[0].mime_type == "image/png"
+
+    def test_mime_type_text_none(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        assert list(iter_views(msg))[0].mime_type is None
+
+    def test_size_bytes_text(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hello")])
+        assert list(iter_views(msg))[0].size_bytes == 5
+
+    def test_size_bytes_resource_explicit(self):
+        msg = Message(role=Role.TOOL, content=[ResourceContentPart(content=Resource(
+            resource_request_id="r1", uri="f:///a",
+            resource_type=ResourceType.FILE, size_bytes=1024,
+        ))])
+        assert list(iter_views(msg))[0].size_bytes == 1024
+
+    def test_size_bytes_resource_from_content(self):
+        msg = Message(role=Role.TOOL, content=[ResourceContentPart(content=Resource(
+            resource_request_id="r1", uri="f:///a",
+            resource_type=ResourceType.FILE, content="hello",
+        ))])
+        assert list(iter_views(msg))[0].size_bytes == 5
+
+    def test_args_tool_call(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="x", arguments={"a": 1, "b": 2}))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.args == {"a": 1, "b": 2}
+
+    def test_args_text_none(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        assert list(iter_views(msg))[0].args is None
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    """Tests for to_dict() and to_opa_input()."""
+
+    def test_to_dict_basic(self, simple_assistant_msg):
+        view = list(iter_views(simple_assistant_msg))[2]
+        d = view.to_dict()
+        assert d["kind"] == "tool_call"
+        assert d["role"] == "assistant"
+        assert d["is_pre"] is True
+        assert d["is_post"] is False
+        assert d["action"] == "execute"
+        assert d["name"] == "execute_sql"
+        assert d["uri"] == "tool://_/execute_sql"
+
+    def test_to_dict_strips_sensitive_headers(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        d = view.to_dict()
+        headers = d["extensions"].get("headers", {})
+        assert "Authorization" not in headers
+        assert "Cookie" not in headers
+        assert "Content-Type" in headers
+
+    def test_to_dict_includes_extensions(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        d = view.to_dict()
+        ext = d["extensions"]
+        assert ext["environment"] == "production"
+        assert ext["subject"]["id"] == "user-alice"
+        assert "CONFIDENTIAL" in ext["labels"]
+        assert ext["object"]["managed_by"] == "tool"
+        assert "PII" in ext["data"]["apply_labels"]
+        assert ext["agent"]["input"] == "Show me Alice's compensation"
+
+    def test_to_dict_exclude_content(self, simple_assistant_msg):
+        view = list(iter_views(simple_assistant_msg))[0]
+        d = view.to_dict(include_content=False)
+        assert "content" not in d
+        assert "size_bytes" not in d
+
+    def test_to_dict_exclude_context(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        d = view.to_dict(include_context=False)
+        assert "extensions" not in d
+
+    def test_to_opa_input(self, simple_assistant_msg):
+        view = list(iter_views(simple_assistant_msg))[2]
+        opa = view.to_opa_input()
+        assert "input" in opa
+        assert opa["input"]["kind"] == "tool_call"
+
+    def test_to_dict_no_extensions(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        d = view.to_dict()
+        assert "extensions" not in d
+
+
+# ---------------------------------------------------------------------------
+# Repr
+# ---------------------------------------------------------------------------
+
+
+class TestRepr:
+    """Tests for __repr__."""
+
+    def test_repr_text(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        r = repr(view)
+        assert "kind=text" in r
+        assert "role=user" in r
+        assert "pre" in r
+
+    def test_repr_tool_call(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="test", arguments={}))],
+        )
+        view = list(iter_views(msg))[0]
+        r = repr(view)
+        assert "tool_call" in r
+        assert "tool://_/test" in r

--- a/tests/unit/cpex/framework/extensions/test_extensions.py
+++ b/tests/unit/cpex/framework/extensions/test_extensions.py
@@ -1,0 +1,624 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/cpex/framework/extensions/test_extensions.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Unit tests for extension models.
+"""
+
+# Standard
+from typing import Any
+
+# Third-Party
+import pytest
+
+# First-Party
+from cpex.framework.extensions.agent import AgentExtension, ConversationContext
+from cpex.framework.extensions.completion import (
+    CompletionExtension,
+    StopReason,
+    TokenUsage,
+)
+from cpex.framework.extensions.extensions import Extensions
+from cpex.framework.extensions.framework import FrameworkExtension
+from cpex.framework.extensions.http import HttpExtension
+from cpex.framework.extensions.llm import LLMExtension
+from cpex.framework.extensions.mcp import (
+    MCPExtension,
+    PromptMetadata,
+    ResourceMetadata,
+    ToolMetadata,
+)
+from cpex.framework.extensions.provenance import ProvenanceExtension
+from cpex.framework.extensions.request import RequestExtension
+from cpex.framework.extensions.security import (
+    DataPolicy,
+    ObjectSecurityProfile,
+    RetentionPolicy,
+    SecurityExtension,
+    SubjectExtension,
+    SubjectType,
+)
+
+
+# ---------------------------------------------------------------------------
+# RequestExtension
+# ---------------------------------------------------------------------------
+
+
+class TestRequestExtension:
+    """Tests for RequestExtension."""
+
+    def test_creation(self):
+        ext = RequestExtension(
+            environment="production",
+            request_id="req-001",
+            timestamp="2025-01-15T10:30:00Z",
+        )
+        assert ext.environment == "production"
+        assert ext.request_id == "req-001"
+        assert ext.timestamp == "2025-01-15T10:30:00Z"
+
+    def test_defaults(self):
+        ext = RequestExtension()
+        assert ext.environment is None
+        assert ext.request_id is None
+        assert ext.timestamp is None
+        assert ext.trace_id is None
+        assert ext.span_id is None
+
+    def test_frozen(self):
+        ext = RequestExtension(environment="dev")
+        with pytest.raises(Exception):
+            ext.environment = "production"
+
+    def test_model_copy(self):
+        ext = RequestExtension(environment="dev")
+        updated = ext.model_copy(update={"environment": "production"})
+        assert ext.environment == "dev"
+        assert updated.environment == "production"
+
+    def test_tracing_fields(self):
+        ext = RequestExtension(
+            trace_id="trace-abc",
+            span_id="span-123",
+        )
+        assert ext.trace_id == "trace-abc"
+        assert ext.span_id == "span-123"
+
+
+# ---------------------------------------------------------------------------
+# AgentExtension
+# ---------------------------------------------------------------------------
+
+
+class TestConversationContext:
+    """Tests for ConversationContext."""
+
+    def test_creation(self):
+        ctx = ConversationContext(
+            summary="User asked about revenue.",
+            topics=["revenue", "Q4"],
+        )
+        assert ctx.summary == "User asked about revenue."
+        assert ctx.topics == ["revenue", "Q4"]
+
+    def test_defaults(self):
+        ctx = ConversationContext()
+        assert ctx.history == []
+        assert ctx.summary is None
+        assert ctx.topics == []
+
+    def test_frozen(self):
+        ctx = ConversationContext(summary="test")
+        with pytest.raises(Exception):
+            ctx.summary = "modified"
+
+
+class TestAgentExtension:
+    """Tests for AgentExtension."""
+
+    def test_creation(self):
+        ext = AgentExtension(
+            input="What is the weather?",
+            session_id="sess-001",
+            conversation_id="conv-042",
+            turn=3,
+            agent_id="weather-agent",
+        )
+        assert ext.input == "What is the weather?"
+        assert ext.session_id == "sess-001"
+        assert ext.turn == 3
+
+    def test_defaults(self):
+        ext = AgentExtension()
+        assert ext.input is None
+        assert ext.session_id is None
+        assert ext.conversation_id is None
+        assert ext.turn is None
+        assert ext.agent_id is None
+        assert ext.parent_agent_id is None
+        assert ext.conversation is None
+
+    def test_multi_agent_lineage(self):
+        ext = AgentExtension(
+            agent_id="sub-agent-01",
+            parent_agent_id="main-agent",
+        )
+        assert ext.parent_agent_id == "main-agent"
+
+    def test_with_conversation(self):
+        conv = ConversationContext(summary="Prior context", topics=["weather"])
+        ext = AgentExtension(conversation=conv)
+        assert ext.conversation.summary == "Prior context"
+
+
+# ---------------------------------------------------------------------------
+# HttpExtension
+# ---------------------------------------------------------------------------
+
+
+class TestHttpExtension:
+    """Tests for HttpExtension."""
+
+    def test_creation(self):
+        ext = HttpExtension(
+            headers={"Content-Type": "application/json", "X-Request-ID": "req-001"},
+        )
+        assert ext.headers["Content-Type"] == "application/json"
+
+    def test_defaults(self):
+        ext = HttpExtension()
+        assert ext.headers == {}
+
+    def test_frozen(self):
+        ext = HttpExtension(headers={"X-Test": "value"})
+        with pytest.raises(Exception):
+            ext.headers = {}
+
+    def test_model_copy_add_header(self):
+        ext = HttpExtension(headers={"X-Test": "value"})
+        updated = ext.model_copy(
+            update={"headers": {**ext.headers, "X-New": "added"}},
+        )
+        assert "X-New" in updated.headers
+        assert "X-New" not in ext.headers
+
+
+# ---------------------------------------------------------------------------
+# SecurityExtension
+# ---------------------------------------------------------------------------
+
+
+class TestSubjectType:
+    """Tests for SubjectType enum."""
+
+    def test_values(self):
+        assert SubjectType.USER.value == "user"
+        assert SubjectType.AGENT.value == "agent"
+        assert SubjectType.SERVICE.value == "service"
+        assert SubjectType.SYSTEM.value == "system"
+
+    def test_member_count(self):
+        assert len(SubjectType) == 4
+
+
+class TestSubjectExtension:
+    """Tests for SubjectExtension."""
+
+    def test_creation(self):
+        subject = SubjectExtension(
+            id="user-alice",
+            type=SubjectType.USER,
+            roles=frozenset({"admin", "developer"}),
+            permissions=frozenset({"db.read", "tools.execute"}),
+        )
+        assert subject.id == "user-alice"
+        assert subject.type == SubjectType.USER
+        assert "admin" in subject.roles
+        assert "db.read" in subject.permissions
+
+    def test_defaults(self):
+        subject = SubjectExtension(id="svc-1", type=SubjectType.SERVICE)
+        assert subject.roles == frozenset()
+        assert subject.permissions == frozenset()
+        assert subject.teams == frozenset()
+        assert subject.claims == {}
+
+    def test_frozen_sets(self):
+        subject = SubjectExtension(
+            id="test",
+            type=SubjectType.USER,
+            roles=frozenset({"admin"}),
+        )
+        assert isinstance(subject.roles, frozenset)
+        assert isinstance(subject.permissions, frozenset)
+        assert isinstance(subject.teams, frozenset)
+
+
+class TestObjectSecurityProfile:
+    """Tests for ObjectSecurityProfile."""
+
+    def test_creation(self):
+        profile = ObjectSecurityProfile(
+            managed_by="tool",
+            permissions=["read:compensation"],
+            trust_domain="internal",
+            data_scope=["salary", "bonus"],
+        )
+        assert profile.managed_by == "tool"
+        assert "read:compensation" in profile.permissions
+        assert profile.trust_domain == "internal"
+
+    def test_defaults(self):
+        profile = ObjectSecurityProfile()
+        assert profile.managed_by == "host"
+        assert profile.permissions == []
+        assert profile.trust_domain is None
+        assert profile.data_scope == []
+
+
+class TestRetentionPolicy:
+    """Tests for RetentionPolicy."""
+
+    def test_creation(self):
+        ret = RetentionPolicy(
+            max_age_seconds=3600,
+            policy="session",
+        )
+        assert ret.max_age_seconds == 3600
+        assert ret.policy == "session"
+
+    def test_defaults(self):
+        ret = RetentionPolicy()
+        assert ret.max_age_seconds is None
+        assert ret.policy == "persistent"
+        assert ret.delete_after is None
+
+
+class TestDataPolicy:
+    """Tests for DataPolicy."""
+
+    def test_creation(self):
+        policy = DataPolicy(
+            apply_labels=["PII", "financial"],
+            denied_actions=["export", "forward"],
+            retention=RetentionPolicy(policy="session", max_age_seconds=7200),
+        )
+        assert "PII" in policy.apply_labels
+        assert "export" in policy.denied_actions
+        assert policy.retention.policy == "session"
+
+    def test_defaults(self):
+        policy = DataPolicy()
+        assert policy.apply_labels == []
+        assert policy.allowed_actions is None
+        assert policy.denied_actions == []
+        assert policy.retention is None
+
+    def test_unrestricted_vs_restricted(self):
+        unrestricted = DataPolicy()
+        restricted = DataPolicy(allowed_actions=["view", "summarize"])
+        assert unrestricted.allowed_actions is None
+        assert restricted.allowed_actions == ["view", "summarize"]
+
+
+class TestSecurityExtension:
+    """Tests for SecurityExtension."""
+
+    def test_creation(self):
+        ext = SecurityExtension(
+            labels=frozenset({"PII", "CONFIDENTIAL"}),
+            classification="confidential",
+            subject=SubjectExtension(id="user-1", type=SubjectType.USER),
+        )
+        assert "PII" in ext.labels
+        assert ext.classification == "confidential"
+        assert ext.subject.id == "user-1"
+
+    def test_defaults(self):
+        ext = SecurityExtension()
+        assert ext.labels == frozenset()
+        assert ext.classification is None
+        assert ext.subject is None
+        assert ext.objects == {}
+        assert ext.data == {}
+
+    def test_monotonic_label_addition(self):
+        ext = SecurityExtension(labels=frozenset({"PII"}))
+        updated = ext.model_copy(
+            update={"labels": ext.labels | frozenset({"CONFIDENTIAL"})},
+        )
+        assert "PII" in updated.labels
+        assert "CONFIDENTIAL" in updated.labels
+        assert ext.labels == frozenset({"PII"})
+
+    def test_labels_are_frozenset(self):
+        ext = SecurityExtension(labels=frozenset({"PII"}))
+        assert isinstance(ext.labels, frozenset)
+
+    def test_with_objects_and_data(self):
+        ext = SecurityExtension(
+            objects={
+                "get_user": ObjectSecurityProfile(
+                    managed_by="host",
+                    permissions=["users.read"],
+                ),
+            },
+            data={
+                "get_user": DataPolicy(
+                    apply_labels=["PII"],
+                    denied_actions=["export"],
+                ),
+            },
+        )
+        assert ext.objects["get_user"].permissions == ["users.read"]
+        assert ext.data["get_user"].apply_labels == ["PII"]
+
+
+# ---------------------------------------------------------------------------
+# MCPExtension
+# ---------------------------------------------------------------------------
+
+
+class TestToolMetadata:
+    """Tests for ToolMetadata."""
+
+    def test_creation(self):
+        meta = ToolMetadata(
+            name="get_user",
+            description="Retrieve user by ID",
+            input_schema={"type": "object", "properties": {"id": {"type": "string"}}},
+        )
+        assert meta.name == "get_user"
+        assert meta.input_schema is not None
+
+    def test_defaults(self):
+        meta = ToolMetadata(name="test")
+        assert meta.title is None
+        assert meta.description is None
+        assert meta.input_schema is None
+        assert meta.output_schema is None
+        assert meta.server_id is None
+        assert meta.namespace is None
+        assert meta.annotations == {}
+
+
+class TestResourceMetadata:
+    """Tests for ResourceMetadata."""
+
+    def test_creation(self):
+        meta = ResourceMetadata(
+            uri="file:///data/report.csv",
+            name="Quarterly Report",
+            mime_type="text/csv",
+        )
+        assert meta.uri == "file:///data/report.csv"
+
+
+class TestPromptMetadata:
+    """Tests for PromptMetadata."""
+
+    def test_creation(self):
+        meta = PromptMetadata(
+            name="summarize",
+            arguments=[{"name": "text", "description": "Text to summarize", "required": True}],
+        )
+        assert meta.name == "summarize"
+        assert meta.arguments[0]["name"] == "text"
+
+
+class TestMCPExtension:
+    """Tests for MCPExtension."""
+
+    def test_with_tool(self):
+        ext = MCPExtension(tool=ToolMetadata(name="get_user"))
+        assert ext.tool.name == "get_user"
+        assert ext.resource is None
+        assert ext.prompt is None
+
+    def test_with_resource(self):
+        ext = MCPExtension(resource=ResourceMetadata(uri="file:///test"))
+        assert ext.resource.uri == "file:///test"
+        assert ext.tool is None
+
+    def test_with_prompt(self):
+        ext = MCPExtension(prompt=PromptMetadata(name="summarize"))
+        assert ext.prompt.name == "summarize"
+
+    def test_defaults(self):
+        ext = MCPExtension()
+        assert ext.tool is None
+        assert ext.resource is None
+        assert ext.prompt is None
+
+
+# ---------------------------------------------------------------------------
+# CompletionExtension
+# ---------------------------------------------------------------------------
+
+
+class TestStopReason:
+    """Tests for StopReason enum."""
+
+    def test_values(self):
+        assert StopReason.END.value == "end"
+        assert StopReason.MAX_TOKENS.value == "max_tokens"
+
+    def test_member_count(self):
+        assert len(StopReason) == 5
+
+
+class TestTokenUsage:
+    """Tests for TokenUsage."""
+
+    def test_creation(self):
+        usage = TokenUsage(input_tokens=100, output_tokens=50, total_tokens=150)
+        assert usage.total_tokens == 150
+
+
+class TestCompletionExtension:
+    """Tests for CompletionExtension."""
+
+    def test_creation(self):
+        ext = CompletionExtension(
+            stop_reason=StopReason.END,
+            tokens=TokenUsage(input_tokens=100, output_tokens=50, total_tokens=150),
+            model="gpt-4o",
+            latency_ms=1200,
+        )
+        assert ext.stop_reason == StopReason.END
+        assert ext.tokens.total_tokens == 150
+        assert ext.model == "gpt-4o"
+        assert ext.latency_ms == 1200
+
+    def test_defaults(self):
+        ext = CompletionExtension()
+        assert ext.stop_reason is None
+        assert ext.tokens is None
+        assert ext.model is None
+        assert ext.raw_format is None
+        assert ext.created_at is None
+        assert ext.latency_ms is None
+
+
+# ---------------------------------------------------------------------------
+# ProvenanceExtension
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceExtension:
+    """Tests for ProvenanceExtension."""
+
+    def test_creation(self):
+        ext = ProvenanceExtension(
+            source="agent:weather-bot",
+            message_id="msg-001",
+            parent_id="msg-000",
+        )
+        assert ext.source == "agent:weather-bot"
+        assert ext.message_id == "msg-001"
+
+    def test_defaults(self):
+        ext = ProvenanceExtension()
+        assert ext.source is None
+        assert ext.message_id is None
+        assert ext.parent_id is None
+
+
+# ---------------------------------------------------------------------------
+# LLMExtension
+# ---------------------------------------------------------------------------
+
+
+class TestLLMExtension:
+    """Tests for LLMExtension."""
+
+    def test_creation(self):
+        ext = LLMExtension(
+            model_id="claude-sonnet-4-20250514",
+            provider="anthropic",
+            capabilities=["vision", "tool_use"],
+        )
+        assert ext.provider == "anthropic"
+        assert "tool_use" in ext.capabilities
+
+    def test_defaults(self):
+        ext = LLMExtension()
+        assert ext.model_id is None
+        assert ext.provider is None
+        assert ext.capabilities == []
+
+
+# ---------------------------------------------------------------------------
+# FrameworkExtension
+# ---------------------------------------------------------------------------
+
+
+class TestFrameworkExtension:
+    """Tests for FrameworkExtension."""
+
+    def test_creation(self):
+        ext = FrameworkExtension(
+            framework="langgraph",
+            framework_version="0.2.0",
+            node_id="weather_node",
+            graph_id="travel_planner",
+        )
+        assert ext.framework == "langgraph"
+        assert ext.node_id == "weather_node"
+
+    def test_defaults(self):
+        ext = FrameworkExtension()
+        assert ext.framework is None
+        assert ext.framework_version is None
+        assert ext.node_id is None
+        assert ext.graph_id is None
+        assert ext.metadata == {}
+
+
+# ---------------------------------------------------------------------------
+# Extensions Container
+# ---------------------------------------------------------------------------
+
+
+class TestExtensions:
+    """Tests for the Extensions container."""
+
+    def test_all_none_by_default(self):
+        ext = Extensions()
+        assert ext.request is None
+        assert ext.agent is None
+        assert ext.http is None
+        assert ext.security is None
+        assert ext.mcp is None
+        assert ext.completion is None
+        assert ext.provenance is None
+        assert ext.llm is None
+        assert ext.framework is None
+        assert ext.custom is None
+
+    def test_frozen(self):
+        ext = Extensions()
+        with pytest.raises(Exception):
+            ext.request = RequestExtension()
+
+    def test_model_copy(self):
+        ext = Extensions(
+            request=RequestExtension(environment="dev"),
+        )
+        updated = ext.model_copy(
+            update={"request": RequestExtension(environment="production")},
+        )
+        assert ext.request.environment == "dev"
+        assert updated.request.environment == "production"
+
+    def test_full_construction(self):
+        ext = Extensions(
+            request=RequestExtension(environment="production", request_id="req-001"),
+            agent=AgentExtension(input="Hello", session_id="sess-001"),
+            http=HttpExtension(headers={"X-Test": "value"}),
+            security=SecurityExtension(labels=frozenset({"PII"})),
+            mcp=MCPExtension(tool=ToolMetadata(name="get_user")),
+            completion=CompletionExtension(stop_reason=StopReason.END),
+            provenance=ProvenanceExtension(source="user"),
+            llm=LLMExtension(model_id="gpt-4o", provider="openai"),
+            framework=FrameworkExtension(framework="langgraph"),
+            custom={"debug": True},
+        )
+        assert ext.request.environment == "production"
+        assert ext.agent.input == "Hello"
+        assert ext.http.headers["X-Test"] == "value"
+        assert "PII" in ext.security.labels
+        assert ext.mcp.tool.name == "get_user"
+        assert ext.completion.stop_reason == StopReason.END
+        assert ext.provenance.source == "user"
+        assert ext.llm.provider == "openai"
+        assert ext.framework.framework == "langgraph"
+        assert ext.custom["debug"] is True
+
+    def test_custom_extension(self):
+        ext = Extensions(custom={"key": "value", "nested": {"a": 1}})
+        assert ext.custom["key"] == "value"
+        assert ext.custom["nested"]["a"] == 1

--- a/tests/unit/cpex/framework/hooks/test_message.py
+++ b/tests/unit/cpex/framework/hooks/test_message.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/cpex/framework/hooks/test_message.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Unit tests for message evaluation hook definitions.
+"""
+
+# Third-Party
+import pytest
+
+# First-Party
+from cpex.framework.cmf.message import Message, Role, TextContent
+from cpex.framework.hooks.message import (
+    MessageHookType,
+    MessagePayload,
+    MessageResult,
+)
+from cpex.framework.hooks.registry import get_hook_registry
+from cpex.framework.models import PluginPayload, PluginResult
+
+
+# ---------------------------------------------------------------------------
+# MessageHookType Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMessageHookType:
+    """Tests for the MessageHookType enum."""
+
+    def test_evaluate_value(self):
+        assert MessageHookType.EVALUATE.value == "evaluate"
+
+    def test_from_string(self):
+        assert MessageHookType("evaluate") == MessageHookType.EVALUATE
+
+    def test_invalid_value(self):
+        with pytest.raises(ValueError):
+            MessageHookType("invalid")
+
+    def test_member_count(self):
+        assert len(MessageHookType) == 1
+
+    def test_is_str_enum(self):
+        assert isinstance(MessageHookType.EVALUATE, str)
+        assert MessageHookType.EVALUATE == "evaluate"
+
+
+# ---------------------------------------------------------------------------
+# MessagePayload Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMessagePayload:
+    """Tests for the MessagePayload model."""
+
+    def test_subclass_of_plugin_payload(self):
+        assert issubclass(MessagePayload, PluginPayload)
+
+    def test_creation(self):
+        msg = Message(
+            role=Role.USER,
+            content=[TextContent(text="Hello")],
+        )
+        payload = MessagePayload(message=msg)
+        assert payload.message is msg
+        assert payload.message.role == Role.USER
+        assert payload.message.content[0].text == "Hello"
+
+    def test_message_field_required(self):
+        with pytest.raises(Exception):
+            MessagePayload()
+
+    def test_with_multi_part_message(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[
+                TextContent(text="Part one"),
+                TextContent(text="Part two"),
+            ],
+        )
+        payload = MessagePayload(message=msg)
+        assert len(payload.message.content) == 2
+
+    def test_iter_views_through_payload(self):
+        msg = Message(
+            role=Role.USER,
+            content=[
+                TextContent(text="First"),
+                TextContent(text="Second"),
+            ],
+        )
+        payload = MessagePayload(message=msg)
+        views = list(payload.message.iter_views())
+        assert len(views) == 2
+
+
+# ---------------------------------------------------------------------------
+# MessageResult Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMessageResult:
+    """Tests for the MessageResult type alias."""
+
+    def test_is_plugin_result_subclass(self):
+        assert issubclass(MessageResult, PluginResult)
+
+
+# ---------------------------------------------------------------------------
+# Hook Registration Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMessageHookRegistration:
+    """Tests for message hook registration in the global registry."""
+
+    def test_evaluate_hook_registered(self):
+        registry = get_hook_registry()
+        assert registry.is_registered(MessageHookType.EVALUATE)
+
+    def test_payload_type(self):
+        registry = get_hook_registry()
+        assert registry.get_payload_type(MessageHookType.EVALUATE) is MessagePayload
+
+    def test_result_type(self):
+        registry = get_hook_registry()
+        assert registry.get_result_type(MessageHookType.EVALUATE) is MessageResult
+
+    def test_idempotent_registration(self):
+        """Re-importing or re-calling _register should not raise."""
+        # First-Party
+        from cpex.framework.hooks.message import _register_message_hooks
+
+        _register_message_hooks()
+        registry = get_hook_registry()
+        assert registry.is_registered(MessageHookType.EVALUATE)

--- a/tests/unit/cpex/framework/hooks/test_message.py
+++ b/tests/unit/cpex/framework/hooks/test_message.py
@@ -40,7 +40,7 @@ class TestMessageHookType:
             MessageHookType("invalid")
 
     def test_member_count(self):
-        assert len(MessageHookType) == 1
+        assert len(MessageHookType) == 9
 
     def test_is_str_enum(self):
         assert isinstance(MessageHookType.EVALUATE, str)


### PR DESCRIPTION
This is an initial revision of the CMF data format for plugins.


# Common Message Format (CMF) Specification

**Status**: Draft
**Version**: 2.0

## Introduction

The Common Message Format (CMF) defines a **provider-agnostic, structured representation** for interactions between users, agents, tools, and language models.

CMF provides a canonical message model that supports interoperability, policy enforcement, access control, data governance, and end-to-end auditing across heterogeneous model providers and agent frameworks.

The format explicitly separates:

* **Transport** (provider-specific wire protocols)
* **Canonical message representation** (CMF Message)
* **Policy and enforcement surface** (MessageView abstraction)

This separation allows transport adapters, processing pipelines, and policy engines to evolve independently while operating over a consistent enforcement-ready message model.

```mermaid
flowchart LR
    A([Provider Wire Format]) --> B[Adapter]
    B --> C([CMF Message])
    C --> D[Processing Pipeline]
    D --> E([CMF Message])
    E --> F[Adapter]
    F --> G([Wire Format])
```

## Table of Contents

1. [Design Goals](#1-design-goals)
2. [Message](#2-message)
   - 2.1 [Role](#21-role)
   - 2.2 [Content](#22-content)
   - 2.3 [Channel](#23-channel)
3. [Extensions](#3-extensions)
   - 3.1 [Mutability Tiers](#31-mutability-tiers)
   - 3.2 [Extension Types](#32-extension-types)
   - 3.3 [RequestExtension (immutable)](#33-requestextension-immutable)
   - 3.4 [AgentExtension (immutable)](#34-agentextension-immutable)
   - 3.5 [HttpExtension (guarded)](#35-httpextension-guarded)
   - 3.6 [SecurityExtension (monotonic)](#36-securityextension-monotonic)
     - 3.6.1 [SubjectExtension (immutable)](#361-subjectextension-immutable)
     - 3.6.2 [Objects (immutable)](#362-objects-immutable)
     - 3.6.3 [Data (immutable)](#363-data-immutable)
   - 3.7 [MCPExtension (immutable)](#37-mcpextension-immutable)
   - 3.8 [CompletionExtension (immutable)](#38-completionextension-immutable)
   - 3.9 [ProvenanceExtension (immutable)](#39-provenanceextension-immutable)
   - 3.10 [LLMExtension (immutable)](#310-llmextension-immutable)
   - 3.11 [FrameworkExtension (immutable)](#311-frameworkextension-immutable)
   - 3.12 [Custom Extensions (mutable)](#312-custom-extensions-mutable)
4. [MessageView](#4-messageview)
   - 4.1 [Message vs. MessageView](#41-message-vs-messageview)
   - 4.2 [Supporting Both LLM and Framework Formats](#42-supporting-both-llm-and-framework-formats)
   - 4.3 [Core Attributes](#43-core-attributes)
   - 4.4 [Direction](#44-direction)
   - 4.5 [Flat Accessors (capability-gated)](#45-flat-accessors-capability-gated)
   - 4.6 [Type-Specific Properties](#46-type-specific-properties)
   - 4.7 [Serialization](#47-serialization)
5. [Security Properties](#5-security-properties)
   - 5.1 [Label Propagation](#51-label-propagation)
   - 5.2 [Extension Tier Enforcement](#52-extension-tier-enforcement)

## 1. Design Goals

The CMF is designed to satisfy the following goals:

* **Interoperable, canonical representation**
  Define a provider-agnostic message format that decouples transport wire protocols from internal processing, enabling consistent handling across LLM providers, agent frameworks, tools, and enforcement systems.

* **Complete and explicit enforcement surface**
  Represent all policy-relevant data—including identity, access control metadata, governance attributes, execution context, and provenance—as structured, typed fields on the message.

* **Integrity and safety by construction**
  Protect security-relevant data through explicit mutability tiers (immutable, monotonic, guarded, mutable) enforced by the processing pipeline, and enable safe read-only inspection for policy evaluation.

* **Extensibility without compromising correctness**
  Support structured extensions while preserving interoperability, enforcement guarantees, and message integrity.

To realize these goals, CMF defines the following abstractions:

| Concept              | Purpose                                                                        |
| -------------------- | ------------------------------------------------------------------------------ |
| **Message**          | Canonical structure representing a single agent interaction.                   |
| **Extensions**       | Structured metadata for identity, security, governance, and execution context. |
| **Mutability Tiers** | Explicit contracts governing how fields may be modified.                       |
| **MessageView**      | Read-only projection providing uniform access for policy evaluation.           |

## 2. Message

A `Message` represents a single turn in a conversation. It has four fields:

```
Message
├── schema_version: str                 # Message schema version
├── role: Role                          # WHO is speaking
├── content: list[ContentPart]          # WHAT they said (multimodal parts)
├── channel: Channel | None             # WHAT KIND of output (analysis, commentary, final)
└── extensions: Extensions              # Everything: context, identity, security, completion, provenance
```

### 2.1 Role

Role is a closed-set enumeration type.

| Role | Meaning |
|------|---------|
| `system` | System-level instructions |
| `developer` | Developer-provided instructions (Harmony concept) |
| `user` | Human user input |
| `assistant` | LLM/agent response |
| `tool` | Tool execution result |

### 2.2 Content

Content is a list of typed `ContentPart`s for multimodal messages.

This is the **wire format**, which preserves the LLM's response grouping. A single assistant message can contain text, thinking, and multiple tool calls, just as the provider API returns them.

**ContentPart:**

Each `ContentPart` must include a `ContentType` type discriminator.

| Attribute | Type | Description |
|-----------|------|-------------|
| `content_type` | `ContentType` | The content type |

**ContentPart types:**

| Content Type | Value Type | Description |
|--------------|------------|-------------|
| `text` | `str` | Plain text content |
| `thinking` | `str` | Chain-of-thought / reasoning (may not be shown to end user) |
| `tool_call` | `ToolCall` | Tool/function invocation request |
| `tool_result` | `ToolResult` | Result from tool execution |
| `resource` | `Resource` | Embedded resource with content (MCP) |
| `resource_ref` | `ResourceReference` | Lightweight resource reference without embedded content |
| `prompt_request` | `PromptRequest` | Prompt template invocation request (MCP) |
| `prompt_result` | `PromptResult` | Rendered prompt template result |
| `image` | `ImageSource` | Image content (URL or base64) |
| `video` | `VideoSource` | Video content (URL or base64) |
| `audio` | `AudioSource` | Audio content (URL or base64) |
| `document` | `DocumentSource` | Document content (PDF, Word, etc.) |

**ToolCall:**

| Attribute | Type | Description |
|-----------|------|-------------|
| `tool_call_id` | `str` | Unique request correlation ID |
| `name` | `str` | Tool name |
| `arguments` | `dict[str, Any]` | Arguments as a JSON-serializable dict |
| `namespace` | `str \| None` | Namespace for namespaced tools |

**ToolResult:**

| Attribute | Type | Description |
|-----------|------|-------------|
| `tool_call_id` | `str` | Correlation ID linking to the corresponding tool call |
| `tool_name` | `str` | Name of the tool that was executed |
| `content` | `JSONValue` | Result content, any JSON-serializable value |
| `is_error` | `bool` | Whether the result represents an error |

**Resource:**

| Attribute | Type | Description |
|-----------|------|-------------|
| `resource_request_id` | `str` | Unique request correlation ID |
| `uri` | `str` | Unique identifier (URI format) |
| `name` | `str \| None` | Human-readable name |
| `description` | `str \| None` | What this resource contains |
| `resource_type` | `ResourceType` | `file`, `blob`, `uri`, `database`, `api`, `memory`, `artifact` |
| `content` | `str \| None` | Text content (if embedded) |
| `blob` | `bytes \| None` | Binary content (if embedded) |
| `mime_type` | `str \| None` | MIME type of content |
| `size_bytes` | `int \| None` | Size information |
| `annotations` | `dict` | Metadata (classification, retention, etc.) |
| `version` | `str \| None` | Version tracking |

**ResourceReference:**

| Attribute | Type | Description |
|-----------|------|-------------|
| `resource_request_id` | `str` | Correlation ID linking to the originating resource request |
| `uri` | `str` | Resource URI |
| `name` | `str \| None` | Human-readable name |
| `resource_type` | `ResourceType` | Type of resource |
| `range_start` | `int \| None` | Line number or byte offset (partial references) |
| `range_end` | `int \| None` | End of range |
| `selector` | `str \| None` | CSS/XPath/JSONPath selector |

**ResourceType:**

`ResourceType` is a closed-set enumeration.

| Value | Description |
|-------|-------------|
| `file` | File-system resource |
| `blob` | Binary large object |
| `uri` | Generic URI-addressable resource |
| `database` | Database entity |
| `api` | API endpoint |
| `memory` | In-memory or ephemeral resource |
| `artifact` | Produced artifact (generated output, build result) |

**PromptRequest:**

| Attribute | Type | Description |
|-----------|------|-------------|
| `prompt_request_id` | `str` | Request ID for correlation |
| `name` | `str` | Prompt template name |
| `arguments` | `dict[str, Any]` | Arguments to pass to the template |
| `server_id` | `str \| None` | Source server (multi-server scenarios) |

**PromptResult:**

| Attribute | Type | Description |
|-----------|------|-------------|
| `prompt_request_id` | `str` | ID of the corresponding prompt request |
| `prompt_name` | `str` | Name of the prompt that was rendered |
| `messages` | `list[Message]` | Rendered messages (prompts produce messages) |
| `content` | `str \| None` | Single text result for simple prompts |
| `is_error` | `bool` | Whether rendering failed |
| `error_message` | `str \| None` | Error details if rendering failed |

**ImageSource:**

| Attribute | Type | Description |
|-----------|------|-------------|
| `type` | `"url" \| "base64"` | Source type |
| `data` | `str` | URL or base64-encoded string |
| `media_type` | `str \| None` | MIME type (e.g., `image/jpeg`) |

**VideoSource:**

| Attribute | Type | Description |
|-----------|------|-------------|
| `type` | `"url" \| "base64"` | Source type |
| `data` | `str` | URL or base64-encoded string |
| `media_type` | `str \| None` | MIME type (e.g., `video/mp4`) |
| `duration_ms` | `int \| None` | Duration in milliseconds |

**AudioSource:**

| Attribute | Type | Description |
|-----------|------|-------------|
| `type` | `"url" \| "base64"` | Source type |
| `data` | `str` | URL or base64-encoded string |
| `media_type` | `str \| None` | MIME type (e.g., `audio/mp3`) |
| `duration_ms` | `int \| None` | Duration in milliseconds |

**DocumentSource:**

| Attribute | Type | Description |
|-----------|------|-------------|
| `type` | `"url" \| "base64"` | Source type |
| `data` | `str` | URL or base64-encoded string |
| `media_type` | `str \| None` | MIME type (e.g., `application/pdf`) |
| `title` | `str \| None` | Document title |

### 2.3 Channel

`Channel` is a closed-set enumeration that classifies the kind of output a message represents. It is **optional**, and when unset, it indicates a standard, unclassified message. Channels allow agentic frameworks and pipelines to route or filter messages by output type without inspecting content.

| Channel | Description |
|---------|-------------|
| `analysis` | Intermediate analytical output, such as reasoning, evaluation, or investigation produced during task execution, not intended as the final response. |
| `commentary` | Meta-level observations about the task or process, such as notes, warnings, or annotations produced alongside primary output. |
| `final` | The terminal response for a task or conversation turn, such as the output intended for delivery to the end consumer. |

## 3. Extensions

Extensions are the sole carrier of all contextual data. Everything a consumer or policy engine needs (e.g., identity, security classification, HTTP context, entity metadata, agent lineage, execution environment, completion info, provenance) is stored as a typed message extension with an explicit mutability tier.

```
Extensions
├── request: RequestExtension | None
├── agent: AgentExtension | None
├── http: HttpExtension | None
├── security: SecurityExtension | None
├── mcp: MCPExtension | None
├── completion: CompletionExtension | None
├── provenance: ProvenanceExtension | None
├── llm: LLMExtension | None
├── framework: FrameworkExtension | None
└── custom: dict[str, Any] | None
```

### 3.1 Mutability Tiers

Every extension declares its mutability tier. The processing pipeline enforces these contracts during copy-on-write.

| Tier | Copy Behavior | Pipeline Validation |
|------|-------------|---------------------|
| **Immutable** | Shared reference, not deep-copied | Rejects if changed in returned copy |
| **Monotonic** | Copied, but only additive operations allowed | Rejects if any element was removed |
| **Guarded** | Copied, but write requires a declared capability | Rejects if modified without the required capability |
| **Mutable** | Normal deep copy, fully modifiable | Accepted as-is |

### 3.2 Extension Types

| Extension | Mutability | Contents |
|-----------|-----------|----------|
| `request` | Immutable | Execution environment, request ID, timestamp, distributed tracing |
| `agent` | Immutable | Session ID, conversation ID, turn, agent lineage, original user intent |
| `http` | Guarded | HTTP headers (readable with `read_headers`, writable with `write_headers`) |
| `security` | Monotonic | Security labels, classification level, and the nested immutable fields below |
| `security.subject` | Immutable | Authenticated identity: ID, type, roles, permissions, teams, claims |
| `security.objects` | Immutable | Access control profiles keyed by entity |
| `security.data` | Immutable | Data governance policies keyed by entity |
| `mcp` | Immutable | Tool, resource, or prompt metadata (name, schema, annotations, server ID) |
| `completion` | Immutable | Stop reason, token usage, model identifier, wire format, latency |
| `provenance` | Immutable | Source identifier, message ID, parent message ID |
| `llm` | Immutable | Model identifier, provider, model capabilities |
| `framework` | Immutable | Agentic framework context (LangGraph, CrewAI, etc.) |
| `custom` | Mutable | Custom extensions |

### 3.3 RequestExtension (immutable)

Execution environment and request-level timing/tracing. Available to all consumers without any capability requirement (base tier).

| Attribute | Type | Description |
|-----------|------|-------------|
| `environment` | `str \| None` | Execution environment (`production`, `staging`, `dev`) |
| `request_id` | `str \| None` | Request correlation ID |
| `timestamp` | `str \| None` | ISO timestamp of the request |
| `trace_id` | `str \| None` | Distributed tracing ID (OpenTelemetry) |
| `span_id` | `str \| None` | Distributed tracing span ID |

### 3.4 AgentExtension (immutable)

Agent execution context — session tracking, multi-agent lineage, and the original user intent. Immutable because the user's intent and session identity must not be modifiable by processing components.

| Attribute | Type | Description |
|-----------|------|-------------|
| `input` | `str \| None` | Original user intent that triggered this action |
| `session_id` | `str \| None` | Broad session identifier |
| `conversation_id` | `str \| None` | Specific dialogue/task within a session |
| `turn` | `int \| None` | Position in conversation (0-indexed) |
| `agent_id` | `str \| None` | Identifier of the producing agent |
| `parent_agent_id` | `str \| None` | Spawning agent's ID (multi-agent lineage) |
| `conversation` | `ConversationContext \| None` | Windowed conversation context |

**ConversationContext:**

| Attribute | Type | Description |
|-----------|------|-------------|
| `history` | `list[Message] \| None` | Windowed message history (recent turns) |
| `summary` | `str \| None` | Summarized prior context |
| `topics` | `list[str]` | Extracted topics or intents |

### 3.5 HttpExtension (guarded)

HTTP request context. Readable with `read_headers`, writable with `write_headers`. The write capability exists because consumers sometimes need to inject headers for downstream systems — e.g., adding an OAuth token for an API call, or a correlation ID for tracing.

| Attribute | Read Capability | Write Capability | Type | Description |
|-----------|----------------|-----------------|------|-------------|
| `headers` | `read_headers` | `write_headers` | `dict[str, str]` | HTTP headers as key-value pairs |

Sensitive headers (`Authorization`, `Cookie`, `X-API-Key`) are stripped when serialized for external policy engines. Consumers with `write_headers` can inject new headers; the pipeline audits all header modifications.

### 3.6 SecurityExtension (monotonic and immutable)

Data classification, security labels, and all security-relevant contextual data: subject identity, access control profiles, and data governance policies. The `SecurityExtension` labels are add-only during normal message flow. Its nested immutable fields (`subject`, `objects`, `data`) cannot be replaced or modified.

| Attribute | Type | Description |
|-----------|------|-------------|
| `labels` | `set[str]` | Security/data labels (`PII`, `CONFIDENTIAL`, `SECRET`, etc.) |
| `classification` | `str \| None` | Data classification level |
| `subject` | `SubjectExtension \| None` | Authenticated identity (see 3.6.1) |
| `objects` | `dict[str, ObjectSecurityProfile]` | Access control profiles, keyed by entity identifier (see 3.6.2) |
| `data` | `dict[str, DataPolicy]` | Data governance policies, keyed by entity identifier (see 3.6.3) |

Requires `read_labels` capability to see labels. Any consumer can add labels (through copy-on-write), but the pipeline validates that no labels were removed (`before.labels ⊆ after.labels`). Removal requires a privileged declassification operation that is audited separately.

#### 3.6.1 SubjectExtension (immutable)

The authenticated entity making the request. Access to individual fields is controlled by declared capabilities.

`SubjectType` is a closed-set enumeration: `user`, `agent`, `service`, `system`.

| Attribute | Capability Required | Type | Description |
|-----------|-------------------|------|-------------|
| `id` | `read_subject` | `str` | Unique subject identifier |
| `type` | `read_subject` | `SubjectType` | Subject kind |
| `roles` | `read_roles` | `set[str]` | Assigned roles (`developer`, `admin`, `viewer`, etc.) |
| `permissions` | `read_permissions` | `set[str]` | Granted permissions (`tools.execute`, `db.read`, etc.) |
| `teams` | `read_teams` | `set[str]` | Team memberships (for multi-tenant scoping) |
| `claims` | `read_claims` | `dict` | Raw identity claims (JWT, SAML) |

#### 3.6.2 Objects (immutable)

Access control profiles for entities referenced in the message, keyed by entity identifier (tool name, resource URI, prompt name). Each entry is an `ObjectSecurityProfile` declaring the entity's access requirements and data scope.

```
objects: dict[str, ObjectSecurityProfile] = {}
```

**ObjectSecurityProfile** (flat):

| Attribute | Type | Description |
|-----------|------|-------------|
| `managed_by` | `str` | Who enforces access control: `"host"`, `"tool"`, or `"both"` |
| `permissions` | `list[str]` | Required permissions to invoke (e.g., `["read:compensation"]`) |
| `trust_domain` | `str \| None` | Trust domain: `"internal"`, `"external"`, `"privileged"` |
| `data_scope` | `list[str]` | Field names this entity accesses/returns (e.g., `["salary", "bonus"]`) |

For MCP/framework messages (single entity), this map has one entry. For LLM provider messages with multiple tool calls, it has one entry per entity. The host pipeline populates this map during message ingestion by looking up each entity's registered profile from an implementation-defined registry (e.g., tool registration metadata, MCP server manifests, or a policy store). Profile lookup is keyed by entity identifier — the tool name, resource URI, or prompt name that appears in the message content.

The `MessageView` exposes a singular accessor — each view resolves its own profile from the map:

```
view.object → ObjectSecurityProfile | None
  (resolved by: extensions.security.objects.get(view.name))
```

For the full model and policy integration, see the [Object Security Profile Spec](object-security-profile-spec.md).

#### 3.6.3 Data (immutable)

Data governance policies for entities referenced in the message, keyed by entity identifier (tool name, resource URI, prompt name). Each entry is a `DataPolicy` declaring labeling, action restrictions, and retention rules for the entity's output.

```
data: dict[str, DataPolicy] = {}
```

**DataPolicy:**

| Attribute | Type | Description |
|-----------|------|-------------|
| `apply_labels` | `list[str]` | Labels to stamp on output (e.g., `["PII", "financial"]`) |
| `allowed_actions` | `list[str] \| None` | What downstream can do. `None` = unrestricted. |
| `denied_actions` | `list[str]` | What downstream cannot do (e.g., `["export", "forward"]`) |
| `retention` | `RetentionPolicy \| None` | How long data can be kept |

**RetentionPolicy:**

| Attribute | Type | Description |
|-----------|------|-------------|
| `max_age_seconds` | `int \| None` | Maximum retention duration in seconds |
| `policy` | `str` | Retention class: `"session"`, `"transient"`, `"persistent"`, `"none"` |
| `delete_after` | `str \| None` | ISO timestamp after which data must be deleted |

The `data` extension is evaluated on post views (tool results, resource responses, prompt results). When a tool returns data, the pipeline looks up its `DataPolicy`, stamps `apply_labels` onto the message's `SecurityExtension`, and enforces action restrictions downstream.

The `MessageView` exposes a singular accessor:

```
view.data_policy → DataPolicy | None
  (resolved by: extensions.security.data.get(view.name))
```

For the full model, action vocabulary, and policy integration, see the [Object Security Profile Spec](object-security-profile-spec.md).

### 3.7 MCPExtension (immutable)

Typed metadata about the MCP entity being processed. Gives consumers access to the schema and annotations of the tool, resource, or prompt being evaluated.

**ToolMetadata** (`ext.mcp.metadata.tool`):

| Attribute | Type | Description |
|-----------|------|-------------|
| `name` | `str` | Unique tool identifier |
| `title` | `str \| None` | Human-readable display name |
| `description` | `str \| None` | Description of tool functionality |
| `input_schema` | `dict \| None` | JSON Schema defining expected parameters |
| `output_schema` | `dict \| None` | JSON Schema for structured output |
| `server_id` | `str \| None` | ID of the server providing this tool |
| `namespace` | `str \| None` | Tool namespace (server/origin) |
| `annotations` | `dict` | MCP annotations (e.g., `readOnlyHint`, `destructiveHint`) |

**ResourceMetadata** (`ext.mcp.metadata.resource`):

| Attribute | Type | Description |
|-----------|------|-------------|
| `uri` | `str` | Resource URI (`file:///path`, `db://table/id`, etc.) |
| `name` | `str \| None` | Resource name |
| `description` | `str \| None` | Resource description |
| `mime_type` | `str \| None` | MIME type (`text/csv`, `application/json`, etc.) |
| `server_id` | `str \| None` | ID of the server providing this resource |
| `annotations` | `dict` | MCP annotations (classification, retention, access hints) |

**PromptMetadata** (`ext.mcp.metadata.prompt`):

| Attribute | Type | Description |
|-----------|------|-------------|
| `name` | `str` | Prompt template name |
| `description` | `str \| None` | Prompt description |
| `arguments` | `list[dict] \| None` | Argument definitions — each entry has `name`, `description`, `required` |
| `server_id` | `str \| None` | ID of the server providing this prompt |
| `annotations` | `dict` | MCP annotations |

Note: Prompts use an argument list rather than JSON Schema for input definition, following the MCP prompt specification. There is no output schema — prompt output is always rendered messages.

### 3.8 CompletionExtension (immutable)

LLM completion information. Fields like `model` and `stop_reason` can drive policy decisions (e.g., "only allow gpt-4 for financial queries", "flag max_tokens responses for review").

`StopReason` is a closed-set enumeration: `end`, `return`, `call`, `max_tokens`, `stop_sequence`.

**TokenUsage:**

| Attribute | Type | Description |
|-----------|------|-------------|
| `input_tokens` | `int` | Tokens consumed by the input |
| `output_tokens` | `int` | Tokens generated in the output |
| `total_tokens` | `int` | Total tokens (input + output) |

| Attribute | Type | Description |
|-----------|------|-------------|
| `stop_reason` | `StopReason \| None` | Why the model stopped |
| `tokens` | `TokenUsage \| None` | Token counts |
| `model` | `str \| None` | Model identifier that generated this response |
| `raw_format` | `str \| None` | Original wire format (`chatml`, `harmony`, `gemini`, `anthropic`) |
| `created_at` | `str \| None` | ISO timestamp when the message was created |
| `latency_ms` | `int \| None` | Response generation time in milliseconds |

### 3.9 ProvenanceExtension (immutable)

Origin and threading information for the message. Enables lineage tracking across multi-turn conversations and multi-agent systems.

| Attribute | Type | Description |
|-----------|------|-------------|
| `source` | `str \| None` | Source identifier (`"user"`, `"agent:xyz"`, `"mcp-server:abc"`) |
| `message_id` | `str \| None` | Unique message identifier |
| `parent_id` | `str \| None` | Parent message ID (threading/replies) |

Note: `conversation_id`, `session_id`, and agent lineage (`agent_id`, `parent_agent_id`) live on `AgentExtension` (section 3.4) since they are per-request context, not per-message. `trace_id` and `span_id` live on `RequestExtension` (section 3.3) alongside `request_id`.

### 3.10 LLMExtension (immutable)

Model identity and capability metadata. Used for routing, policy evaluation, and audit when the producing model's identity matters independently of the completion itself.

| Attribute | Type | Description |
|-----------|------|-------------|
| `model_id` | `str \| None` | Model identifier (e.g., `gpt-4o`, `claude-sonnet-4-20250514`) |
| `provider` | `str \| None` | Provider name (e.g., `openai`, `anthropic`, `google`) |
| `capabilities` | `list[str]` | Declared model capabilities (e.g., `["vision", "tool_use", "extended_thinking"]`) |

### 3.11 FrameworkExtension (immutable)

Agentic framework context. Captures the framework-level execution environment for messages that originate from or pass through agentic orchestration layers.

| Attribute | Type | Description |
|-----------|------|-------------|
| `framework` | `str \| None` | Framework identifier (e.g., `langgraph`, `crewai`, `autogen`, `a2a`) |
| `framework_version` | `str \| None` | Framework version |
| `node_id` | `str \| None` | Framework-specific node or step identifier |
| `graph_id` | `str \| None` | Graph or workflow identifier |
| `metadata` | `dict[str, Any]` | Framework-specific metadata |

### 3.12 Custom Extensions (mutable)

Custom extensions. Fully mutable through copy-on-write, no restrictions on modification.

## 4. MessageView

`Message` is the **storage format** — it preserves the wire structure exactly as the LLM sent it. `MessageView` is the **policy and interaction surface** — it decomposes a message into individually addressable parts, enriches each with computed semantics, and provides a uniform interface regardless of content type.

### 4.1 Message vs. MessageView

A single LLM response can contain text, reasoning, and multiple tool calls bundled together. That's one `Message` but potentially many things that need to be evaluated independently.

**Message** (one object, wire format):
```json
{
  "role": "assistant",
  "content": [
    {"content_type": "thinking", "text": "The user wants admin users. I'll query the database..."},
    {"content_type": "text", "text": "Let me look that up for you."},
    {"content_type": "tool_call", "name": "execute_sql", "arguments": {"query": "SELECT * FROM users WHERE role='admin'"}},
    {"content_type": "tool_call", "name": "send_email", "arguments": {"to": "boss@company.com", "body": "..."}}
  ]
}
```

Calling `message.iter_views()` produces **four MessageViews**, each with a uniform interface:

| # | `kind` | `name` | `action` | `is_pre` | `uri` | `content` |
|---|--------|--------|----------|----------|-------|-----------|
| 1 | `thinking` | — | `generate` | `false` | — | `"The user wants admin users..."` |
| 2 | `text` | — | `send` | `false` | — | `"Let me look that up for you."` |
| 3 | `tool_call` | `execute_sql` | `execute` | `true` | `tool://db-server/execute_sql` | `'{"query": "SELECT..."}'` |
| 4 | `tool_call` | `send_email` | `execute` | `true` | `tool://email-server/send_email` | `'{"to": "boss@..."}'` |

**What the view adds** that doesn't exist on the raw content parts:

| Property | Raw ContentPart | MessageView |
|----------|----------------|-------------|
| Identity | No URI | Synthetic URI (`tool://ns/name`, `prompt://server/name`, `file:///path`) |
| Direction | No concept | `is_pre`/`is_post` computed from kind + role |
| Semantic action | No concept | `action`: `read`, `write`, `execute`, `invoke`, `send`, `receive`, `generate` |
| Context | Not attached | Capability-gated flat accessors (`roles`, `labels`, `environment`, etc.) |
| Content normalization | Type-specific | `content` always returns scannable text (serialized arguments for tool calls) |
| Uniform query API | Type-specific fields | `has_role()`, `has_label()`, `matches_uri_pattern()`, `get_arg()`, etc. |

### 4.2 Supporting Both LLM and Framework Formats

The CMF naturally supports two messaging patterns through the same structure:

| Pattern | Content | Views | Example |
|---------|---------|-------|---------|
| **LLM wire format** | Multiple ContentParts per message | Many views per message | OpenAI/Anthropic assistant response with text + thinking + tool calls |
| **Framework/protocol format** | Single ContentPart per message | One view per message | MCP tool call, A2A task message, LangGraph node output |

An MCP tool invocation is simply a Message with one `tool_call` content part:

```json
{"role": "assistant", "content": [{"content_type": "tool_call", "name": "get_user", "arguments": {"id": "123"}}]}
```

This produces one view. An OpenAI assistant response that bundles reasoning with two tool calls produces three views. The processing pipeline doesn't care — `iter_views()` yields the right number either way, and every view has the same interface.

This means the CMF does not force a choice between "one action per message" (MCP, A2A) and "bundled response" (LLM providers). Both are first-class, and the same policies and routing rules work across both patterns without adaptation.

### 4.3 Core Attributes

`ViewKind` is a closed-set enumeration: `text`, `thinking`, `tool_call`, `tool_result`, `resource`, `resource_ref`, `prompt_request`, `prompt_result`, `image`, `video`, `audio`, `document`.

`ViewAction` is a closed-set enumeration: `read`, `write`, `execute`, `invoke`, `send`, `receive`, `generate`.

| Attribute | Type | Description |
|-----------|------|-------------|
| `kind` | `ViewKind` | Content type of this view |
| `role` | `Role` | Role of the parent message (`user`, `assistant`, `system`, `developer`, `tool`) |
| `content` | `str \| None` | Scannable text. For tool calls and prompt requests: JSON-serialized arguments. For tool results: JSON-serialized content. For resources: embedded content string. |
| `uri` | `str \| None` | Synthetic identity: `tool://ns/name`, `prompt://server/name`, `tool_result://name`, `file:///path` |
| `name` | `str \| None` | Human-readable name (tool name, resource name, prompt name) |
| `action` | `ViewAction` | Semantic action |
| `args` | `dict \| None` | Alias for the underlying `arguments` dict on `tool_call` and `prompt_request` content parts; `None` for other kinds |
| `mime_type` | `str \| None` | MIME type for resources and images |
| `size_bytes` | `int \| None` | Content size in bytes (computed from content) |
| `properties` | `dict` | Type-specific properties (see 4.6) |

### 4.4 Direction

Direction is determined by a combination of ViewKind and Role:

| Content | Direction | Rule |
|---------|-----------|------|
| `tool_call`, `prompt_request`, `resource_ref` | **pre** | Always requests |
| `tool_result`, `prompt_result`, `resource` | **post** | Always responses |
| `text`, `thinking`, media | **pre** if role is user/system/developer/tool | Input to LLM |
| `text`, `thinking`, media | **post** if role is assistant | Output from LLM |

| Attribute | Type | Description |
|-----------|------|-------------|
| `is_pre` | `bool` | True if input/request (before processing) |
| `is_post` | `bool` | True if output/response (after processing) |
| `is_tool` | `bool` | True if `tool_call` or `tool_result` |
| `is_prompt` | `bool` | True if `prompt_request` or `prompt_result` |
| `is_resource` | `bool` | True if `resource` or `resource_ref` |
| `is_text` | `bool` | True if `text` or `thinking` |
| `is_media` | `bool` | True if `image`, `video`, `audio`, or `document` |

### 4.5 Flat Accessors (capability-gated)

MessageView provides flat accessor properties over extensions. These hide the underlying extension nesting — consumers write `view.roles`, not `view.extensions.security.subject.roles`. Availability depends on the consumer's declared capabilities — extensions for which access has not been granted are `None` on the view.

| Accessor | Capability | Type | Reads From |
|----------|-----------|------|------------|
| `environment` | _(base)_ | `str \| None` | `ext.request.environment` |
| `request_id` | _(base)_ | `str \| None` | `ext.request.request_id` |
| `subject` | `read_subject` | `SubjectExtension \| None` | `ext.security.subject` |
| `roles` | `read_roles` | `set[str]` | `ext.security.subject.roles` |
| `permissions` | `read_permissions` | `set[str]` | `ext.security.subject.permissions` |
| `teams` | `read_teams` | `set[str]` | `ext.security.subject.teams` |
| `headers` | `read_headers` | `dict[str, str]` | `ext.http.headers` |
| `labels` | `read_labels` | `set[str]` | `ext.security.labels` |
| `agent_input` | `read_agent` | `str \| None` | `ext.agent.input` |
| `session_id` | `read_agent` | `str \| None` | `ext.agent.session_id` |
| `conversation_id` | `read_agent` | `str \| None` | `ext.agent.conversation_id` |
| `turn` | `read_agent` | `int \| None` | `ext.agent.turn` |
| `agent_id` | `read_agent` | `str \| None` | `ext.agent.agent_id` |
| `parent_agent_id` | `read_agent` | `str \| None` | `ext.agent.parent_agent_id` |
| `object` | `read_objects` | `ObjectSecurityProfile \| None` | `ext.security.objects.get(view.name)` |
| `data_policy` | `read_data` | `DataPolicy \| None` | `ext.security.data.get(view.name)` |

Helper methods:

| Method | Description |
|--------|-------------|
| `has_role(role)` | Check if subject has a specific role |
| `has_permission(perm)` | Check if subject has a specific permission |
| `has_label(label)` | Check if a security label is present |
| `has_header(name)` | Check if an HTTP header exists (case-insensitive) |
| `get_header(name)` | Get header value (case-insensitive) |
| `get_arg(name)` | Get a single argument value |
| `has_arg(name)` | Check if an argument exists |
| `matches_uri_pattern(glob)` | Glob match on URI (`*`, `**` wildcards) |
| `has_content()` | True if scannable text content is available |

### 4.6 Type-Specific Properties

Each ViewKind exposes additional properties via `get_property(name)` or `properties`:

| ViewKind | Property | Type | Description |
|----------|----------|------|-------------|
| `resource` | `resource_type` | `str` | `file`, `blob`, `uri`, `database`, `api`, `memory`, `artifact` |
| `resource` | `version` | `str \| None` | Resource version |
| `resource` | `annotations` | `dict \| None` | Resource annotations (classification, retention, etc.) |
| `tool_call` | `namespace` | `str \| None` | Tool namespace (server/origin) |
| `tool_call` | `tool_id` | `str \| None` | Call correlation ID |
| `tool_result` | `is_error` | `bool` | Whether the tool execution errored |
| `tool_result` | `tool_name` | `str` | Name of the tool that produced this result |
| `prompt_request` | `server_id` | `str \| None` | Source server for the prompt |
| `prompt_result` | `is_error` | `bool` | Whether prompt rendering errored |
| `prompt_result` | `message_count` | `int` | Number of messages in the rendered prompt |

### 4.7 Serialization

| Method | Description |
|--------|-------------|
| `to_dict()` | Serialize to JSON-compatible dict. Options: `include_content`, `include_context` |
| `to_opa_input()` | Wrap in OPA envelope: `{"input": {...view...}}` |

Sensitive headers (`Authorization`, `Cookie`, `X-API-Key`) are automatically stripped from serialized output. The serialized `extensions` block is assembled from capability-gated extensions, mirroring the extension hierarchy.

## 5. Security Properties

### 5.1 Label Propagation

Security labels on `extensions.security` are **monotonically accumulating** during normal message flow. A message that touches PII data carries the `PII` label for its lifetime. Labels propagate through the pipeline:

- Tool result carries labels → subsequent messages inherit them
- Multiple data sources → union of labels

Removal requires explicit declassification, a privileged operation that is audited separately.

### 5.2 Extension Tier Enforcement

The four mutability tiers (immutable, monotonic, guarded, mutable) provide layered protection:

| Layer | What it prevents | How |
|-------|-----------------|-----|
| **MessageView** | Accidental mutation through read path | Read-only by design; no mutation API |
| **Capability gating** | Unauthorized access to sensitive extensions | Extensions not populated if capability not declared |
| **Write validation** | Unauthorized modification through write path | Pipeline validates tier constraints on returned copies |
