### PR TITLE
feat: capabilities and common message format

### DIFF
--- a/cpex/framework/base.py
+++ b/cpex/framework/base.py
@@ -455,7 +455,7 @@ class HookRef:
 
                 # Check for @hook decorator metadata
                 metadata = get_hook_metadata(method)
-                if metadata and metadata.hook_type == hook:
+                if metadata and metadata.matches(hook):
                     self._func = method
                     break
 

--- a/cpex/framework/base.py
+++ b/cpex/framework/base.py
@@ -65,6 +65,11 @@ class Plugin(ABC):
     ) -> None:
         """Initialize a plugin with a configuration and context.
 
+        The plugin receives the config directly. When the plugin is
+        registered with the Manager, the PluginRef retains the
+        authoritative config and gives the plugin a defensive copy,
+        so the Manager never trusts config read back from the plugin.
+
         Args:
             config: The plugin configuration
             hook_payloads: optional mapping of hookpoints to payloads for the plugin.
@@ -267,11 +272,18 @@ class PluginRef:
         ['ref', 'test']
     """
 
-    def __init__(self, plugin: Plugin):
+    def __init__(self, plugin: Plugin, trusted_config: PluginConfig | None = None):
         """Initialize a plugin reference.
+
+        Stores the authoritative config separately from the plugin.
+        The Manager reads policy-sensitive fields (capabilities, mode,
+        on_error) from the trusted config, never from the plugin.
 
         Args:
             plugin: The plugin to reference.
+            trusted_config: The authoritative config retained by the
+                Manager. If not provided, falls back to plugin.config
+                (for backward compatibility in tests).
 
         Examples:
             >>> from cpex.framework import PluginConfig
@@ -293,6 +305,7 @@ class PluginRef:
             True
         """
         self._plugin = plugin
+        self._trusted_config = trusted_config or plugin.config
         self._uuid = uuid.uuid4()
 
     @property
@@ -303,6 +316,15 @@ class PluginRef:
             The underlying plugin.
         """
         return self._plugin
+
+    @property
+    def trusted_config(self) -> PluginConfig:
+        """Return the authoritative config held by the Manager.
+
+        Returns:
+            The trusted PluginConfig (not the plugin's copy).
+        """
+        return self._trusted_config
 
     @property
     def uuid(self) -> str:
@@ -320,7 +342,7 @@ class PluginRef:
         Returns:
             Plugin's priority.
         """
-        return self._plugin.priority
+        return self._trusted_config.priority
 
     @property
     def name(self) -> str:
@@ -329,7 +351,7 @@ class PluginRef:
         Returns:
             Plugin's name.
         """
-        return self._plugin.name
+        return self._trusted_config.name
 
     @property
     def hooks(self) -> list[str]:
@@ -338,7 +360,7 @@ class PluginRef:
         Returns:
             Plugin's configured hooks.
         """
-        return self._plugin.hooks
+        return self._trusted_config.hooks
 
     @property
     def tags(self) -> list[str]:
@@ -347,7 +369,7 @@ class PluginRef:
         Returns:
             Plugin's tags.
         """
-        return self._plugin.tags
+        return self._trusted_config.tags
 
     @property
     def conditions(self) -> list[PluginCondition] | None:
@@ -356,7 +378,7 @@ class PluginRef:
         Returns:
             Plugin's conditions for operation.
         """
-        return self._plugin.conditions
+        return self._trusted_config.conditions
 
     @property
     def mode(self) -> PluginMode:
@@ -365,7 +387,7 @@ class PluginRef:
         Returns:
             Plugin's mode.
         """
-        return self.plugin.mode
+        return self._trusted_config.mode
 
     @property
     def on_error(self) -> OnError:
@@ -374,7 +396,16 @@ class PluginRef:
         Returns:
             Plugin's on_error behavior.
         """
-        return self.plugin.config.on_error
+        return self._trusted_config.on_error
+
+    @property
+    def capabilities(self) -> frozenset[str]:
+        """Return the plugin's declared capabilities.
+
+        Returns:
+            The authoritative capability set from the trusted config.
+        """
+        return self._trusted_config.capabilities
 
 
 class HookRef:
@@ -439,19 +470,25 @@ class HookRef:
             )
 
         # Validate hook method signature (parameter count and async)
-        self._validate_hook_signature(hook, self._func, plugin_ref.plugin.name)
+        param_count = self._validate_hook_signature(hook, self._func, plugin_ref.plugin.name)
 
-    def _validate_hook_signature(self, hook: str, func: Callable, plugin_name: str) -> None:
+        # Store whether the plugin accepts extensions as a third argument
+        self._accepts_extensions = param_count == 3
+
+    def _validate_hook_signature(self, hook: str, func: Callable, plugin_name: str) -> int:
         """Validate that the hook method has the correct signature.
 
         Checks:
-        1. Method accepts correct number of parameters (self, payload, context)
+        1. Method accepts 2 parameters (payload, context) or 3 (payload, context, extensions)
         2. Method is async (returns coroutine)
 
         Args:
             hook: The hook type being validated
             func: The hook method to validate
             plugin_name: Name of the plugin (for error messages)
+
+        Returns:
+            The number of parameters (2 or 3).
 
         Raises:
             PluginError: If the signature is invalid
@@ -462,14 +499,16 @@ class HookRef:
         sig = inspect.signature(func)
         params = list(sig.parameters.values())
 
-        # Check parameter count (should be: payload, context)
+        # Check parameter count (should be: payload, context[, extensions])
         # Note: 'self' is not included in bound method signatures
-        if len(params) != 2:
+        if len(params) not in (2, 3):
             raise PluginError(
                 error=PluginErrorModel(
                     message=f"Plugin '{plugin_name}' hook '{hook}' has invalid signature. "
-                    f"Expected 2 parameters (payload, context), got {len(params)}: {list(sig.parameters.keys())}. "
-                    f"Correct signature: async def {hook}(self, payload: PayloadType, context: PluginContext) -> ResultType",
+                    f"Expected 2 or 3 parameters (payload, context[, extensions]), "
+                    f"got {len(params)}: {list(sig.parameters.keys())}. "
+                    f"Correct signature: async def {hook}(self, payload: PayloadType, "
+                    f"context: PluginContext[, extensions: Extensions]) -> ResultType",
                     plugin_name=plugin_name,
                 )
             )
@@ -484,6 +523,8 @@ class HookRef:
                     plugin_name=plugin_name,
                 )
             )
+
+        return len(params)
 
         # ========== OPTIONAL: Type Hint Validation ==========
         # Uncomment to enable strict type checking of payload and return types.
@@ -608,7 +649,16 @@ class HookRef:
         return self._hook
 
     @property
-    def hook(self) -> Callable[[PluginPayload, PluginContext], Awaitable[PluginResult]] | None:
+    def accepts_extensions(self) -> bool:
+        """Whether the hook method accepts extensions as a third argument.
+
+        Returns:
+            True if the hook signature has 3 parameters (payload, context, extensions).
+        """
+        return self._accepts_extensions
+
+    @property
+    def hook(self) -> Callable[..., Awaitable[PluginResult]] | None:
         """The hooking function that can be invoked within the reference.
 
         Returns:

--- a/cpex/framework/base.py
+++ b/cpex/framework/base.py
@@ -526,14 +526,6 @@ class HookRef:
 
         return len(params)
 
-        # ========== OPTIONAL: Type Hint Validation ==========
-        # Uncomment to enable strict type checking of payload and return types.
-        # This validates that type hints match the expected types from the hook registry.
-        # Pros: Catches type errors at plugin load time instead of runtime
-        # Cons: Requires all plugins to have type hints, adds validation overhead
-        #
-        # self._validate_type_hints(hook, func, params, plugin_name)
-
     def _validate_type_hints(self, hook: str, func: Callable, params: list, plugin_name: str) -> None:
         """Validate that type hints match expected payload and result types.
 

--- a/cpex/framework/cmf/__init__.py
+++ b/cpex/framework/cmf/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/cmf/__init__.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Common Message Format (CMF) Package.
+Provides the canonical, provider-agnostic message representation
+for interactions between users, agents, tools, and language models.
+"""

--- a/cpex/framework/cmf/message.py
+++ b/cpex/framework/cmf/message.py
@@ -19,7 +19,7 @@ compose them into the typed content-part hierarchy for message serialization.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Annotated, Iterator, Literal, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Annotated, Any, Iterator, Literal, Union
 
 # Third-Party
 from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, model_validator
@@ -263,6 +263,14 @@ class Resource(BaseModel):
 
     @model_validator(mode="after")
     def _check_content_blob_exclusion(self) -> Resource:
+        """Ensure content and blob are mutually exclusive.
+
+        Returns:
+            The validated Resource instance.
+
+        Raises:
+            ValueError: If both content and blob are set.
+        """
         if self.content is not None and self.blob is not None:
             raise ValueError("Resource cannot have both 'content' and 'blob' set")
         return self
@@ -309,6 +317,14 @@ class ResourceReference(BaseModel):
 
     @model_validator(mode="after")
     def _check_range_consistency(self) -> ResourceReference:
+        """Ensure range_end is not less than range_start.
+
+        Returns:
+            The validated ResourceReference instance.
+
+        Raises:
+            ValueError: If range_end < range_start.
+        """
         if self.range_start is not None and self.range_end is not None:
             if self.range_end < self.range_start:
                 raise ValueError(f"range_end ({self.range_end}) must be >= range_start ({self.range_start})")

--- a/cpex/framework/cmf/message.py
+++ b/cpex/framework/cmf/message.py
@@ -890,7 +890,7 @@ class Message(BaseModel):
         'get_weather'
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     schema_version: str = Field(default="2.0", description="Message schema version.")
     role: Role = Field(description="Who is speaking.")

--- a/cpex/framework/cmf/message.py
+++ b/cpex/framework/cmf/message.py
@@ -832,7 +832,7 @@ class Message(BaseModel):
         role: Who is speaking.
         content: List of typed content parts (multimodal).
         channel: Optional output classification.
-        extensions: Contextual metadata (identity, security, governance, etc.).
+        extensions: Optional contextual metadata (identity, security, governance).
 
     Examples:
         >>> msg = Message(

--- a/cpex/framework/cmf/message.py
+++ b/cpex/framework/cmf/message.py
@@ -896,12 +896,8 @@ class Message(BaseModel):
     role: Role = Field(description="Who is speaking.")
     content: list[ContentPartUnion] = Field(default_factory=list, description="List of typed content parts.")
     channel: Channel | None = Field(default=None, description="Optional output classification.")
-    extensions: Extensions | None = Field(
-        default=None,
-        description="Contextual metadata (identity, security, governance, etc.).",
-    )
 
-    def iter_views(self, hook: str | None = None) -> Iterator[MessageView]:
+    def iter_views(self, hook: str | None = None, extensions: Extensions | None = None) -> Iterator[MessageView]:
         """Decompose this message into individually addressable MessageViews.
 
         Yields one MessageView per content part. Each view provides a
@@ -938,7 +934,7 @@ class Message(BaseModel):
         """
         from cpex.framework.cmf.view import iter_views  # pylint: disable=import-outside-toplevel
 
-        return iter_views(self, hook=hook)
+        return iter_views(self, hook=hook, extensions=extensions)
 
 
 if TYPE_CHECKING:

--- a/cpex/framework/cmf/message.py
+++ b/cpex/framework/cmf/message.py
@@ -1,0 +1,881 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/cmf/message.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Common Message Format (CMF) message models.
+This module implements the canonical message representation for interactions
+between users, agents, tools, and language models. All models are frozen
+(immutable) and require model_copy() for modification, supporting the CMF's
+copy-on-write semantics and mutability tier enforcement.
+
+Domain objects (ToolCall, ImageSource, etc.) are standalone frozen models
+reusable across contexts. ContentPart wrappers (ToolCallContentPart, etc.)
+compose them into the typed content-part hierarchy for message serialization.
+"""
+
+# Standard
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Annotated, Iterator, TYPE_CHECKING, Union
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class Role(str, Enum):
+    """Closed-set enumeration of message roles.
+
+    Identifies WHO is speaking in a conversation turn.
+
+    Attributes:
+        SYSTEM: System-level instructions.
+        DEVELOPER: Developer-provided instructions.
+        USER: Human user input.
+        ASSISTANT: LLM/agent response.
+        TOOL: Tool execution result.
+
+    Examples:
+        >>> Role.USER
+        <Role.USER: 'user'>
+        >>> Role.USER.value
+        'user'
+        >>> Role("assistant")
+        <Role.ASSISTANT: 'assistant'>
+    """
+
+    SYSTEM = "system"
+    DEVELOPER = "developer"
+    USER = "user"
+    ASSISTANT = "assistant"
+    TOOL = "tool"
+
+
+class Channel(str, Enum):
+    """Closed-set enumeration of output channel types.
+
+    Classifies the kind of output a message represents, allowing
+    pipelines to route or filter messages by output type without
+    inspecting content.
+
+    Attributes:
+        ANALYSIS: Intermediate analytical output not intended as final response.
+        COMMENTARY: Meta-level observations about the task or process.
+        FINAL: Terminal response intended for delivery to the end consumer.
+
+    Examples:
+        >>> Channel.FINAL
+        <Channel.FINAL: 'final'>
+        >>> Channel("analysis")
+        <Channel.ANALYSIS: 'analysis'>
+    """
+
+    ANALYSIS = "analysis"
+    COMMENTARY = "commentary"
+    FINAL = "final"
+
+
+class ContentType(str, Enum):
+    """Closed-set enumeration of content part types.
+
+    Discriminator for the typed ContentPart hierarchy, identifying
+    the kind of content carried by each part of a multimodal message.
+
+    Attributes:
+        TEXT: Plain text content.
+        THINKING: Chain-of-thought reasoning.
+        TOOL_CALL: Tool/function invocation request.
+        TOOL_RESULT: Result from tool execution.
+        RESOURCE: Embedded resource with content (MCP).
+        RESOURCE_REF: Lightweight resource reference without embedded content.
+        PROMPT_REQUEST: Prompt template invocation request (MCP).
+        PROMPT_RESULT: Rendered prompt template result.
+        IMAGE: Image content (URL or base64).
+        VIDEO: Video content (URL or base64).
+        AUDIO: Audio content (URL or base64).
+        DOCUMENT: Document content (PDF, Word, etc.).
+
+    Examples:
+        >>> ContentType.TOOL_CALL
+        <ContentType.TOOL_CALL: 'tool_call'>
+        >>> ContentType("text")
+        <ContentType.TEXT: 'text'>
+    """
+
+    TEXT = "text"
+    THINKING = "thinking"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    RESOURCE = "resource"
+    RESOURCE_REF = "resource_ref"
+    PROMPT_REQUEST = "prompt_request"
+    PROMPT_RESULT = "prompt_result"
+    IMAGE = "image"
+    VIDEO = "video"
+    AUDIO = "audio"
+    DOCUMENT = "document"
+
+
+class ResourceType(str, Enum):
+    """Closed-set enumeration of resource types.
+
+    Attributes:
+        FILE: File-system resource.
+        BLOB: Binary large object.
+        URI: Generic URI-addressable resource.
+        DATABASE: Database entity.
+        API: API endpoint.
+        MEMORY: In-memory or ephemeral resource.
+        ARTIFACT: Produced artifact (generated output, build result).
+
+    Examples:
+        >>> ResourceType.FILE
+        <ResourceType.FILE: 'file'>
+        >>> ResourceType("database")
+        <ResourceType.DATABASE: 'database'>
+    """
+
+    FILE = "file"
+    BLOB = "blob"
+    URI = "uri"
+    DATABASE = "database"
+    API = "api"
+    MEMORY = "memory"
+    ARTIFACT = "artifact"
+
+
+# ---------------------------------------------------------------------------
+# Domain Objects (standalone, reusable across contexts)
+# ---------------------------------------------------------------------------
+
+
+class ToolCall(BaseModel):
+    """Normalized tool/function invocation request.
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        tool_call_id: Unique request correlation ID.
+        name: Tool name.
+        arguments: Arguments as a JSON-serializable dict.
+        namespace: Optional namespace for namespaced tools.
+
+    Examples:
+        >>> call = ToolCall(
+        ...     tool_call_id="tc_001",
+        ...     name="get_user",
+        ...     arguments={"user_id": "123"},
+        ... )
+        >>> call.name
+        'get_user'
+        >>> call.arguments
+        {'user_id': '123'}
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    tool_call_id: str = Field(description="Unique request correlation ID.")
+    name: str = Field(description="Tool name.")
+    arguments: dict[str, Any] = Field(default_factory=dict, description="Arguments as a JSON-serializable dict.")
+    namespace: str | None = Field(default=None, description="Namespace for namespaced tools.")
+
+
+class ToolResult(BaseModel):
+    """Result from tool execution.
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        tool_call_id: Correlation ID linking to the corresponding tool call.
+        tool_name: Name of the tool that was executed.
+        content: Result content, any JSON-serializable value.
+        is_error: Whether the result represents an error.
+
+    Examples:
+        >>> result = ToolResult(
+        ...     tool_call_id="tc_001",
+        ...     tool_name="get_user",
+        ...     content={"name": "Alice"},
+        ... )
+        >>> result.is_error
+        False
+        >>> result.tool_name
+        'get_user'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    tool_call_id: str = Field(description="Correlation ID linking to the corresponding tool call.")
+    tool_name: str = Field(description="Name of the tool that was executed.")
+    content: Any = Field(default=None, description="Result content, any JSON-serializable value.")
+    is_error: bool = Field(default=False, description="Whether the result represents an error.")
+
+
+class Resource(BaseModel):
+    """Embedded resource with content (MCP).
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        resource_request_id: Unique request correlation ID.
+        uri: Unique identifier in URI format.
+        name: Human-readable name.
+        description: What this resource contains.
+        resource_type: The kind of resource.
+        content: Text content if embedded.
+        blob: Binary content if embedded.
+        mime_type: MIME type of content.
+        size_bytes: Size information.
+        annotations: Metadata (classification, retention, etc.).
+        version: Version tracking.
+
+    Examples:
+        >>> res = Resource(
+        ...     resource_request_id="rr_001",
+        ...     uri="file:///data/report.csv",
+        ...     name="Q4 Report",
+        ...     resource_type=ResourceType.FILE,
+        ...     content="col1,col2\\n1,2",
+        ...     mime_type="text/csv",
+        ... )
+        >>> res.uri
+        'file:///data/report.csv'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    resource_request_id: str = Field(description="Unique request correlation ID.")
+    uri: str = Field(description="Unique identifier in URI format.")
+    name: str | None = Field(default=None, description="Human-readable name.")
+    description: str | None = Field(default=None, description="What this resource contains.")
+    resource_type: ResourceType = Field(description="The kind of resource.")
+    content: str | None = Field(default=None, description="Text content if embedded.")
+    blob: bytes | None = Field(default=None, description="Binary content if embedded.")
+    mime_type: str | None = Field(default=None, description="MIME type of content.")
+    size_bytes: int | None = Field(default=None, description="Size information.")
+    annotations: dict[str, Any] = Field(default_factory=dict, description="Metadata (classification, retention, etc.).")
+    version: str | None = Field(default=None, description="Version tracking.")
+
+
+class ResourceReference(BaseModel):
+    """Lightweight resource reference without embedded content.
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        resource_request_id: Correlation ID linking to the originating resource request.
+        uri: Resource URI.
+        name: Human-readable name.
+        resource_type: Type of resource.
+        range_start: Line number or byte offset for partial references.
+        range_end: End of range.
+        selector: CSS/XPath/JSONPath selector.
+
+    Examples:
+        >>> ref = ResourceReference(
+        ...     resource_request_id="rr_002",
+        ...     uri="db://users/42",
+        ...     resource_type=ResourceType.DATABASE,
+        ... )
+        >>> ref.uri
+        'db://users/42'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    resource_request_id: str = Field(description="Correlation ID linking to the originating resource request.")
+    uri: str = Field(description="Resource URI.")
+    name: str | None = Field(default=None, description="Human-readable name.")
+    resource_type: ResourceType = Field(description="Type of resource.")
+    range_start: int | None = Field(default=None, description="Line number or byte offset for partial references.")
+    range_end: int | None = Field(default=None, description="End of range.")
+    selector: str | None = Field(default=None, description="CSS/XPath/JSONPath selector.")
+
+
+class PromptRequest(BaseModel):
+    """Prompt template invocation request (MCP).
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        prompt_request_id: Request ID for correlation.
+        name: Prompt template name.
+        arguments: Arguments to pass to the template.
+        server_id: Source server for multi-server scenarios.
+
+    Examples:
+        >>> req = PromptRequest(
+        ...     prompt_request_id="pr_001",
+        ...     name="summarize",
+        ...     arguments={"text": "Long document..."},
+        ... )
+        >>> req.name
+        'summarize'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    prompt_request_id: str = Field(description="Request ID for correlation.")
+    name: str = Field(description="Prompt template name.")
+    arguments: dict[str, Any] = Field(default_factory=dict, description="Arguments to pass to the template.")
+    server_id: str | None = Field(default=None, description="Source server for multi-server scenarios.")
+
+
+class PromptResult(BaseModel):
+    """Rendered prompt template result.
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        prompt_request_id: ID of the corresponding prompt request.
+        prompt_name: Name of the prompt that was rendered.
+        messages: Rendered messages (prompts produce messages).
+        content: Single text result for simple prompts.
+        is_error: Whether rendering failed.
+        error_message: Error details if rendering failed.
+
+    Examples:
+        >>> result = PromptResult(
+        ...     prompt_request_id="pr_001",
+        ...     prompt_name="summarize",
+        ...     content="This document discusses...",
+        ... )
+        >>> result.is_error
+        False
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    prompt_request_id: str = Field(description="ID of the corresponding prompt request.")
+    prompt_name: str = Field(description="Name of the prompt that was rendered.")
+    messages: list[Any] = Field(
+        default_factory=list,
+        description="Rendered messages (prompts produce messages).",
+    )
+    content: str | None = Field(default=None, description="Single text result for simple prompts.")
+    is_error: bool = Field(default=False, description="Whether rendering failed.")
+    error_message: str | None = Field(default=None, description="Error details if rendering failed.")
+
+
+class ImageSource(BaseModel):
+    """Image source data.
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        type: Source type, either URL or base64-encoded.
+        data: URL or base64-encoded string.
+        media_type: MIME type (e.g., image/jpeg).
+
+    Examples:
+        >>> img = ImageSource(type="url", data="https://example.com/photo.jpg")
+        >>> img.type
+        'url'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    type: str = Field(description="Source type: 'url' or 'base64'.")
+    data: str = Field(description="URL or base64-encoded string.")
+    media_type: str | None = Field(default=None, description="MIME type (e.g., image/jpeg).")
+
+
+class VideoSource(BaseModel):
+    """Video source data.
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        type: Source type, either URL or base64-encoded.
+        data: URL or base64-encoded string.
+        media_type: MIME type (e.g., video/mp4).
+        duration_ms: Duration in milliseconds.
+
+    Examples:
+        >>> vid = VideoSource(type="url", data="https://example.com/clip.mp4")
+        >>> vid.type
+        'url'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    type: str = Field(description="Source type: 'url' or 'base64'.")
+    data: str = Field(description="URL or base64-encoded string.")
+    media_type: str | None = Field(default=None, description="MIME type (e.g., video/mp4).")
+    duration_ms: int | None = Field(default=None, description="Duration in milliseconds.")
+
+
+class AudioSource(BaseModel):
+    """Audio source data.
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        type: Source type, either URL or base64-encoded.
+        data: URL or base64-encoded string.
+        media_type: MIME type (e.g., audio/mp3).
+        duration_ms: Duration in milliseconds.
+
+    Examples:
+        >>> aud = AudioSource(type="url", data="https://example.com/track.mp3")
+        >>> aud.type
+        'url'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    type: str = Field(description="Source type: 'url' or 'base64'.")
+    data: str = Field(description="URL or base64-encoded string.")
+    media_type: str | None = Field(default=None, description="MIME type (e.g., audio/mp3).")
+    duration_ms: int | None = Field(default=None, description="Duration in milliseconds.")
+
+
+class DocumentSource(BaseModel):
+    """Document source data (PDF, Word, etc.).
+
+    Standalone domain object reusable outside of message content parts.
+
+    Attributes:
+        type: Source type, either URL or base64-encoded.
+        data: URL or base64-encoded string.
+        media_type: MIME type (e.g., application/pdf).
+        title: Document title.
+
+    Examples:
+        >>> doc = DocumentSource(
+        ...     type="base64",
+        ...     data="JVBERi0xLjQ...",
+        ...     media_type="application/pdf",
+        ...     title="Annual Report",
+        ... )
+        >>> doc.title
+        'Annual Report'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    type: str = Field(description="Source type: 'url' or 'base64'.")
+    data: str = Field(description="URL or base64-encoded string.")
+    media_type: str | None = Field(default=None, description="MIME type (e.g., application/pdf).")
+    title: str | None = Field(default=None, description="Document title.")
+
+
+# ---------------------------------------------------------------------------
+# Content Parts (ContentPart base + wrappers)
+# ---------------------------------------------------------------------------
+
+
+class ContentPart(BaseModel):
+    """Base class for all content parts in a CMF message.
+
+    Frozen by design — subclasses inherit immutability. Consumers must
+    use model_copy(update={...}) to create modified copies.
+
+    Attributes:
+        content_type: Discriminator identifying the concrete content type.
+
+    Examples:
+        >>> part = TextContent(text="hello")
+        >>> isinstance(part, ContentPart)
+        True
+        >>> part.content_type
+        <ContentType.TEXT: 'text'>
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    content_type: ContentType = Field(description="Content type discriminator.")
+
+
+class TextContent(ContentPart):
+    """Plain text content part.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.TEXT.
+        text: The text content.
+
+    Examples:
+        >>> part = TextContent(text="Hello, world!")
+        >>> part.content_type
+        <ContentType.TEXT: 'text'>
+        >>> part.text
+        'Hello, world!'
+        >>> modified = part.model_copy(update={"text": "Updated"})
+        >>> (part.text, modified.text)
+        ('Hello, world!', 'Updated')
+    """
+
+    content_type: ContentType = Field(default=ContentType.TEXT, description="Content type discriminator.")
+    text: str = Field(description="The text content.")
+
+
+class ThinkingContent(ContentPart):
+    """Chain-of-thought reasoning content part.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.THINKING.
+        text: The reasoning text.
+
+    Examples:
+        >>> part = ThinkingContent(text="Let me analyze this...")
+        >>> part.content_type
+        <ContentType.THINKING: 'thinking'>
+    """
+
+    content_type: ContentType = Field(default=ContentType.THINKING, description="Content type discriminator.")
+    text: str = Field(description="The reasoning text.")
+
+
+class ToolCallContentPart(ContentPart):
+    """Content part wrapping a ToolCall domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.TOOL_CALL.
+        content: The wrapped ToolCall.
+
+    Examples:
+        >>> part = ToolCallContentPart(
+        ...     content=ToolCall(tool_call_id="tc_001", name="search", arguments={"q": "test"}),
+        ... )
+        >>> part.content.name
+        'search'
+    """
+
+    content_type: ContentType = Field(default=ContentType.TOOL_CALL, description="Content type discriminator.")
+    content: ToolCall = Field(description="The wrapped ToolCall.")
+
+
+class ToolResultContentPart(ContentPart):
+    """Content part wrapping a ToolResult domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.TOOL_RESULT.
+        content: The wrapped ToolResult.
+
+    Examples:
+        >>> part = ToolResultContentPart(
+        ...     content=ToolResult(tool_call_id="tc_001", tool_name="search", content="Found 10 results"),
+        ... )
+        >>> part.content.tool_name
+        'search'
+    """
+
+    content_type: ContentType = Field(default=ContentType.TOOL_RESULT, description="Content type discriminator.")
+    content: ToolResult = Field(description="The wrapped ToolResult.")
+
+
+class ResourceContentPart(ContentPart):
+    """Content part wrapping a Resource domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.RESOURCE.
+        content: The wrapped Resource.
+
+    Examples:
+        >>> part = ResourceContentPart(
+        ...     content=Resource(resource_request_id="rr_001", uri="file:///data.txt", resource_type=ResourceType.FILE),
+        ... )
+        >>> part.content.uri
+        'file:///data.txt'
+    """
+
+    content_type: ContentType = Field(default=ContentType.RESOURCE, description="Content type discriminator.")
+    content: Resource = Field(description="The wrapped Resource.")
+
+
+class ResourceRefContentPart(ContentPart):
+    """Content part wrapping a ResourceReference domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.RESOURCE_REF.
+        content: The wrapped ResourceReference.
+
+    Examples:
+        >>> part = ResourceRefContentPart(
+        ...     content=ResourceReference(resource_request_id="rr_002", uri="db://users/42", resource_type=ResourceType.DATABASE),
+        ... )
+        >>> part.content.uri
+        'db://users/42'
+    """
+
+    content_type: ContentType = Field(default=ContentType.RESOURCE_REF, description="Content type discriminator.")
+    content: ResourceReference = Field(description="The wrapped ResourceReference.")
+
+
+class PromptRequestContentPart(ContentPart):
+    """Content part wrapping a PromptRequest domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.PROMPT_REQUEST.
+        content: The wrapped PromptRequest.
+
+    Examples:
+        >>> part = PromptRequestContentPart(
+        ...     content=PromptRequest(prompt_request_id="pr_001", name="summarize"),
+        ... )
+        >>> part.content.name
+        'summarize'
+    """
+
+    content_type: ContentType = Field(default=ContentType.PROMPT_REQUEST, description="Content type discriminator.")
+    content: PromptRequest = Field(description="The wrapped PromptRequest.")
+
+
+class PromptResultContentPart(ContentPart):
+    """Content part wrapping a PromptResult domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.PROMPT_RESULT.
+        content: The wrapped PromptResult.
+
+    Examples:
+        >>> part = PromptResultContentPart(
+        ...     content=PromptResult(prompt_request_id="pr_001", prompt_name="summarize"),
+        ... )
+        >>> part.content.prompt_name
+        'summarize'
+    """
+
+    content_type: ContentType = Field(default=ContentType.PROMPT_RESULT, description="Content type discriminator.")
+    content: PromptResult = Field(description="The wrapped PromptResult.")
+
+
+class ImageContentPart(ContentPart):
+    """Content part wrapping an ImageSource domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.IMAGE.
+        content: The wrapped ImageSource.
+
+    Examples:
+        >>> part = ImageContentPart(
+        ...     content=ImageSource(type="url", data="https://example.com/photo.jpg"),
+        ... )
+        >>> part.content.type
+        'url'
+    """
+
+    content_type: ContentType = Field(default=ContentType.IMAGE, description="Content type discriminator.")
+    content: ImageSource = Field(description="The wrapped ImageSource.")
+
+
+class VideoContentPart(ContentPart):
+    """Content part wrapping a VideoSource domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.VIDEO.
+        content: The wrapped VideoSource.
+
+    Examples:
+        >>> part = VideoContentPart(
+        ...     content=VideoSource(type="url", data="https://example.com/clip.mp4"),
+        ... )
+        >>> part.content.type
+        'url'
+    """
+
+    content_type: ContentType = Field(default=ContentType.VIDEO, description="Content type discriminator.")
+    content: VideoSource = Field(description="The wrapped VideoSource.")
+
+
+class AudioContentPart(ContentPart):
+    """Content part wrapping an AudioSource domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.AUDIO.
+        content: The wrapped AudioSource.
+
+    Examples:
+        >>> part = AudioContentPart(
+        ...     content=AudioSource(type="url", data="https://example.com/track.mp3"),
+        ... )
+        >>> part.content.type
+        'url'
+    """
+
+    content_type: ContentType = Field(default=ContentType.AUDIO, description="Content type discriminator.")
+    content: AudioSource = Field(description="The wrapped AudioSource.")
+
+
+class DocumentContentPart(ContentPart):
+    """Content part wrapping a DocumentSource domain object.
+
+    Attributes:
+        content_type: Discriminator, always ContentType.DOCUMENT.
+        content: The wrapped DocumentSource.
+
+    Examples:
+        >>> part = DocumentContentPart(
+        ...     content=DocumentSource(type="base64", data="JVBERi0xLjQ...", media_type="application/pdf"),
+        ... )
+        >>> part.content.media_type
+        'application/pdf'
+    """
+
+    content_type: ContentType = Field(default=ContentType.DOCUMENT, description="Content type discriminator.")
+    content: DocumentSource = Field(description="The wrapped DocumentSource.")
+
+
+# ---------------------------------------------------------------------------
+# ContentPart Discriminated Union
+# ---------------------------------------------------------------------------
+
+
+def _content_type_discriminator(v: Any) -> str:
+    """Extract the content_type discriminator value from a content part.
+
+    Supports both dict (during deserialization) and model instance access.
+
+    Args:
+        v: A content part as a dict or model instance.
+
+    Returns:
+        The content_type string value for discriminator routing.
+    """
+    if isinstance(v, dict):
+        return v.get("content_type", "text")
+    return v.content_type.value if hasattr(v, "content_type") else "text"
+
+
+ContentPartUnion = Annotated[
+    Union[
+        Annotated[TextContent, Tag("text")],
+        Annotated[ThinkingContent, Tag("thinking")],
+        Annotated[ToolCallContentPart, Tag("tool_call")],
+        Annotated[ToolResultContentPart, Tag("tool_result")],
+        Annotated[ResourceContentPart, Tag("resource")],
+        Annotated[ResourceRefContentPart, Tag("resource_ref")],
+        Annotated[PromptRequestContentPart, Tag("prompt_request")],
+        Annotated[PromptResultContentPart, Tag("prompt_result")],
+        Annotated[ImageContentPart, Tag("image")],
+        Annotated[VideoContentPart, Tag("video")],
+        Annotated[AudioContentPart, Tag("audio")],
+        Annotated[DocumentContentPart, Tag("document")],
+    ],
+    Discriminator(_content_type_discriminator),
+]
+"""Discriminated union of all content part types.
+
+Pydantic uses the content_type field to resolve the correct subclass
+during validation and deserialization.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Message
+# ---------------------------------------------------------------------------
+
+
+class Message(BaseModel):
+    """Canonical CMF message representing a single turn in a conversation.
+
+    A Message is the storage and wire format. It preserves the structure
+    exactly as the LLM or framework sent it. For policy evaluation and
+    inspection, use MessageView (via iter_views()) which decomposes the
+    message into individually addressable, uniformly accessible parts.
+
+    All Message instances are frozen. To create a modified copy, use
+    model_copy(update={...}).
+
+    Attributes:
+        schema_version: Message schema version.
+        role: Who is speaking.
+        content: List of typed content parts (multimodal).
+        channel: Optional output classification.
+        extensions: Contextual metadata (identity, security, governance, etc.).
+
+    Examples:
+        >>> msg = Message(
+        ...     role=Role.USER,
+        ...     content=[TextContent(text="What is the weather?")],
+        ... )
+        >>> msg.role
+        <Role.USER: 'user'>
+        >>> msg.content[0].text
+        'What is the weather?'
+        >>> msg.schema_version
+        '2.0'
+
+        >>> # Frozen: modifications require model_copy
+        >>> updated = msg.model_copy(update={"channel": Channel.FINAL})
+        >>> updated.channel
+        <Channel.FINAL: 'final'>
+        >>> msg.channel is None
+        True
+
+        >>> # Multi-part assistant message
+        >>> assistant_msg = Message(
+        ...     role=Role.ASSISTANT,
+        ...     content=[
+        ...         ThinkingContent(text="I should check the weather API."),
+        ...         TextContent(text="Let me look that up."),
+        ...         ToolCallContentPart(
+        ...             content=ToolCall(
+        ...                 tool_call_id="tc_001",
+        ...                 name="get_weather",
+        ...                 arguments={"city": "London"},
+        ...             ),
+        ...         ),
+        ...     ],
+        ... )
+        >>> len(assistant_msg.content)
+        3
+        >>> assistant_msg.content[2].content.name
+        'get_weather'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    schema_version: str = Field(default="2.0", description="Message schema version.")
+    role: Role = Field(description="Who is speaking.")
+    content: list[ContentPartUnion] = Field(default_factory=list, description="List of typed content parts.")
+    channel: Channel | None = Field(default=None, description="Optional output classification.")
+    extensions: Any = Field(
+        default=None,
+        description="Contextual metadata (identity, security, governance, etc.).",
+    )
+
+    def iter_views(self) -> Iterator[MessageView]:
+        """Decompose this message into individually addressable MessageViews.
+
+        Yields one MessageView per content part. Each view provides a
+        uniform interface for policy evaluation regardless of content type.
+
+        Returns:
+            An iterator of MessageView objects.
+
+        Examples:
+            >>> msg = Message(
+            ...     role=Role.ASSISTANT,
+            ...     content=[
+            ...         TextContent(text="Let me check."),
+            ...         ToolCallContentPart(
+            ...             content=ToolCall(
+            ...                 tool_call_id="tc_001",
+            ...                 name="get_weather",
+            ...                 arguments={"city": "London"},
+            ...             ),
+            ...         ),
+            ...     ],
+            ... )
+            >>> views = list(msg.iter_views())
+            >>> len(views)
+            2
+            >>> views[0].kind.value
+            'text'
+            >>> views[1].name
+            'get_weather'
+        """
+        from cpex.framework.cmf.view import iter_views  # pylint: disable=import-outside-toplevel
+
+        return iter_views(self)
+
+
+if TYPE_CHECKING:
+    from cpex.framework.cmf.view import MessageView

--- a/cpex/framework/cmf/message.py
+++ b/cpex/framework/cmf/message.py
@@ -19,10 +19,13 @@ compose them into the typed content-part hierarchy for message serialization.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Annotated, Iterator, TYPE_CHECKING, Union
+from typing import Any, Annotated, Iterator, Literal, TYPE_CHECKING, Union
 
 # Third-Party
-from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag
+from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, model_validator
+
+# First-Party
+from cpex.framework.extensions.extensions import Extensions
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -257,6 +260,13 @@ class Resource(BaseModel):
     resource_type: ResourceType = Field(description="The kind of resource.")
     content: str | None = Field(default=None, description="Text content if embedded.")
     blob: bytes | None = Field(default=None, description="Binary content if embedded.")
+
+    @model_validator(mode="after")
+    def _check_content_blob_exclusion(self) -> Resource:
+        if self.content is not None and self.blob is not None:
+            raise ValueError("Resource cannot have both 'content' and 'blob' set")
+        return self
+
     mime_type: str | None = Field(default=None, description="MIME type of content.")
     size_bytes: int | None = Field(default=None, description="Size information.")
     annotations: dict[str, Any] = Field(default_factory=dict, description="Metadata (classification, retention, etc.).")
@@ -296,6 +306,13 @@ class ResourceReference(BaseModel):
     range_start: int | None = Field(default=None, description="Line number or byte offset for partial references.")
     range_end: int | None = Field(default=None, description="End of range.")
     selector: str | None = Field(default=None, description="CSS/XPath/JSONPath selector.")
+
+    @model_validator(mode="after")
+    def _check_range_consistency(self) -> ResourceReference:
+        if self.range_start is not None and self.range_end is not None:
+            if self.range_end < self.range_start:
+                raise ValueError(f"range_end ({self.range_end}) must be >= range_start ({self.range_start})")
+        return self
 
 
 class PromptRequest(BaseModel):
@@ -354,7 +371,7 @@ class PromptResult(BaseModel):
 
     prompt_request_id: str = Field(description="ID of the corresponding prompt request.")
     prompt_name: str = Field(description="Name of the prompt that was rendered.")
-    messages: list[Any] = Field(
+    messages: list[Message] = Field(
         default_factory=list,
         description="Rendered messages (prompts produce messages).",
     )
@@ -381,7 +398,7 @@ class ImageSource(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    type: str = Field(description="Source type: 'url' or 'base64'.")
+    type: Literal["url", "base64"] = Field(description="Source type: 'url' or 'base64'.")
     data: str = Field(description="URL or base64-encoded string.")
     media_type: str | None = Field(default=None, description="MIME type (e.g., image/jpeg).")
 
@@ -405,7 +422,7 @@ class VideoSource(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    type: str = Field(description="Source type: 'url' or 'base64'.")
+    type: Literal["url", "base64"] = Field(description="Source type: 'url' or 'base64'.")
     data: str = Field(description="URL or base64-encoded string.")
     media_type: str | None = Field(default=None, description="MIME type (e.g., video/mp4).")
     duration_ms: int | None = Field(default=None, description="Duration in milliseconds.")
@@ -430,7 +447,7 @@ class AudioSource(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    type: str = Field(description="Source type: 'url' or 'base64'.")
+    type: Literal["url", "base64"] = Field(description="Source type: 'url' or 'base64'.")
     data: str = Field(description="URL or base64-encoded string.")
     media_type: str | None = Field(default=None, description="MIME type (e.g., audio/mp3).")
     duration_ms: int | None = Field(default=None, description="Duration in milliseconds.")
@@ -460,7 +477,7 @@ class DocumentSource(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    type: str = Field(description="Source type: 'url' or 'base64'.")
+    type: Literal["url", "base64"] = Field(description="Source type: 'url' or 'base64'.")
     data: str = Field(description="URL or base64-encoded string.")
     media_type: str | None = Field(default=None, description="MIME type (e.g., application/pdf).")
     title: str | None = Field(default=None, description="Document title.")
@@ -511,7 +528,7 @@ class TextContent(ContentPart):
         ('Hello, world!', 'Updated')
     """
 
-    content_type: ContentType = Field(default=ContentType.TEXT, description="Content type discriminator.")
+    content_type: Literal[ContentType.TEXT] = Field(default=ContentType.TEXT, description="Content type discriminator.")
     text: str = Field(description="The text content.")
 
 
@@ -528,7 +545,9 @@ class ThinkingContent(ContentPart):
         <ContentType.THINKING: 'thinking'>
     """
 
-    content_type: ContentType = Field(default=ContentType.THINKING, description="Content type discriminator.")
+    content_type: Literal[ContentType.THINKING] = Field(
+        default=ContentType.THINKING, description="Content type discriminator."
+    )
     text: str = Field(description="The reasoning text.")
 
 
@@ -547,7 +566,9 @@ class ToolCallContentPart(ContentPart):
         'search'
     """
 
-    content_type: ContentType = Field(default=ContentType.TOOL_CALL, description="Content type discriminator.")
+    content_type: Literal[ContentType.TOOL_CALL] = Field(
+        default=ContentType.TOOL_CALL, description="Content type discriminator."
+    )
     content: ToolCall = Field(description="The wrapped ToolCall.")
 
 
@@ -566,7 +587,9 @@ class ToolResultContentPart(ContentPart):
         'search'
     """
 
-    content_type: ContentType = Field(default=ContentType.TOOL_RESULT, description="Content type discriminator.")
+    content_type: Literal[ContentType.TOOL_RESULT] = Field(
+        default=ContentType.TOOL_RESULT, description="Content type discriminator."
+    )
     content: ToolResult = Field(description="The wrapped ToolResult.")
 
 
@@ -585,7 +608,9 @@ class ResourceContentPart(ContentPart):
         'file:///data.txt'
     """
 
-    content_type: ContentType = Field(default=ContentType.RESOURCE, description="Content type discriminator.")
+    content_type: Literal[ContentType.RESOURCE] = Field(
+        default=ContentType.RESOURCE, description="Content type discriminator."
+    )
     content: Resource = Field(description="The wrapped Resource.")
 
 
@@ -604,7 +629,9 @@ class ResourceRefContentPart(ContentPart):
         'db://users/42'
     """
 
-    content_type: ContentType = Field(default=ContentType.RESOURCE_REF, description="Content type discriminator.")
+    content_type: Literal[ContentType.RESOURCE_REF] = Field(
+        default=ContentType.RESOURCE_REF, description="Content type discriminator."
+    )
     content: ResourceReference = Field(description="The wrapped ResourceReference.")
 
 
@@ -623,7 +650,9 @@ class PromptRequestContentPart(ContentPart):
         'summarize'
     """
 
-    content_type: ContentType = Field(default=ContentType.PROMPT_REQUEST, description="Content type discriminator.")
+    content_type: Literal[ContentType.PROMPT_REQUEST] = Field(
+        default=ContentType.PROMPT_REQUEST, description="Content type discriminator."
+    )
     content: PromptRequest = Field(description="The wrapped PromptRequest.")
 
 
@@ -642,7 +671,9 @@ class PromptResultContentPart(ContentPart):
         'summarize'
     """
 
-    content_type: ContentType = Field(default=ContentType.PROMPT_RESULT, description="Content type discriminator.")
+    content_type: Literal[ContentType.PROMPT_RESULT] = Field(
+        default=ContentType.PROMPT_RESULT, description="Content type discriminator."
+    )
     content: PromptResult = Field(description="The wrapped PromptResult.")
 
 
@@ -661,7 +692,9 @@ class ImageContentPart(ContentPart):
         'url'
     """
 
-    content_type: ContentType = Field(default=ContentType.IMAGE, description="Content type discriminator.")
+    content_type: Literal[ContentType.IMAGE] = Field(
+        default=ContentType.IMAGE, description="Content type discriminator."
+    )
     content: ImageSource = Field(description="The wrapped ImageSource.")
 
 
@@ -680,7 +713,9 @@ class VideoContentPart(ContentPart):
         'url'
     """
 
-    content_type: ContentType = Field(default=ContentType.VIDEO, description="Content type discriminator.")
+    content_type: Literal[ContentType.VIDEO] = Field(
+        default=ContentType.VIDEO, description="Content type discriminator."
+    )
     content: VideoSource = Field(description="The wrapped VideoSource.")
 
 
@@ -699,7 +734,9 @@ class AudioContentPart(ContentPart):
         'url'
     """
 
-    content_type: ContentType = Field(default=ContentType.AUDIO, description="Content type discriminator.")
+    content_type: Literal[ContentType.AUDIO] = Field(
+        default=ContentType.AUDIO, description="Content type discriminator."
+    )
     content: AudioSource = Field(description="The wrapped AudioSource.")
 
 
@@ -718,7 +755,9 @@ class DocumentContentPart(ContentPart):
         'application/pdf'
     """
 
-    content_type: ContentType = Field(default=ContentType.DOCUMENT, description="Content type discriminator.")
+    content_type: Literal[ContentType.DOCUMENT] = Field(
+        default=ContentType.DOCUMENT, description="Content type discriminator."
+    )
     content: DocumentSource = Field(description="The wrapped DocumentSource.")
 
 
@@ -739,8 +778,13 @@ def _content_type_discriminator(v: Any) -> str:
         The content_type string value for discriminator routing.
     """
     if isinstance(v, dict):
-        return v.get("content_type", "text")
-    return v.content_type.value if hasattr(v, "content_type") else "text"
+        ct = v.get("content_type")
+        if ct is None:
+            raise ValueError("Missing 'content_type' discriminator in content part dict")
+        return ct
+    if not hasattr(v, "content_type"):
+        raise ValueError(f"Content part {type(v).__name__} missing 'content_type' attribute")
+    return v.content_type.value
 
 
 ContentPartUnion = Annotated[
@@ -836,16 +880,20 @@ class Message(BaseModel):
     role: Role = Field(description="Who is speaking.")
     content: list[ContentPartUnion] = Field(default_factory=list, description="List of typed content parts.")
     channel: Channel | None = Field(default=None, description="Optional output classification.")
-    extensions: Any = Field(
+    extensions: Extensions | None = Field(
         default=None,
         description="Contextual metadata (identity, security, governance, etc.).",
     )
 
-    def iter_views(self) -> Iterator[MessageView]:
+    def iter_views(self, hook: str | None = None) -> Iterator[MessageView]:
         """Decompose this message into individually addressable MessageViews.
 
         Yields one MessageView per content part. Each view provides a
         uniform interface for policy evaluation regardless of content type.
+
+        Args:
+            hook: Optional hook location string (e.g., "llm_input",
+                "tool_post_invoke") to attach to each view.
 
         Returns:
             An iterator of MessageView objects.
@@ -874,7 +922,7 @@ class Message(BaseModel):
         """
         from cpex.framework.cmf.view import iter_views  # pylint: disable=import-outside-toplevel
 
-        return iter_views(self)
+        return iter_views(self, hook=hook)
 
 
 if TYPE_CHECKING:

--- a/cpex/framework/cmf/view.py
+++ b/cpex/framework/cmf/view.py
@@ -734,6 +734,13 @@ class MessageView:
 
         Capability: read_headers.
 
+        .. note::
+           This returns raw headers including sensitive values
+           (Authorization, Cookie, X-API-Key). This is by design —
+           plugins with ``read_headers`` capability are trusted to
+           see them. Sensitive headers are only stripped in
+           ``to_dict()`` serialization, not in direct property access.
+
         Returns:
             Read-only mapping of header name to value.
         """

--- a/cpex/framework/cmf/view.py
+++ b/cpex/framework/cmf/view.py
@@ -210,7 +210,7 @@ class MessageView:
         True
     """
 
-    __slots__ = ("_part", "_kind", "_message", "_hook")
+    __slots__ = ("_part", "_kind", "_message", "_extensions", "_hook")
 
     def __init__(
         self,
@@ -218,19 +218,23 @@ class MessageView:
         kind: ViewKind,
         message: Message,
         hook: str | None = None,
+        extensions: Any = None,
     ) -> None:
         """Initialize a MessageView.
 
         Args:
             part: The underlying content part.
             kind: The kind of content.
-            message: The parent message (for role and extensions access).
+            message: The parent message (for role access).
             hook: The hook location where this view is being evaluated
                 (e.g., "llm_input", "tool_post_invoke"). None if unset.
+            extensions: The Extensions object, passed separately from the
+                message for capability-gated filtering.
         """
         self._part = part
         self._kind = kind
         self._message = message
+        self._extensions = extensions
         self._hook = hook
 
     # =========================================================================
@@ -631,8 +635,8 @@ class MessageView:
     # =========================================================================
 
     def _ext(self) -> Any:
-        """Get the message extensions, or None."""
-        return self._message.extensions
+        """Get the extensions, or None."""
+        return self._extensions
 
     # --- Base tier (no capability required) ---
 
@@ -1169,7 +1173,7 @@ class MessageView:
 # ---------------------------------------------------------------------------
 
 
-def iter_views(message: Message, hook: str | None = None) -> Iterator[MessageView]:
+def iter_views(message: Message, hook: str | None = None, extensions: Any = None) -> Iterator[MessageView]:
     """Iterate over a message yielding one MessageView per content part.
 
     Memory-efficient: views are yielded one at a time and hold only
@@ -1216,4 +1220,4 @@ def iter_views(message: Message, hook: str | None = None) -> Iterator[MessageVie
         if kind is None:
             logger.warning("Unknown content type %r in iter_views", part.content_type)
             raise ValueError(f"Unknown content type: {part.content_type!r}")
-        yield MessageView(part, kind, message, hook=hook)
+        yield MessageView(part, kind, message, hook=hook, extensions=extensions)

--- a/cpex/framework/cmf/view.py
+++ b/cpex/framework/cmf/view.py
@@ -14,9 +14,11 @@ content part and message extensions directly.
 
 # Standard
 import json
+import logging
 import re
 from enum import Enum
-from typing import Any, Iterator
+from types import MappingProxyType
+from typing import Any, Iterator, Mapping
 
 # First-Party
 from cpex.framework.cmf.message import (
@@ -31,6 +33,8 @@ from cpex.framework.extensions.security import (
     ObjectSecurityProfile,
     SubjectExtension,
 )
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -123,6 +127,21 @@ _CONTENT_TYPE_TO_VIEW_KIND: dict[ContentType, ViewKind] = {
     ContentType.DOCUMENT: ViewKind.DOCUMENT,
 }
 
+_ACTION_MAP: dict[ViewKind, ViewAction] = {
+    ViewKind.TOOL_CALL: ViewAction.EXECUTE,
+    ViewKind.TOOL_RESULT: ViewAction.RECEIVE,
+    ViewKind.RESOURCE: ViewAction.READ,
+    ViewKind.RESOURCE_REF: ViewAction.READ,
+    ViewKind.PROMPT_REQUEST: ViewAction.INVOKE,
+    ViewKind.PROMPT_RESULT: ViewAction.RECEIVE,
+}
+
+# Kinds whose action depends on message direction (role)
+_DIRECTION_DEPENDENT_KINDS = frozenset({
+    ViewKind.TEXT, ViewKind.THINKING,
+    ViewKind.IMAGE, ViewKind.VIDEO, ViewKind.AUDIO, ViewKind.DOCUMENT,
+})
+
 # Sensitive headers stripped during serialization
 _SENSITIVE_HEADERS = frozenset({"authorization", "cookie", "x-api-key"})
 
@@ -185,19 +204,28 @@ class MessageView:
         True
     """
 
-    __slots__ = ("_part", "_kind", "_message")
+    __slots__ = ("_part", "_kind", "_message", "_hook")
 
-    def __init__(self, part: ContentPart, kind: ViewKind, message: Message) -> None:
+    def __init__(
+        self,
+        part: ContentPart,
+        kind: ViewKind,
+        message: Message,
+        hook: str | None = None,
+    ) -> None:
         """Initialize a MessageView.
 
         Args:
             part: The underlying content part.
             kind: The kind of content.
             message: The parent message (for role and extensions access).
+            hook: The hook location where this view is being evaluated
+                (e.g., "llm_input", "tool_post_invoke"). None if unset.
         """
         self._part = part
         self._kind = kind
         self._message = message
+        self._hook = hook
 
     # =========================================================================
     # Internal Helpers
@@ -239,6 +267,19 @@ class MessageView:
             The Role (user, assistant, system, developer, tool).
         """
         return self._message.role
+
+    @property
+    def hook(self) -> str | None:
+        """The hook location where this view is being evaluated.
+
+        Indicates where in the pipeline the evaluation is occurring
+        (e.g., "llm_input", "llm_output", "tool_pre_invoke",
+        "tool_post_invoke"). None if not set.
+
+        Returns:
+            Hook location string or None.
+        """
+        return self._hook
 
     @property
     def raw(self) -> ContentPart:
@@ -355,24 +396,22 @@ class MessageView:
     def action(self) -> ViewAction:
         """The semantic action this view represents.
 
+        For content kinds like text and media, the action depends on
+        the message role: SEND for user/system/developer input,
+        GENERATE for assistant output, RECEIVE for tool output.
+
         Returns:
             A ViewAction value.
         """
-        _ACTION_MAP: dict[ViewKind, ViewAction] = {
-            ViewKind.TEXT: ViewAction.SEND,
-            ViewKind.THINKING: ViewAction.GENERATE,
-            ViewKind.TOOL_CALL: ViewAction.EXECUTE,
-            ViewKind.TOOL_RESULT: ViewAction.RECEIVE,
-            ViewKind.RESOURCE: ViewAction.READ,
-            ViewKind.RESOURCE_REF: ViewAction.READ,
-            ViewKind.PROMPT_REQUEST: ViewAction.INVOKE,
-            ViewKind.PROMPT_RESULT: ViewAction.GENERATE,
-            ViewKind.IMAGE: ViewAction.SEND,
-            ViewKind.VIDEO: ViewAction.SEND,
-            ViewKind.AUDIO: ViewAction.SEND,
-            ViewKind.DOCUMENT: ViewAction.SEND,
-        }
-        return _ACTION_MAP.get(self._kind, ViewAction.SEND)
+        fixed = _ACTION_MAP.get(self._kind)
+        if fixed is not None:
+            return fixed
+        role = self._message.role
+        if role == Role.ASSISTANT:
+            return ViewAction.GENERATE
+        if role == Role.TOOL:
+            return ViewAction.RECEIVE
+        return ViewAction.SEND
 
     @property
     def args(self) -> dict[str, Any] | None:
@@ -521,7 +560,7 @@ class MessageView:
             return True
         if self._kind in (ViewKind.TOOL_RESULT, ViewKind.PROMPT_RESULT, ViewKind.RESOURCE):
             return False
-        return self._message.role in (Role.USER, Role.SYSTEM, Role.DEVELOPER, Role.TOOL)
+        return self._message.role in (Role.USER, Role.SYSTEM, Role.DEVELOPER)
 
     @property
     def is_post(self) -> bool:
@@ -534,7 +573,7 @@ class MessageView:
             return True
         if self._kind in (ViewKind.TOOL_CALL, ViewKind.PROMPT_REQUEST, ViewKind.RESOURCE_REF):
             return False
-        return self._message.role == Role.ASSISTANT
+        return self._message.role in (Role.ASSISTANT, Role.TOOL)
 
     @property
     def is_tool(self) -> bool:
@@ -680,18 +719,18 @@ class MessageView:
     # --- read_headers ---
 
     @property
-    def headers(self) -> dict[str, str]:
+    def headers(self) -> Mapping[str, str]:
         """HTTP headers associated with the request.
 
         Capability: read_headers.
 
         Returns:
-            Dict of header name to value.
+            Read-only mapping of header name to value.
         """
         ext = self._ext()
         if ext and ext.http:
-            return ext.http.headers
-        return {}
+            return MappingProxyType(ext.http.headers)
+        return MappingProxyType({})
 
     # --- read_labels ---
 
@@ -939,10 +978,13 @@ class MessageView:
         view_uri = self.uri
         if not view_uri:
             return False
-        regex = pattern.replace("**", "<<<DOUBLE>>>")
-        regex = regex.replace("*", "[^/]*")
-        regex = regex.replace("<<<DOUBLE>>>", ".*")
-        regex = f"^{regex}$"
+        # Split on ** first, then * within each segment, escaping literals
+        parts = pattern.split("**")
+        regex_parts = []
+        for part in parts:
+            sub_parts = part.split("*")
+            regex_parts.append("[^/]*".join(re.escape(s) for s in sub_parts))
+        regex = f"^{'.*'.join(regex_parts)}$"
         return bool(re.match(regex, view_uri))
 
     def has_content(self) -> bool:
@@ -978,6 +1020,9 @@ class MessageView:
             "action": self.action.value,
         }
 
+        if self._hook is not None:
+            result["hook"] = self._hook
+
         if self.uri:
             result["uri"] = self.uri
         if self.name:
@@ -987,9 +1032,11 @@ class MessageView:
             text = self.content
             if text is not None:
                 result["content"] = text
-            size = self.size_bytes
-            if size is not None:
-                result["size_bytes"] = size
+                result["size_bytes"] = len(text.encode("utf-8"))
+            else:
+                size = self.size_bytes
+                if size is not None:
+                    result["size_bytes"] = size
 
         if self.mime_type:
             result["mime_type"] = self.mime_type
@@ -1106,8 +1153,9 @@ class MessageView:
         """
         role_part = f", role={self._message.role.value}"
         uri_part = f", uri={self.uri}" if self.uri else ""
+        hook_part = f", hook={self._hook}" if self._hook else ""
         direction = "pre" if self.is_pre else "post" if self.is_post else "?"
-        return f"MessageView(kind={self._kind.value}{role_part}, {direction}{uri_part})"
+        return f"MessageView(kind={self._kind.value}{role_part}, {direction}{uri_part}{hook_part})"
 
 
 # ---------------------------------------------------------------------------
@@ -1115,7 +1163,7 @@ class MessageView:
 # ---------------------------------------------------------------------------
 
 
-def iter_views(message: Message) -> Iterator[MessageView]:
+def iter_views(message: Message, hook: str | None = None) -> Iterator[MessageView]:
     """Iterate over a message yielding one MessageView per content part.
 
     Memory-efficient: views are yielded one at a time and hold only
@@ -1126,6 +1174,8 @@ def iter_views(message: Message) -> Iterator[MessageView]:
 
     Args:
         message: The message to decompose into views.
+        hook: Optional hook location string (e.g., "llm_input",
+            "tool_post_invoke") to attach to each view.
 
     Yields:
         A MessageView for each content part in the message.
@@ -1157,5 +1207,7 @@ def iter_views(message: Message) -> Iterator[MessageView]:
     """
     for part in message.content:
         kind = _CONTENT_TYPE_TO_VIEW_KIND.get(part.content_type)
-        if kind is not None:
-            yield MessageView(part, kind, message)
+        if kind is None:
+            logger.warning("Unknown content type %r in iter_views", part.content_type)
+            raise ValueError(f"Unknown content type: {part.content_type!r}")
+        yield MessageView(part, kind, message, hook=hook)

--- a/cpex/framework/cmf/view.py
+++ b/cpex/framework/cmf/view.py
@@ -137,10 +137,16 @@ _ACTION_MAP: dict[ViewKind, ViewAction] = {
 }
 
 # Kinds whose action depends on message direction (role)
-_DIRECTION_DEPENDENT_KINDS = frozenset({
-    ViewKind.TEXT, ViewKind.THINKING,
-    ViewKind.IMAGE, ViewKind.VIDEO, ViewKind.AUDIO, ViewKind.DOCUMENT,
-})
+_DIRECTION_DEPENDENT_KINDS = frozenset(
+    {
+        ViewKind.TEXT,
+        ViewKind.THINKING,
+        ViewKind.IMAGE,
+        ViewKind.VIDEO,
+        ViewKind.AUDIO,
+        ViewKind.DOCUMENT,
+    }
+)
 
 # Sensitive headers stripped during serialization
 _SENSITIVE_HEADERS = frozenset({"authorization", "cookie", "x-api-key"})

--- a/cpex/framework/cmf/view.py
+++ b/cpex/framework/cmf/view.py
@@ -1,0 +1,1161 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/cmf/view.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+MessageView — read-only projection for policy evaluation.
+
+Decomposes a Message into individually addressable views with a
+uniform interface regardless of content type. Zero-copy design —
+properties are computed on-demand by accessing the underlying
+content part and message extensions directly.
+"""
+
+# Standard
+import json
+import re
+from enum import Enum
+from typing import Any, Iterator
+
+# First-Party
+from cpex.framework.cmf.message import (
+    ContentPart,
+    ContentType,
+    Message,
+    Resource,
+    Role,
+)
+from cpex.framework.extensions.security import (
+    DataPolicy,
+    ObjectSecurityProfile,
+    SubjectExtension,
+)
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class ViewKind(str, Enum):
+    """Closed-set enumeration of message view kinds.
+
+    Maps one-to-one with ContentType, identifying the kind of
+    content that a view represents.
+
+    Attributes:
+        TEXT: Plain text content.
+        THINKING: Reasoning/chain-of-thought content.
+        TOOL_CALL: Tool/function invocation.
+        TOOL_RESULT: Result from tool execution.
+        RESOURCE: Embedded resource with content.
+        RESOURCE_REF: Reference to a resource (URI only).
+        PROMPT_REQUEST: Prompt template request.
+        PROMPT_RESULT: Rendered prompt result.
+        IMAGE: Image content.
+        VIDEO: Video content.
+        AUDIO: Audio content.
+        DOCUMENT: Document content.
+
+    Examples:
+        >>> ViewKind.TOOL_CALL
+        <ViewKind.TOOL_CALL: 'tool_call'>
+        >>> ViewKind.TOOL_CALL.value
+        'tool_call'
+    """
+
+    TEXT = "text"
+    THINKING = "thinking"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    RESOURCE = "resource"
+    RESOURCE_REF = "resource_ref"
+    PROMPT_REQUEST = "prompt_request"
+    PROMPT_RESULT = "prompt_result"
+    IMAGE = "image"
+    VIDEO = "video"
+    AUDIO = "audio"
+    DOCUMENT = "document"
+
+
+class ViewAction(str, Enum):
+    """Closed-set enumeration of semantic actions.
+
+    Attributes:
+        READ: Reading/accessing data.
+        WRITE: Writing/modifying data.
+        EXECUTE: Executing a tool or command.
+        INVOKE: Invoking a prompt template.
+        SEND: Sending content outbound.
+        RECEIVE: Receiving content inbound.
+        GENERATE: Generating content (LLM output).
+
+    Examples:
+        >>> ViewAction.EXECUTE
+        <ViewAction.EXECUTE: 'execute'>
+    """
+
+    READ = "read"
+    WRITE = "write"
+    EXECUTE = "execute"
+    INVOKE = "invoke"
+    SEND = "send"
+    RECEIVE = "receive"
+    GENERATE = "generate"
+
+
+# ---------------------------------------------------------------------------
+# ContentType -> ViewKind mapping
+# ---------------------------------------------------------------------------
+
+_CONTENT_TYPE_TO_VIEW_KIND: dict[ContentType, ViewKind] = {
+    ContentType.TEXT: ViewKind.TEXT,
+    ContentType.THINKING: ViewKind.THINKING,
+    ContentType.TOOL_CALL: ViewKind.TOOL_CALL,
+    ContentType.TOOL_RESULT: ViewKind.TOOL_RESULT,
+    ContentType.RESOURCE: ViewKind.RESOURCE,
+    ContentType.RESOURCE_REF: ViewKind.RESOURCE_REF,
+    ContentType.PROMPT_REQUEST: ViewKind.PROMPT_REQUEST,
+    ContentType.PROMPT_RESULT: ViewKind.PROMPT_RESULT,
+    ContentType.IMAGE: ViewKind.IMAGE,
+    ContentType.VIDEO: ViewKind.VIDEO,
+    ContentType.AUDIO: ViewKind.AUDIO,
+    ContentType.DOCUMENT: ViewKind.DOCUMENT,
+}
+
+# Sensitive headers stripped during serialization
+_SENSITIVE_HEADERS = frozenset({"authorization", "cookie", "x-api-key"})
+
+
+# ---------------------------------------------------------------------------
+# MessageView
+# ---------------------------------------------------------------------------
+
+
+class MessageView:
+    """Read-only, zero-copy view over a single content part for policy evaluation.
+
+    A MessageView provides a uniform interface for inspecting any content
+    part of a message — regardless of whether it's text, a tool call, a
+    resource, or media. Properties are computed on-demand from the
+    underlying content part and message extensions without copying data.
+
+    For wrapped content parts (tool calls, resources, media, etc.), the
+    domain object is accessed via the wrapper's .content field. The _inner
+    property provides convenient access to the wrapped domain object.
+
+    MessageViews are produced by Message.iter_views() or the standalone
+    iter_views() function. A single Message with multiple content parts
+    yields one view per part.
+
+    Attributes:
+        kind: The type of content this view represents.
+        role: The role of the parent message.
+        raw: Direct access to the underlying content part.
+
+    Examples:
+        >>> from cpex.framework.cmf.message import (
+        ...     Message, Role, TextContent, ToolCall, ToolCallContentPart,
+        ... )
+        >>> msg = Message(
+        ...     role=Role.ASSISTANT,
+        ...     content=[
+        ...         TextContent(text="Let me look that up."),
+        ...         ToolCallContentPart(
+        ...             content=ToolCall(
+        ...                 tool_call_id="tc_001",
+        ...                 name="get_user",
+        ...                 arguments={"id": "123"},
+        ...             ),
+        ...         ),
+        ...     ],
+        ... )
+        >>> views = list(iter_views(msg))
+        >>> len(views)
+        2
+        >>> views[0].kind
+        <ViewKind.TEXT: 'text'>
+        >>> views[1].kind
+        <ViewKind.TOOL_CALL: 'tool_call'>
+        >>> views[1].name
+        'get_user'
+        >>> views[1].uri
+        'tool://_/get_user'
+        >>> views[1].is_pre
+        True
+    """
+
+    __slots__ = ("_part", "_kind", "_message")
+
+    def __init__(self, part: ContentPart, kind: ViewKind, message: Message) -> None:
+        """Initialize a MessageView.
+
+        Args:
+            part: The underlying content part.
+            kind: The kind of content.
+            message: The parent message (for role and extensions access).
+        """
+        self._part = part
+        self._kind = kind
+        self._message = message
+
+    # =========================================================================
+    # Internal Helpers
+    # =========================================================================
+
+    @property
+    def _inner(self) -> Any:
+        """Get the wrapped domain object for composite content parts.
+
+        For TextContent/ThinkingContent (which have no wrapper), returns
+        the part itself. For all other types, returns the .content field
+        which holds the domain object (ToolCall, Resource, etc.).
+
+        Returns:
+            The domain object for this content part.
+        """
+        if self._kind in (ViewKind.TEXT, ViewKind.THINKING):
+            return self._part
+        return self._part.content  # type: ignore[union-attr]
+
+    # =========================================================================
+    # Core Properties
+    # =========================================================================
+
+    @property
+    def kind(self) -> ViewKind:
+        """The type of content this view represents.
+
+        Returns:
+            The ViewKind for this view.
+        """
+        return self._kind
+
+    @property
+    def role(self) -> Role:
+        """The role of the parent message.
+
+        Returns:
+            The Role (user, assistant, system, developer, tool).
+        """
+        return self._message.role
+
+    @property
+    def raw(self) -> ContentPart:
+        """Direct access to the underlying content part.
+
+        Returns:
+            The underlying ContentPart subclass instance.
+        """
+        return self._part
+
+    @property
+    def content(self) -> str | None:
+        """Scannable text content.
+
+        For text/thinking: the text itself. For tool calls and prompt
+        requests: JSON-serialized arguments. For tool results:
+        JSON-serialized content. For resources: embedded content string.
+
+        Returns:
+            Scannable text or None if no text content is available.
+        """
+        inner = self._inner
+
+        if self._kind in (ViewKind.TEXT, ViewKind.THINKING):
+            return inner.text
+
+        if self._kind == ViewKind.RESOURCE:
+            return inner.content
+
+        if self._kind == ViewKind.TOOL_CALL:
+            try:
+                return json.dumps(inner.arguments)
+            except (TypeError, ValueError):
+                return str(inner.arguments)
+
+        if self._kind == ViewKind.TOOL_RESULT:
+            result_content = inner.content
+            if result_content is None:
+                return None
+            if isinstance(result_content, str):
+                return result_content
+            try:
+                return json.dumps(result_content)
+            except (TypeError, ValueError):
+                return str(result_content)
+
+        if self._kind == ViewKind.PROMPT_REQUEST:
+            try:
+                return json.dumps(inner.arguments)
+            except (TypeError, ValueError):
+                return str(inner.arguments)
+
+        if self._kind == ViewKind.PROMPT_RESULT:
+            return inner.content
+
+        return None
+
+    @property
+    def uri(self) -> str | None:
+        """Synthetic identity URI.
+
+        Tools: tool://namespace/name. Tool results: tool_result://name.
+        Prompts: prompt://server/name. Prompt results: prompt_result://name.
+        Resources: the resource's own URI.
+
+        Returns:
+            URI string or None if not applicable.
+        """
+        inner = self._inner
+
+        if self._kind in (ViewKind.RESOURCE, ViewKind.RESOURCE_REF):
+            return inner.uri
+
+        if self._kind == ViewKind.TOOL_CALL:
+            ns = inner.namespace or "_"
+            return f"tool://{ns}/{inner.name}"
+
+        if self._kind == ViewKind.TOOL_RESULT:
+            return f"tool_result://{inner.tool_name}"
+
+        if self._kind == ViewKind.PROMPT_REQUEST:
+            server = inner.server_id or "_"
+            return f"prompt://{server}/{inner.name}"
+
+        if self._kind == ViewKind.PROMPT_RESULT:
+            return f"prompt_result://{inner.prompt_name}"
+
+        return None
+
+    @property
+    def name(self) -> str | None:
+        """Human-readable name (tool name, resource name, prompt name).
+
+        Returns:
+            Name string or None if not applicable.
+        """
+        inner = self._inner
+
+        if self._kind in (ViewKind.TOOL_CALL, ViewKind.PROMPT_REQUEST):
+            return inner.name
+
+        if self._kind in (ViewKind.RESOURCE, ViewKind.RESOURCE_REF):
+            return inner.name
+
+        if self._kind == ViewKind.TOOL_RESULT:
+            return inner.tool_name
+
+        if self._kind == ViewKind.PROMPT_RESULT:
+            return inner.prompt_name
+
+        return None
+
+    @property
+    def action(self) -> ViewAction:
+        """The semantic action this view represents.
+
+        Returns:
+            A ViewAction value.
+        """
+        _ACTION_MAP: dict[ViewKind, ViewAction] = {
+            ViewKind.TEXT: ViewAction.SEND,
+            ViewKind.THINKING: ViewAction.GENERATE,
+            ViewKind.TOOL_CALL: ViewAction.EXECUTE,
+            ViewKind.TOOL_RESULT: ViewAction.RECEIVE,
+            ViewKind.RESOURCE: ViewAction.READ,
+            ViewKind.RESOURCE_REF: ViewAction.READ,
+            ViewKind.PROMPT_REQUEST: ViewAction.INVOKE,
+            ViewKind.PROMPT_RESULT: ViewAction.GENERATE,
+            ViewKind.IMAGE: ViewAction.SEND,
+            ViewKind.VIDEO: ViewAction.SEND,
+            ViewKind.AUDIO: ViewAction.SEND,
+            ViewKind.DOCUMENT: ViewAction.SEND,
+        }
+        return _ACTION_MAP.get(self._kind, ViewAction.SEND)
+
+    @property
+    def args(self) -> dict[str, Any] | None:
+        """Arguments dict for tool calls and prompt requests.
+
+        Returns:
+            Arguments dict or None for other content types.
+        """
+        inner = self._inner
+        if self._kind == ViewKind.TOOL_CALL:
+            return inner.arguments
+        if self._kind == ViewKind.PROMPT_REQUEST:
+            return inner.arguments
+        return None
+
+    @property
+    def mime_type(self) -> str | None:
+        """MIME type if applicable.
+
+        Returns:
+            MIME type string or None.
+        """
+        inner = self._inner
+        if self._kind == ViewKind.RESOURCE:
+            return inner.mime_type
+        if self._kind in (ViewKind.IMAGE, ViewKind.VIDEO, ViewKind.AUDIO, ViewKind.DOCUMENT):
+            return inner.media_type
+        return None
+
+    @property
+    def size_bytes(self) -> int | None:
+        """Content size in bytes (computed from content).
+
+        Returns:
+            Size in bytes or None.
+        """
+        if self._kind == ViewKind.RESOURCE:
+            res: Resource = self._inner
+            if res.size_bytes is not None:
+                return res.size_bytes
+            if res.content:
+                return len(res.content.encode("utf-8"))
+            if res.blob:
+                return len(res.blob)
+            return None
+
+        text = self.content
+        if text is not None:
+            return len(text.encode("utf-8"))
+        return None
+
+    @property
+    def properties(self) -> dict[str, Any]:
+        """Type-specific properties as a dict.
+
+        For single property access, prefer get_property() which
+        avoids allocating a dict.
+
+        Returns:
+            Dict of property name to value for this view's kind.
+        """
+        props: dict[str, Any] = {}
+        inner = self._inner
+
+        if self._kind == ViewKind.RESOURCE:
+            props["resource_type"] = inner.resource_type.value
+            props["version"] = inner.version
+            props["annotations"] = inner.annotations
+
+        elif self._kind == ViewKind.TOOL_CALL:
+            props["namespace"] = inner.namespace
+            props["tool_id"] = inner.tool_call_id
+
+        elif self._kind == ViewKind.TOOL_RESULT:
+            props["is_error"] = inner.is_error
+            props["tool_name"] = inner.tool_name
+
+        elif self._kind == ViewKind.PROMPT_REQUEST:
+            props["server_id"] = inner.server_id
+
+        elif self._kind == ViewKind.PROMPT_RESULT:
+            props["is_error"] = inner.is_error
+            props["message_count"] = len(inner.messages) if inner.messages else 0
+
+        return props
+
+    def get_property(self, name: str, default: Any = None) -> Any:
+        """Get a single type-specific property without allocating a dict.
+
+        Args:
+            name: Property name to retrieve.
+            default: Value to return if property doesn't exist.
+
+        Returns:
+            The property value or default.
+        """
+        inner = self._inner
+
+        if self._kind == ViewKind.RESOURCE:
+            if name == "resource_type":
+                return inner.resource_type.value
+            if name == "version":
+                return inner.version
+            if name == "annotations":
+                return inner.annotations
+
+        elif self._kind == ViewKind.TOOL_CALL:
+            if name == "namespace":
+                return inner.namespace
+            if name == "tool_id":
+                return inner.tool_call_id
+
+        elif self._kind == ViewKind.TOOL_RESULT:
+            if name == "is_error":
+                return inner.is_error
+            if name == "tool_name":
+                return inner.tool_name
+
+        elif self._kind == ViewKind.PROMPT_REQUEST:
+            if name == "server_id":
+                return inner.server_id
+
+        elif self._kind == ViewKind.PROMPT_RESULT:
+            if name == "is_error":
+                return inner.is_error
+            if name == "message_count":
+                return len(inner.messages) if inner.messages else 0
+
+        return default
+
+    # =========================================================================
+    # Direction
+    # =========================================================================
+
+    @property
+    def is_pre(self) -> bool:
+        """True if this represents input/request content (before processing).
+
+        Determined by ViewKind for requests/responses, and by Role
+        for text, thinking, and media content.
+
+        Returns:
+            True if this is pre-processing content.
+        """
+        if self._kind in (ViewKind.TOOL_CALL, ViewKind.PROMPT_REQUEST, ViewKind.RESOURCE_REF):
+            return True
+        if self._kind in (ViewKind.TOOL_RESULT, ViewKind.PROMPT_RESULT, ViewKind.RESOURCE):
+            return False
+        return self._message.role in (Role.USER, Role.SYSTEM, Role.DEVELOPER, Role.TOOL)
+
+    @property
+    def is_post(self) -> bool:
+        """True if this represents output/response content (after processing).
+
+        Returns:
+            True if this is post-processing content.
+        """
+        if self._kind in (ViewKind.TOOL_RESULT, ViewKind.PROMPT_RESULT, ViewKind.RESOURCE):
+            return True
+        if self._kind in (ViewKind.TOOL_CALL, ViewKind.PROMPT_REQUEST, ViewKind.RESOURCE_REF):
+            return False
+        return self._message.role == Role.ASSISTANT
+
+    @property
+    def is_tool(self) -> bool:
+        """True if tool_call or tool_result.
+
+        Returns:
+            True if this is a tool-related view.
+        """
+        return self._kind in (ViewKind.TOOL_CALL, ViewKind.TOOL_RESULT)
+
+    @property
+    def is_prompt(self) -> bool:
+        """True if prompt_request or prompt_result.
+
+        Returns:
+            True if this is a prompt-related view.
+        """
+        return self._kind in (ViewKind.PROMPT_REQUEST, ViewKind.PROMPT_RESULT)
+
+    @property
+    def is_resource(self) -> bool:
+        """True if resource or resource_ref.
+
+        Returns:
+            True if this is a resource-related view.
+        """
+        return self._kind in (ViewKind.RESOURCE, ViewKind.RESOURCE_REF)
+
+    @property
+    def is_text(self) -> bool:
+        """True if text or thinking.
+
+        Returns:
+            True if this is text-based content.
+        """
+        return self._kind in (ViewKind.TEXT, ViewKind.THINKING)
+
+    @property
+    def is_media(self) -> bool:
+        """True if image, video, audio, or document.
+
+        Returns:
+            True if this is media content.
+        """
+        return self._kind in (ViewKind.IMAGE, ViewKind.VIDEO, ViewKind.AUDIO, ViewKind.DOCUMENT)
+
+    # =========================================================================
+    # Flat Accessors (capability-gated in the spec)
+    # =========================================================================
+
+    def _ext(self) -> Any:
+        """Get the message extensions, or None."""
+        return self._message.extensions
+
+    # --- Base tier (no capability required) ---
+
+    @property
+    def environment(self) -> str | None:
+        """Execution environment (production, staging, dev).
+
+        Capability: base (no requirement).
+
+        Returns:
+            Environment string or None.
+        """
+        ext = self._ext()
+        if ext and ext.request:
+            return ext.request.environment
+        return None
+
+    @property
+    def request_id(self) -> str | None:
+        """Request correlation ID.
+
+        Capability: base (no requirement).
+
+        Returns:
+            Request ID string or None.
+        """
+        ext = self._ext()
+        if ext and ext.request:
+            return ext.request.request_id
+        return None
+
+    # --- read_subject ---
+
+    @property
+    def subject(self) -> SubjectExtension | None:
+        """The authenticated entity making the request.
+
+        Capability: read_subject.
+
+        Returns:
+            SubjectExtension or None.
+        """
+        ext = self._ext()
+        if ext and ext.security:
+            return ext.security.subject
+        return None
+
+    # --- read_roles ---
+
+    @property
+    def roles(self) -> frozenset[str]:
+        """Subject's assigned roles.
+
+        Capability: read_roles.
+
+        Returns:
+            Frozenset of role strings.
+        """
+        s = self.subject
+        return s.roles if s else frozenset()
+
+    # --- read_permissions ---
+
+    @property
+    def permissions(self) -> frozenset[str]:
+        """Subject's granted permissions.
+
+        Capability: read_permissions.
+
+        Returns:
+            Frozenset of permission strings.
+        """
+        s = self.subject
+        return s.permissions if s else frozenset()
+
+    # --- read_teams ---
+
+    @property
+    def teams(self) -> frozenset[str]:
+        """Subject's team memberships.
+
+        Capability: read_teams.
+
+        Returns:
+            Frozenset of team strings.
+        """
+        s = self.subject
+        return s.teams if s else frozenset()
+
+    # --- read_headers ---
+
+    @property
+    def headers(self) -> dict[str, str]:
+        """HTTP headers associated with the request.
+
+        Capability: read_headers.
+
+        Returns:
+            Dict of header name to value.
+        """
+        ext = self._ext()
+        if ext and ext.http:
+            return ext.http.headers
+        return {}
+
+    # --- read_labels ---
+
+    @property
+    def labels(self) -> frozenset[str]:
+        """Security/data labels on this message.
+
+        Capability: read_labels.
+
+        Returns:
+            Frozenset of label strings.
+        """
+        ext = self._ext()
+        if ext and ext.security:
+            return ext.security.labels
+        return frozenset()
+
+    # --- read_agent ---
+
+    @property
+    def agent_input(self) -> str | None:
+        """Original user intent that triggered this action.
+
+        Capability: read_agent.
+
+        Returns:
+            Input string or None.
+        """
+        ext = self._ext()
+        if ext and ext.agent:
+            return ext.agent.input
+        return None
+
+    @property
+    def session_id(self) -> str | None:
+        """Broad session identifier.
+
+        Capability: read_agent.
+
+        Returns:
+            Session ID string or None.
+        """
+        ext = self._ext()
+        if ext and ext.agent:
+            return ext.agent.session_id
+        return None
+
+    @property
+    def conversation_id(self) -> str | None:
+        """Specific dialogue/task within a session.
+
+        Capability: read_agent.
+
+        Returns:
+            Conversation ID string or None.
+        """
+        ext = self._ext()
+        if ext and ext.agent:
+            return ext.agent.conversation_id
+        return None
+
+    @property
+    def turn(self) -> int | None:
+        """Position in conversation (0-indexed).
+
+        Capability: read_agent.
+
+        Returns:
+            Turn number or None.
+        """
+        ext = self._ext()
+        if ext and ext.agent:
+            return ext.agent.turn
+        return None
+
+    @property
+    def agent_id(self) -> str | None:
+        """Identifier of the producing agent.
+
+        Capability: read_agent.
+
+        Returns:
+            Agent ID string or None.
+        """
+        ext = self._ext()
+        if ext and ext.agent:
+            return ext.agent.agent_id
+        return None
+
+    @property
+    def parent_agent_id(self) -> str | None:
+        """Spawning agent's ID (multi-agent lineage).
+
+        Capability: read_agent.
+
+        Returns:
+            Parent agent ID string or None.
+        """
+        ext = self._ext()
+        if ext and ext.agent:
+            return ext.agent.parent_agent_id
+        return None
+
+    # --- read_objects ---
+
+    @property
+    def object(self) -> ObjectSecurityProfile | None:
+        """Access control profile for this view's entity.
+
+        Resolved by view.name from extensions.security.objects.
+
+        Capability: read_objects.
+
+        Returns:
+            ObjectSecurityProfile or None.
+        """
+        ext = self._ext()
+        view_name = self.name
+        if ext and ext.security and view_name:
+            return ext.security.objects.get(view_name)
+        return None
+
+    # --- read_data ---
+
+    @property
+    def data_policy(self) -> DataPolicy | None:
+        """Data governance policy for this view's entity.
+
+        Resolved by view.name from extensions.security.data.
+
+        Capability: read_data.
+
+        Returns:
+            DataPolicy or None.
+        """
+        ext = self._ext()
+        view_name = self.name
+        if ext and ext.security and view_name:
+            return ext.security.data.get(view_name)
+        return None
+
+    # =========================================================================
+    # Helper Methods
+    # =========================================================================
+
+    def has_role(self, role: str) -> bool:
+        """Check if subject has a specific role.
+
+        Args:
+            role: The role to check for.
+
+        Returns:
+            True if the subject has the role.
+        """
+        return role in self.roles
+
+    def has_permission(self, perm: str) -> bool:
+        """Check if subject has a specific permission.
+
+        Args:
+            perm: The permission to check for.
+
+        Returns:
+            True if the subject has the permission.
+        """
+        return perm in self.permissions
+
+    def has_label(self, label: str) -> bool:
+        """Check if a security label is present.
+
+        Args:
+            label: Label to check for (e.g., "PII", "SECRET").
+
+        Returns:
+            True if the label is present.
+        """
+        return label in self.labels
+
+    def has_header(self, name: str) -> bool:
+        """Check if an HTTP header exists (case-insensitive).
+
+        Args:
+            name: Header name to check.
+
+        Returns:
+            True if header exists.
+        """
+        return self.get_header(name) is not None
+
+    def get_header(self, name: str, default: str | None = None) -> str | None:
+        """Get an HTTP header value (case-insensitive).
+
+        Args:
+            name: Header name.
+            default: Default value if header not found.
+
+        Returns:
+            Header value or default.
+        """
+        lower_name = name.lower()
+        for key, value in self.headers.items():
+            if key.lower() == lower_name:
+                return value
+        return default
+
+    def get_arg(self, name: str, default: Any = None) -> Any:
+        """Get a single argument value.
+
+        Args:
+            name: Argument name.
+            default: Value if argument doesn't exist.
+
+        Returns:
+            Argument value or default.
+        """
+        args = self.args
+        if args is None:
+            return default
+        return args.get(name, default)
+
+    def has_arg(self, name: str) -> bool:
+        """Check if an argument exists.
+
+        Args:
+            name: Argument name to check.
+
+        Returns:
+            True if argument exists.
+        """
+        args = self.args
+        return args is not None and name in args
+
+    def matches_uri_pattern(self, pattern: str) -> bool:
+        """Check if URI matches a glob-style pattern.
+
+        Supports * (single segment) and ** (any number of segments)
+        wildcards.
+
+        Args:
+            pattern: Glob pattern to match against.
+
+        Returns:
+            True if URI matches the pattern.
+        """
+        view_uri = self.uri
+        if not view_uri:
+            return False
+        regex = pattern.replace("**", "<<<DOUBLE>>>")
+        regex = regex.replace("*", "[^/]*")
+        regex = regex.replace("<<<DOUBLE>>>", ".*")
+        regex = f"^{regex}$"
+        return bool(re.match(regex, view_uri))
+
+    def has_content(self) -> bool:
+        """True if scannable text content is available.
+
+        Returns:
+            True if content is not None.
+        """
+        return self.content is not None
+
+    # =========================================================================
+    # Serialization
+    # =========================================================================
+
+    def to_dict(self, include_content: bool = True, include_context: bool = True) -> dict[str, Any]:
+        """Serialize the view to a JSON-compatible dictionary.
+
+        Sensitive headers (Authorization, Cookie, X-API-Key) are
+        automatically stripped from the serialized output.
+
+        Args:
+            include_content: Include text content (may be large).
+            include_context: Include extensions context.
+
+        Returns:
+            JSON-serializable dictionary with view properties.
+        """
+        result: dict[str, Any] = {
+            "kind": self._kind.value,
+            "role": self._message.role.value,
+            "is_pre": self.is_pre,
+            "is_post": self.is_post,
+            "action": self.action.value,
+        }
+
+        if self.uri:
+            result["uri"] = self.uri
+        if self.name:
+            result["name"] = self.name
+
+        if include_content:
+            text = self.content
+            if text is not None:
+                result["content"] = text
+            size = self.size_bytes
+            if size is not None:
+                result["size_bytes"] = size
+
+        if self.mime_type:
+            result["mime_type"] = self.mime_type
+
+        args = self.args
+        if args is not None:
+            result["arguments"] = args
+
+        props = self.properties
+        if props:
+            result["properties"] = props
+
+        if include_context:
+            extensions: dict[str, Any] = {}
+
+            # Subject
+            s = self.subject
+            if s:
+                extensions["subject"] = {
+                    "id": s.id,
+                    "type": s.type.value,
+                    "roles": sorted(s.roles),
+                    "permissions": sorted(s.permissions),
+                    "teams": sorted(s.teams),
+                }
+
+            # Environment
+            env = self.environment
+            if env:
+                extensions["environment"] = env
+
+            # Labels
+            lbls = self.labels
+            if lbls:
+                extensions["labels"] = sorted(lbls)
+
+            # Headers (strip sensitive)
+            hdrs = self.headers
+            if hdrs:
+                safe = {k: v for k, v in hdrs.items() if k.lower() not in _SENSITIVE_HEADERS}
+                if safe:
+                    extensions["headers"] = safe
+
+            # Object profile (for pre views)
+            obj = self.object
+            if obj:
+                extensions["object"] = {
+                    "managed_by": obj.managed_by,
+                    "permissions": obj.permissions,
+                    "trust_domain": obj.trust_domain,
+                    "data_scope": obj.data_scope,
+                }
+
+            # Data policy (for post views)
+            dp = self.data_policy
+            if dp:
+                dp_dict: dict[str, Any] = {
+                    "apply_labels": dp.apply_labels,
+                    "denied_actions": dp.denied_actions,
+                }
+                if dp.allowed_actions is not None:
+                    dp_dict["allowed_actions"] = dp.allowed_actions
+                if dp.retention:
+                    dp_dict["retention"] = {
+                        "max_age_seconds": dp.retention.max_age_seconds,
+                        "policy": dp.retention.policy,
+                        "delete_after": dp.retention.delete_after,
+                    }
+                extensions["data"] = dp_dict
+
+            # Agent context
+            ext = self._ext()
+            if ext and ext.agent:
+                agent_dict: dict[str, Any] = {}
+                if ext.agent.input:
+                    agent_dict["input"] = ext.agent.input
+                if ext.agent.session_id:
+                    agent_dict["session_id"] = ext.agent.session_id
+                if ext.agent.conversation_id:
+                    agent_dict["conversation_id"] = ext.agent.conversation_id
+                if ext.agent.turn is not None:
+                    agent_dict["turn"] = ext.agent.turn
+                if ext.agent.agent_id:
+                    agent_dict["agent_id"] = ext.agent.agent_id
+                if ext.agent.parent_agent_id:
+                    agent_dict["parent_agent_id"] = ext.agent.parent_agent_id
+                if agent_dict:
+                    extensions["agent"] = agent_dict
+
+            if extensions:
+                result["extensions"] = extensions
+
+        return result
+
+    def to_opa_input(self, include_content: bool = True) -> dict[str, Any]:
+        """Serialize to OPA-compatible input format.
+
+        Wraps the view in the standard OPA input envelope:
+        {"input": {...view data...}}.
+
+        Args:
+            include_content: Include text content in the input.
+
+        Returns:
+            Dict in OPA input format.
+        """
+        return {"input": self.to_dict(include_content=include_content)}
+
+    def __repr__(self) -> str:
+        """String representation of the view.
+
+        Returns:
+            Human-readable representation.
+        """
+        role_part = f", role={self._message.role.value}"
+        uri_part = f", uri={self.uri}" if self.uri else ""
+        direction = "pre" if self.is_pre else "post" if self.is_post else "?"
+        return f"MessageView(kind={self._kind.value}{role_part}, {direction}{uri_part})"
+
+
+# ---------------------------------------------------------------------------
+# View Iterator (standalone)
+# ---------------------------------------------------------------------------
+
+
+def iter_views(message: Message) -> Iterator[MessageView]:
+    """Iterate over a message yielding one MessageView per content part.
+
+    Memory-efficient: views are yielded one at a time and hold only
+    references to the underlying message and content part.
+
+    This is the standalone version. Message.iter_views() delegates
+    to this function.
+
+    Args:
+        message: The message to decompose into views.
+
+    Yields:
+        A MessageView for each content part in the message.
+
+    Examples:
+        >>> from cpex.framework.cmf.message import (
+        ...     Message, Role, TextContent, ToolCall, ToolCallContentPart,
+        ...     ThinkingContent,
+        ... )
+        >>> msg = Message(
+        ...     role=Role.ASSISTANT,
+        ...     content=[
+        ...         ThinkingContent(text="User wants admin users."),
+        ...         TextContent(text="Let me look that up."),
+        ...         ToolCallContentPart(
+        ...             content=ToolCall(
+        ...                 tool_call_id="tc_001",
+        ...                 name="execute_sql",
+        ...                 arguments={"query": "SELECT * FROM users"},
+        ...             ),
+        ...         ),
+        ...     ],
+        ... )
+        >>> views = list(iter_views(msg))
+        >>> len(views)
+        3
+        >>> [(v.kind.value, v.is_pre) for v in views]
+        [('thinking', False), ('text', False), ('tool_call', True)]
+    """
+    for part in message.content:
+        kind = _CONTENT_TYPE_TO_VIEW_KIND.get(part.content_type)
+        if kind is not None:
+            yield MessageView(part, kind, message)

--- a/cpex/framework/decorator.py
+++ b/cpex/framework/decorator.py
@@ -38,7 +38,7 @@ Examples:
 """
 
 # Standard
-from typing import Callable, Optional, Type, TypeVar
+from typing import Callable, Optional, Sequence, Type, TypeVar, Union
 
 # Third-Party
 from pydantic import BaseModel
@@ -58,31 +58,40 @@ class HookMetadata:
     """Metadata stored on decorated hook methods.
 
     Attributes:
-        hook_type: The hook type identifier (e.g., 'tool_pre_invoke')
-        payload_type: Optional payload class for hook registration
-        result_type: Optional result class for hook registration
+        hook_types: The hook type identifiers this method handles.
+        payload_type: Optional payload class for hook registration.
+        result_type: Optional result class for hook registration.
     """
 
     def __init__(
         self,
-        hook_type: str,
+        hook_types: list[str],
         payload_type: Optional[Type[BaseModel]] = None,
         result_type: Optional[Type[BaseModel]] = None,
     ):
         """Initialize hook metadata.
 
         Args:
-            hook_type: The hook type identifier
-            payload_type: Optional payload class for registering new hooks
-            result_type: Optional result class for registering new hooks
+            hook_types: List of hook type identifiers this method handles.
+            payload_type: Optional payload class for registering new hooks.
+            result_type: Optional result class for registering new hooks.
         """
-        self.hook_type = hook_type
+        self.hook_types = hook_types
         self.payload_type = payload_type
         self.result_type = result_type
 
+    @property
+    def hook_type(self) -> str:
+        """Primary hook type (first in list). For backward compatibility."""
+        return self.hook_types[0] if self.hook_types else ""
+
+    def matches(self, hook_type: str) -> bool:
+        """Check if this metadata handles the given hook type."""
+        return hook_type in self.hook_types
+
 
 def hook(
-    hook_type: str,
+    hook_type: Union[str, Sequence[str]],
     payload_type: Optional[Type[P]] = None,
     result_type: Optional[Type[R]] = None,
 ) -> Callable[[Callable], Callable]:
@@ -90,22 +99,30 @@ def hook(
 
     This decorator attaches metadata to a method so the Plugin class can
     discover it during initialization and register it with the appropriate
-    hook type.
+    hook type(s).
 
     Args:
-        hook_type: The hook type identifier (e.g., 'tool_pre_invoke')
-        payload_type: Optional payload class for registering new hook types
-        result_type: Optional result class for registering new hook types
+        hook_type: One or more hook type identifiers. Pass a string for
+            a single hook, or a list/tuple to register the same method
+            for multiple hook points.
+        payload_type: Optional payload class for registering new hook types.
+        result_type: Optional result class for registering new hook types.
 
     Returns:
-        Decorator function that marks the method with hook metadata
+        Decorator function that marks the method with hook metadata.
 
     Examples:
-        Override method name::
+        Single hook::
 
             @hook(ToolHookType.TOOL_PRE_INVOKE)
             def my_custom_method_name(self, payload, context):
                 return ToolPreInvokeResult(continue_processing=True)
+
+        Multiple hooks (same method handles both)::
+
+            @hook([CmfHookType.TOOL_PRE_INVOKE, CmfHookType.TOOL_POST_INVOKE])
+            def evaluate(self, payload, context):
+                return MessageResult()
 
         Register new hook type::
 
@@ -123,8 +140,13 @@ def hook(
         Returns:
             The same function with metadata attached
         """
-        # Store metadata on the function object
-        metadata = HookMetadata(hook_type, payload_type, result_type)
+        # Normalize to list
+        if isinstance(hook_type, str):
+            types = [hook_type]
+        else:
+            types = list(hook_type)
+
+        metadata = HookMetadata(types, payload_type, result_type)
         setattr(func, _HOOK_METADATA_ATTR, metadata)
         return func
 
@@ -147,6 +169,8 @@ def get_hook_metadata(func: Callable) -> Optional[HookMetadata]:
         >>> metadata = get_hook_metadata(test_func)
         >>> metadata.hook_type
         'test_hook'
+        >>> metadata.matches("test_hook")
+        True
         >>> get_hook_metadata(lambda: None) is None
         True
     """

--- a/cpex/framework/extensions/__init__.py
+++ b/cpex/framework/extensions/__init__.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/__init__.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Extensions Package.
+Provides structured, typed extension models for identity, security,
+governance, and execution context metadata. Extensions are designed
+to be reusable across different payload types.
+"""
+
+# First-Party
+from cpex.framework.extensions.agent import AgentExtension, ConversationContext
+from cpex.framework.extensions.completion import CompletionExtension, StopReason, TokenUsage
+from cpex.framework.extensions.extensions import Extensions
+from cpex.framework.extensions.framework import FrameworkExtension
+from cpex.framework.extensions.http import HttpExtension
+from cpex.framework.extensions.llm import LLMExtension
+from cpex.framework.extensions.mcp import MCPExtension, PromptMetadata, ResourceMetadata, ToolMetadata
+from cpex.framework.extensions.provenance import ProvenanceExtension
+from cpex.framework.extensions.request import RequestExtension
+from cpex.framework.extensions.security import (
+    DataPolicy,
+    ObjectSecurityProfile,
+    RetentionPolicy,
+    SecurityExtension,
+    SubjectExtension,
+    SubjectType,
+)
+
+__all__ = [
+    "AgentExtension",
+    "CompletionExtension",
+    "ConversationContext",
+    "DataPolicy",
+    "Extensions",
+    "FrameworkExtension",
+    "HttpExtension",
+    "LLMExtension",
+    "MCPExtension",
+    "ObjectSecurityProfile",
+    "PromptMetadata",
+    "ProvenanceExtension",
+    "RequestExtension",
+    "ResourceMetadata",
+    "RetentionPolicy",
+    "SecurityExtension",
+    "StopReason",
+    "SubjectExtension",
+    "SubjectType",
+    "TokenUsage",
+    "ToolMetadata",
+]

--- a/cpex/framework/extensions/__init__.py
+++ b/cpex/framework/extensions/__init__.py
@@ -14,6 +14,7 @@ to be reusable across different payload types.
 from cpex.framework.extensions.agent import AgentExtension, ConversationContext
 from cpex.framework.extensions.completion import CompletionExtension, StopReason, TokenUsage
 from cpex.framework.extensions.constants import SlotName
+from cpex.framework.extensions.delegation import DelegationExtension, DelegationHop
 from cpex.framework.extensions.extensions import Extensions
 from cpex.framework.extensions.framework import FrameworkExtension
 from cpex.framework.extensions.http import HttpExtension
@@ -50,6 +51,8 @@ __all__ = [
     "CompletionExtension",
     "ConversationContext",
     "DataPolicy",
+    "DelegationExtension",
+    "DelegationHop",
     "Extensions",
     "FrameworkExtension",
     "HttpExtension",

--- a/cpex/framework/extensions/__init__.py
+++ b/cpex/framework/extensions/__init__.py
@@ -17,7 +17,12 @@ from cpex.framework.extensions.extensions import Extensions
 from cpex.framework.extensions.framework import FrameworkExtension
 from cpex.framework.extensions.http import HttpExtension
 from cpex.framework.extensions.llm import LLMExtension
-from cpex.framework.extensions.mcp import MCPExtension, PromptMetadata, ResourceMetadata, ToolMetadata
+from cpex.framework.extensions.mcp import (
+    MCPExtension,
+    PromptMetadata,
+    ResourceMetadata,
+    ToolMetadata,
+)
 from cpex.framework.extensions.provenance import ProvenanceExtension
 from cpex.framework.extensions.request import RequestExtension
 from cpex.framework.extensions.security import (
@@ -28,9 +33,19 @@ from cpex.framework.extensions.security import (
     SubjectExtension,
     SubjectType,
 )
+from cpex.framework.extensions.constants import SlotName
+from cpex.framework.extensions.tiers import (
+    AccessPolicy,
+    Capability,
+    MutabilityTier,
+    TierViolationError,
+)
 
 __all__ = [
+    "AccessPolicy",
+    "SlotName",
     "AgentExtension",
+    "Capability",
     "CompletionExtension",
     "ConversationContext",
     "DataPolicy",
@@ -39,6 +54,7 @@ __all__ = [
     "HttpExtension",
     "LLMExtension",
     "MCPExtension",
+    "MutabilityTier",
     "ObjectSecurityProfile",
     "PromptMetadata",
     "ProvenanceExtension",
@@ -49,6 +65,7 @@ __all__ = [
     "StopReason",
     "SubjectExtension",
     "SubjectType",
+    "TierViolationError",
     "TokenUsage",
     "ToolMetadata",
 ]

--- a/cpex/framework/extensions/__init__.py
+++ b/cpex/framework/extensions/__init__.py
@@ -24,6 +24,7 @@ from cpex.framework.extensions.mcp import (
     ResourceMetadata,
     ToolMetadata,
 )
+from cpex.framework.extensions.meta import MetaExtension
 from cpex.framework.extensions.provenance import ProvenanceExtension
 from cpex.framework.extensions.request import RequestExtension
 from cpex.framework.extensions.security import (
@@ -54,6 +55,7 @@ __all__ = [
     "HttpExtension",
     "LLMExtension",
     "MCPExtension",
+    "MetaExtension",
     "MutabilityTier",
     "ObjectSecurityProfile",
     "PromptMetadata",

--- a/cpex/framework/extensions/__init__.py
+++ b/cpex/framework/extensions/__init__.py
@@ -13,6 +13,7 @@ to be reusable across different payload types.
 # First-Party
 from cpex.framework.extensions.agent import AgentExtension, ConversationContext
 from cpex.framework.extensions.completion import CompletionExtension, StopReason, TokenUsage
+from cpex.framework.extensions.constants import SlotName
 from cpex.framework.extensions.extensions import Extensions
 from cpex.framework.extensions.framework import FrameworkExtension
 from cpex.framework.extensions.http import HttpExtension
@@ -33,7 +34,6 @@ from cpex.framework.extensions.security import (
     SubjectExtension,
     SubjectType,
 )
-from cpex.framework.extensions.constants import SlotName
 from cpex.framework.extensions.tiers import (
     AccessPolicy,
     Capability,

--- a/cpex/framework/extensions/agent.py
+++ b/cpex/framework/extensions/agent.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/agent.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Agent extension models.
+Carries agent execution context — session tracking, multi-agent lineage,
+original user intent, and optional windowed conversation history.
+Immutable tier — the user's intent and session identity must not be
+modifiable by processing components.
+"""
+
+# Standard
+from typing import Any
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ConversationContext(BaseModel):
+    """Windowed conversation context for agent-aware processing.
+
+    Provides a lightweight view of prior conversation history without
+    requiring access to the full message store.
+
+    Attributes:
+        history: Windowed message history (recent turns).
+        summary: Summarized prior context.
+        topics: Extracted topics or intents.
+
+    Examples:
+        >>> ctx = ConversationContext(
+        ...     summary="User asked about quarterly revenue.",
+        ...     topics=["revenue", "Q4"],
+        ... )
+        >>> ctx.summary
+        'User asked about quarterly revenue.'
+        >>> ctx.topics
+        ['revenue', 'Q4']
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    history: list[Any] = Field(
+        default_factory=list,
+        description="Windowed message history (recent turns).",
+    )
+    summary: str | None = Field(default=None, description="Summarized prior context.")
+    topics: list[str] = Field(default_factory=list, description="Extracted topics or intents.")
+
+
+class AgentExtension(BaseModel):
+    """Agent execution context.
+
+    Tracks session identity, multi-agent lineage, and the original
+    user intent that triggered the current action. Immutable — the
+    processing pipeline rejects any modifications.
+
+    Attributes:
+        input: Original user intent that triggered this action.
+        session_id: Broad session identifier.
+        conversation_id: Specific dialogue/task within a session.
+        turn: Position in conversation (0-indexed).
+        agent_id: Identifier of the producing agent.
+        parent_agent_id: Spawning agent's ID (multi-agent lineage).
+        conversation: Windowed conversation context.
+
+    Examples:
+        >>> ext = AgentExtension(
+        ...     input="What is the weather in London?",
+        ...     session_id="sess-001",
+        ...     conversation_id="conv-042",
+        ...     turn=3,
+        ...     agent_id="weather-agent",
+        ... )
+        >>> ext.input
+        'What is the weather in London?'
+        >>> ext.turn
+        3
+
+        >>> # Multi-agent lineage
+        >>> child = AgentExtension(
+        ...     agent_id="sub-agent-01",
+        ...     parent_agent_id="weather-agent",
+        ... )
+        >>> child.parent_agent_id
+        'weather-agent'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    input: str | None = Field(default=None, description="Original user intent that triggered this action.")
+    session_id: str | None = Field(default=None, description="Broad session identifier.")
+    conversation_id: str | None = Field(default=None, description="Specific dialogue/task within a session.")
+    turn: int | None = Field(default=None, description="Position in conversation (0-indexed).")
+    agent_id: str | None = Field(default=None, description="Identifier of the producing agent.")
+    parent_agent_id: str | None = Field(default=None, description="Spawning agent's ID (multi-agent lineage).")
+    conversation: ConversationContext | None = Field(default=None, description="Windowed conversation context.")

--- a/cpex/framework/extensions/agent.py
+++ b/cpex/framework/extensions/agent.py
@@ -12,7 +12,6 @@ modifiable by processing components.
 """
 
 # Standard
-from typing import Any
 
 # Third-Party
 from pydantic import BaseModel, ConfigDict, Field
@@ -42,9 +41,10 @@ class ConversationContext(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    history: list[Any] = Field(
+    history: list[BaseModel] = Field(
         default_factory=list,
-        description="Windowed message history (recent turns).",
+        description="Windowed message history (recent turns). Each entry is a typed model (e.g., CMF Message).",
+        max_length=100,
     )
     summary: str | None = Field(default=None, description="Summarized prior context.")
     topics: list[str] = Field(default_factory=list, description="Extracted topics or intents.")

--- a/cpex/framework/extensions/completion.py
+++ b/cpex/framework/extensions/completion.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/completion.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Completion extension models.
+Carries LLM completion information including stop reason, token usage,
+model identifier, wire format, and latency.
+Immutable tier — shared reference, no modifications allowed.
+"""
+
+# Standard
+from enum import Enum
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class StopReason(str, Enum):
+    """Closed-set enumeration of completion stop reasons.
+
+    Attributes:
+        END: Natural end of generation.
+        RETURN: Model returned a structured result.
+        CALL: Model made a tool call.
+        MAX_TOKENS: Generation stopped due to token limit.
+        STOP_SEQUENCE: Generation stopped at a stop sequence.
+
+    Examples:
+        >>> StopReason.END
+        <StopReason.END: 'end'>
+        >>> StopReason("max_tokens")
+        <StopReason.MAX_TOKENS: 'max_tokens'>
+    """
+
+    END = "end"
+    RETURN = "return"
+    CALL = "call"
+    MAX_TOKENS = "max_tokens"
+    STOP_SEQUENCE = "stop_sequence"
+
+
+class TokenUsage(BaseModel):
+    """Token consumption metrics for a completion.
+
+    Attributes:
+        input_tokens: Tokens consumed by the input.
+        output_tokens: Tokens generated in the output.
+        total_tokens: Total tokens (input + output).
+
+    Examples:
+        >>> usage = TokenUsage(input_tokens=150, output_tokens=50, total_tokens=200)
+        >>> usage.total_tokens
+        200
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    input_tokens: int = Field(description="Tokens consumed by the input.")
+    output_tokens: int = Field(description="Tokens generated in the output.")
+    total_tokens: int = Field(description="Total tokens (input + output).")
+
+
+class CompletionExtension(BaseModel):
+    """LLM completion information.
+
+    Fields like model and stop_reason can drive policy decisions
+    (e.g., "only allow gpt-4 for financial queries", "flag max_tokens
+    responses for review"). Immutable — the processing pipeline rejects
+    any modifications.
+
+    Attributes:
+        stop_reason: Why the model stopped.
+        tokens: Token counts.
+        model: Model identifier that generated this response.
+        raw_format: Original wire format (chatml, harmony, gemini, anthropic).
+        created_at: ISO timestamp when the message was created.
+        latency_ms: Response generation time in milliseconds.
+
+    Examples:
+        >>> ext = CompletionExtension(
+        ...     stop_reason=StopReason.END,
+        ...     tokens=TokenUsage(input_tokens=100, output_tokens=50, total_tokens=150),
+        ...     model="gpt-4o",
+        ...     latency_ms=1200,
+        ... )
+        >>> ext.stop_reason
+        <StopReason.END: 'end'>
+        >>> ext.tokens.total_tokens
+        150
+        >>> ext.latency_ms
+        1200
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    stop_reason: StopReason | None = Field(default=None, description="Why the model stopped.")
+    tokens: TokenUsage | None = Field(default=None, description="Token counts.")
+    model: str | None = Field(default=None, description="Model identifier that generated this response.")
+    raw_format: str | None = Field(
+        default=None, description="Original wire format (chatml, harmony, gemini, anthropic)."
+    )
+    created_at: str | None = Field(default=None, description="ISO timestamp when the message was created.")
+    latency_ms: int | None = Field(default=None, description="Response generation time in milliseconds.")

--- a/cpex/framework/extensions/constants.py
+++ b/cpex/framework/extensions/constants.py
@@ -30,6 +30,14 @@ class SlotName(str, Enum):
     """
 
     def __str__(self) -> str:
+        """Return the enum value as a plain string.
+
+        Overrides the default ``StrEnum.__str__`` which renders as
+        ``ClassName.MEMBER`` in Python 3.11+.
+
+        Returns:
+            The raw string value of the enum member.
+        """
         return self.value
 
     REQUEST = "request"

--- a/cpex/framework/extensions/constants.py
+++ b/cpex/framework/extensions/constants.py
@@ -49,6 +49,7 @@ class SlotName(str, Enum):
     AGENT = "agent"
     HTTP = "http"
     META = "meta"
+    DELEGATION = "delegation"
     CUSTOM = "custom"
 
     # Security sub-fields
@@ -78,6 +79,7 @@ FIELD_MCP: str = "mcp"
 FIELD_AGENT: str = "agent"
 FIELD_HTTP: str = "http"
 FIELD_META: str = "meta"
+FIELD_DELEGATION: str = "delegation"
 FIELD_CUSTOM: str = "custom"
 FIELD_SECURITY: str = "security"
 

--- a/cpex/framework/extensions/constants.py
+++ b/cpex/framework/extensions/constants.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/constants.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Extension constants.
+
+Single source of truth for slot names and field names used in the
+slot registry, filter_extensions(), merge_extensions(), and
+validate_tier_constraints(). Using these constants instead of bare
+strings prevents typo-induced duplicates.
+"""
+
+# Standard
+from __future__ import annotations
+
+from enum import Enum
+
+# ---------------------------------------------------------------------------
+# Slot Registry Names (dot-notation paths for nested sub-fields)
+# ---------------------------------------------------------------------------
+
+
+class SlotName(str, Enum):
+    """Canonical slot names for extension fields and sub-fields.
+
+    Top-level names correspond to Extensions model attributes.
+    Dotted names represent nested sub-fields (e.g., security.subject.roles).
+    """
+
+    def __str__(self) -> str:
+        return self.value
+
+    REQUEST = "request"
+    PROVENANCE = "provenance"
+    COMPLETION = "completion"
+    LLM = "llm"
+    FRAMEWORK = "framework"
+    MCP = "mcp"
+    AGENT = "agent"
+    HTTP = "http"
+    CUSTOM = "custom"
+
+    # Security sub-fields
+    SECURITY_SUBJECT = "security.subject"
+    SECURITY_SUBJECT_ROLES = "security.subject.roles"
+    SECURITY_SUBJECT_TEAMS = "security.subject.teams"
+    SECURITY_SUBJECT_CLAIMS = "security.subject.claims"
+    SECURITY_SUBJECT_PERMISSIONS = "security.subject.permissions"
+    SECURITY_OBJECTS = "security.objects"
+    SECURITY_DATA = "security.data"
+    SECURITY_LABELS = "security.labels"
+
+
+# ---------------------------------------------------------------------------
+# Pydantic Field Name Constants
+# ---------------------------------------------------------------------------
+# Used as keys in model_copy(update={...}) dicts and Extensions(**fields)
+# construction. These match the Pydantic model attribute names exactly.
+
+# Extensions model fields
+FIELD_REQUEST: str = "request"
+FIELD_PROVENANCE: str = "provenance"
+FIELD_COMPLETION: str = "completion"
+FIELD_LLM: str = "llm"
+FIELD_FRAMEWORK: str = "framework"
+FIELD_MCP: str = "mcp"
+FIELD_AGENT: str = "agent"
+FIELD_HTTP: str = "http"
+FIELD_CUSTOM: str = "custom"
+FIELD_SECURITY: str = "security"
+
+# SecurityExtension model fields
+FIELD_LABELS: str = "labels"
+FIELD_CLASSIFICATION: str = "classification"
+FIELD_SUBJECT: str = "subject"
+FIELD_OBJECTS: str = "objects"
+FIELD_DATA: str = "data"
+
+# SubjectExtension model fields
+FIELD_ROLES: str = "roles"
+FIELD_TEAMS: str = "teams"
+FIELD_CLAIMS: str = "claims"
+FIELD_PERMISSIONS: str = "permissions"

--- a/cpex/framework/extensions/constants.py
+++ b/cpex/framework/extensions/constants.py
@@ -48,6 +48,7 @@ class SlotName(str, Enum):
     MCP = "mcp"
     AGENT = "agent"
     HTTP = "http"
+    META = "meta"
     CUSTOM = "custom"
 
     # Security sub-fields
@@ -76,6 +77,7 @@ FIELD_FRAMEWORK: str = "framework"
 FIELD_MCP: str = "mcp"
 FIELD_AGENT: str = "agent"
 FIELD_HTTP: str = "http"
+FIELD_META: str = "meta"
 FIELD_CUSTOM: str = "custom"
 FIELD_SECURITY: str = "security"
 

--- a/cpex/framework/extensions/delegation.py
+++ b/cpex/framework/extensions/delegation.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/delegation.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Delegation extension models.
+Carries the delegation chain state through the CMF message for policy
+evaluation. The chain grows monotonically — each hop appends, never
+removes. Scope narrowing is enforced at the framework level.
+
+See: docs/delegation-hooks-design.md
+"""
+
+# Standard
+from datetime import datetime
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DelegationHop(BaseModel):
+    """One hop in the delegation chain.
+
+    Each hop represents one step: "entity X delegated to entity Y
+    for audience Z with these scopes." Immutable once created.
+
+    Attributes:
+        subject_id: Who is acting at this hop.
+        subject_type: Entity kind (user, agent, service).
+        audience: Target audience for this hop's token.
+        scopes_granted: What this hop's token can do.
+        timestamp: When this hop was created.
+        ttl_seconds: Token lifetime for this hop.
+        strategy: How the token was obtained (token_exchange, ucan, etc.).
+        from_cache: Whether the token came from cache.
+
+    Examples:
+        >>> hop = DelegationHop(
+        ...     subject_id="alice@corp.com",
+        ...     subject_type="user",
+        ...     scopes_granted=("read:compensation",),
+        ...     timestamp=datetime(2025, 1, 1),
+        ...     strategy="token_exchange",
+        ... )
+        >>> hop.subject_id
+        'alice@corp.com'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    subject_id: str = Field(description="Who is acting at this hop.")
+    subject_type: str = Field(description="Entity kind: user, agent, service, system.")
+    audience: str | None = Field(default=None, description="Target audience for this hop's token.")
+    scopes_granted: tuple[str, ...] = Field(default=(), description="Scopes this hop's token grants.")
+    timestamp: datetime = Field(default_factory=datetime.utcnow, description="When this hop was created.")
+    ttl_seconds: int | None = Field(default=None, description="Token lifetime in seconds.")
+    strategy: str | None = Field(default=None, description="Token strategy: token_exchange, ucan, passthrough, etc.")
+    from_cache: bool = Field(default=False, description="Whether the token came from cache.")
+
+
+class DelegationExtension(BaseModel):
+    """Delegation chain state carried in the CMF message.
+
+    Mutability tiers:
+    - chain: monotonic (grows with each hop, never shrinks)
+    - origin_subject_id, delegated: immutable (set at first delegation)
+    - actor_subject_id: updates per hop (current actor changes)
+
+    The chain is available to the DSL via the delegation.* namespace:
+        delegation.origin, delegation.actor, delegation.depth,
+        delegation.age, delegated
+
+    Attributes:
+        chain: Ordered list of delegation hops (monotonic growth).
+        depth: Number of hops in the chain.
+        origin_subject_id: Original caller (immutable once set).
+        actor_subject_id: Current actor (latest hop's subject).
+        delegated: Whether this request is delegated.
+        age_seconds: Seconds since the original delegation.
+
+    Examples:
+        >>> ext = DelegationExtension()
+        >>> ext.delegated
+        False
+        >>> ext.depth
+        0
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    chain: tuple[DelegationHop, ...] = Field(default=(), description="Ordered delegation hops.")
+    depth: int = Field(default=0, description="Number of hops.")
+    origin_subject_id: str | None = Field(default=None, description="Original caller.")
+    actor_subject_id: str | None = Field(default=None, description="Current actor.")
+    delegated: bool = Field(default=False, description="Whether this is a delegated request.")
+    age_seconds: float = Field(default=0.0, description="Seconds since original delegation.")
+
+    def with_new_hop(self, hop: DelegationHop) -> "DelegationExtension":
+        """Create a new DelegationExtension with an appended hop.
+
+        Returns a new instance — the original is unchanged (immutable).
+        The framework enforces scope narrowing before calling this.
+
+        Args:
+            hop: The new delegation hop to append.
+
+        Returns:
+            New DelegationExtension with the hop appended.
+        """
+        new_chain = self.chain + (hop,)
+        origin = self.origin_subject_id or hop.subject_id
+        age = (datetime.utcnow() - self.chain[0].timestamp).total_seconds() if self.chain else 0.0
+        return DelegationExtension(
+            chain=new_chain,
+            depth=len(new_chain),
+            origin_subject_id=origin,
+            actor_subject_id=hop.subject_id,
+            delegated=True,
+            age_seconds=age,
+        )

--- a/cpex/framework/extensions/delegation.py
+++ b/cpex/framework/extensions/delegation.py
@@ -13,7 +13,7 @@ See: docs/delegation-hooks-design.md
 """
 
 # Standard
-from datetime import datetime
+from datetime import UTC, datetime
 
 # Third-Party
 from pydantic import BaseModel, ConfigDict, Field
@@ -53,7 +53,7 @@ class DelegationHop(BaseModel):
     subject_type: str = Field(description="Entity kind: user, agent, service, system.")
     audience: str | None = Field(default=None, description="Target audience for this hop's token.")
     scopes_granted: tuple[str, ...] = Field(default=(), description="Scopes this hop's token grants.")
-    timestamp: datetime = Field(default_factory=datetime.utcnow, description="When this hop was created.")
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC), description="When this hop was created.")
     ttl_seconds: int | None = Field(default=None, description="Token lifetime in seconds.")
     strategy: str | None = Field(default=None, description="Token strategy: token_exchange, ucan, passthrough, etc.")
     from_cache: bool = Field(default=False, description="Whether the token came from cache.")
@@ -110,7 +110,7 @@ class DelegationExtension(BaseModel):
         """
         new_chain = self.chain + (hop,)
         origin = self.origin_subject_id or hop.subject_id
-        age = (datetime.utcnow() - self.chain[0].timestamp).total_seconds() if self.chain else 0.0
+        age = (datetime.now(UTC) - self.chain[0].timestamp).total_seconds() if self.chain else 0.0
         return DelegationExtension(
             chain=new_chain,
             depth=len(new_chain),

--- a/cpex/framework/extensions/extensions.py
+++ b/cpex/framework/extensions/extensions.py
@@ -24,6 +24,7 @@ from cpex.framework.extensions.framework import FrameworkExtension
 from cpex.framework.extensions.http import HttpExtension
 from cpex.framework.extensions.llm import LLMExtension
 from cpex.framework.extensions.mcp import MCPExtension
+from cpex.framework.extensions.meta import MetaExtension
 from cpex.framework.extensions.provenance import ProvenanceExtension
 from cpex.framework.extensions.request import RequestExtension
 from cpex.framework.extensions.security import SecurityExtension
@@ -49,6 +50,7 @@ class Extensions(BaseModel):
         provenance: Source, message ID, parent ID (immutable).
         llm: Model identity and capabilities (immutable).
         framework: Agentic framework context (immutable).
+        meta: Host-provided operational metadata — tags, scope, properties (immutable).
         custom: Custom extensions (mutable).
 
     Examples:
@@ -89,4 +91,5 @@ class Extensions(BaseModel):
     provenance: ProvenanceExtension | None = Field(default=None, description="Origin and threading.")
     llm: LLMExtension | None = Field(default=None, description="Model identity and capabilities.")
     framework: FrameworkExtension | None = Field(default=None, description="Agentic framework context.")
+    meta: MetaExtension | None = Field(default=None, description="Host-provided operational metadata.")
     custom: dict[str, Any] | None = Field(default=None, description="Custom extensions (mutable).")

--- a/cpex/framework/extensions/extensions.py
+++ b/cpex/framework/extensions/extensions.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/extensions.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Extensions container model.
+Aggregates all typed extension models into a single container that
+attaches to a Message. Each extension slot corresponds to a specific
+mutability tier enforced by the processing pipeline.
+"""
+
+# Standard
+from typing import Any
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+# First-Party
+from cpex.framework.extensions.agent import AgentExtension
+from cpex.framework.extensions.completion import CompletionExtension
+from cpex.framework.extensions.framework import FrameworkExtension
+from cpex.framework.extensions.http import HttpExtension
+from cpex.framework.extensions.llm import LLMExtension
+from cpex.framework.extensions.mcp import MCPExtension
+from cpex.framework.extensions.provenance import ProvenanceExtension
+from cpex.framework.extensions.request import RequestExtension
+from cpex.framework.extensions.security import SecurityExtension
+
+
+class Extensions(BaseModel):
+    """Container for all typed message extensions.
+
+    Each extension slot carries contextual metadata with an explicit
+    mutability tier enforced by the processing pipeline during
+    copy-on-write operations.
+
+    Frozen by design — consumers must use model_copy(update={...})
+    to create modified copies.
+
+    Attributes:
+        request: Execution environment, request ID, timestamp, tracing (immutable).
+        agent: Session tracking, multi-agent lineage, user intent (immutable).
+        http: HTTP headers with capability-gated access (guarded).
+        security: Labels, classification, identity, access control, data policy (monotonic/immutable).
+        mcp: Tool, resource, or prompt metadata (immutable).
+        completion: Stop reason, token usage, model, latency (immutable).
+        provenance: Source, message ID, parent ID (immutable).
+        llm: Model identity and capabilities (immutable).
+        framework: Agentic framework context (immutable).
+        custom: Custom extensions (mutable).
+
+    Examples:
+        >>> ext = Extensions(
+        ...     request=RequestExtension(
+        ...         environment="production",
+        ...         request_id="req-001",
+        ...     ),
+        ...     llm=LLMExtension(
+        ...         model_id="gpt-4o",
+        ...         provider="openai",
+        ...     ),
+        ... )
+        >>> ext.request.environment
+        'production'
+        >>> ext.llm.provider
+        'openai'
+        >>> ext.security is None
+        True
+
+        >>> # Frozen: modifications require model_copy
+        >>> updated = ext.model_copy(update={"custom": {"trace": True}})
+        >>> updated.custom
+        {'trace': True}
+        >>> ext.custom is None
+        True
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    request: RequestExtension | None = Field(default=None, description="Execution environment and tracing.")
+    agent: AgentExtension | None = Field(default=None, description="Agent execution context.")
+    http: HttpExtension | None = Field(default=None, description="HTTP request context.")
+    security: SecurityExtension | None = Field(default=None, description="Security labels and identity.")
+    mcp: MCPExtension | None = Field(default=None, description="MCP entity metadata.")
+    completion: CompletionExtension | None = Field(default=None, description="LLM completion information.")
+    provenance: ProvenanceExtension | None = Field(default=None, description="Origin and threading.")
+    llm: LLMExtension | None = Field(default=None, description="Model identity and capabilities.")
+    framework: FrameworkExtension | None = Field(default=None, description="Agentic framework context.")
+    custom: dict[str, Any] | None = Field(default=None, description="Custom extensions (mutable).")

--- a/cpex/framework/extensions/extensions.py
+++ b/cpex/framework/extensions/extensions.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, ConfigDict, Field
 # First-Party
 from cpex.framework.extensions.agent import AgentExtension
 from cpex.framework.extensions.completion import CompletionExtension
+from cpex.framework.extensions.delegation import DelegationExtension
 from cpex.framework.extensions.framework import FrameworkExtension
 from cpex.framework.extensions.http import HttpExtension
 from cpex.framework.extensions.llm import LLMExtension
@@ -82,6 +83,7 @@ class Extensions(BaseModel):
     agent: AgentExtension | None = Field(default=None, description="Agent execution context.")
     http: HttpExtension | None = Field(default=None, description="HTTP request context.")
     security: SecurityExtension | None = Field(default=None, description="Security labels and identity.")
+    delegation: DelegationExtension | None = Field(default=None, description="Delegation chain state.")
     mcp: MCPExtension | None = Field(default=None, description="MCP entity metadata.")
     completion: CompletionExtension | None = Field(default=None, description="LLM completion information.")
     provenance: ProvenanceExtension | None = Field(default=None, description="Origin and threading.")

--- a/cpex/framework/extensions/framework.py
+++ b/cpex/framework/extensions/framework.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/framework.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Framework extension model.
+Captures the agentic framework execution environment for messages
+originating from or passing through orchestration layers.
+Immutable tier — shared reference, no modifications allowed.
+"""
+
+# Standard
+from typing import Any
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class FrameworkExtension(BaseModel):
+    """Agentic framework execution context.
+
+    Captures framework-level metadata for messages that originate
+    from or pass through agentic orchestration layers (LangGraph,
+    CrewAI, AutoGen, A2A, etc.). Immutable — the processing pipeline
+    rejects any modifications.
+
+    Attributes:
+        framework: Framework identifier (e.g., langgraph, crewai, autogen, a2a).
+        framework_version: Framework version.
+        node_id: Framework-specific node or step identifier.
+        graph_id: Graph or workflow identifier.
+        metadata: Framework-specific metadata.
+
+    Examples:
+        >>> ext = FrameworkExtension(
+        ...     framework="langgraph",
+        ...     framework_version="0.2.0",
+        ...     node_id="weather_node",
+        ...     graph_id="travel_planner",
+        ... )
+        >>> ext.framework
+        'langgraph'
+        >>> ext.node_id
+        'weather_node'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    framework: str | None = Field(default=None, description="Framework identifier.")
+    framework_version: str | None = Field(default=None, description="Framework version.")
+    node_id: str | None = Field(default=None, description="Framework-specific node or step identifier.")
+    graph_id: str | None = Field(default=None, description="Graph or workflow identifier.")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Framework-specific metadata.")

--- a/cpex/framework/extensions/http.py
+++ b/cpex/framework/extensions/http.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/http.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+HTTP extension model.
+Carries HTTP request context with capability-gated access.
+Guarded tier — readable with read_headers, writable with write_headers.
+"""
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class HttpExtension(BaseModel):
+    """HTTP request context.
+
+    Readable with the read_headers capability, writable with
+    write_headers. Sensitive headers (Authorization, Cookie, X-API-Key)
+    are stripped when serialized for external policy engines.
+
+    Guarded tier — the processing pipeline rejects modifications
+    unless the consumer holds the write_headers capability.
+
+    Attributes:
+        headers: HTTP headers as key-value pairs.
+
+    Examples:
+        >>> ext = HttpExtension(
+        ...     headers={"Content-Type": "application/json", "X-Request-ID": "req-123"},
+        ... )
+        >>> ext.headers["Content-Type"]
+        'application/json'
+
+        >>> # Frozen: modifications require model_copy
+        >>> updated = ext.model_copy(
+        ...     update={"headers": {**ext.headers, "X-Trace-ID": "trace-456"}},
+        ... )
+        >>> "X-Trace-ID" in updated.headers
+        True
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    headers: dict[str, str] = Field(default_factory=dict, description="HTTP headers as key-value pairs.")

--- a/cpex/framework/extensions/llm.py
+++ b/cpex/framework/extensions/llm.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/llm.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+LLM extension model.
+Carries model identity and capability metadata for routing,
+policy evaluation, and audit.
+Immutable tier — shared reference, no modifications allowed.
+"""
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class LLMExtension(BaseModel):
+    """Model identity and capability metadata.
+
+    Used for routing, policy evaluation, and audit when the producing
+    model's identity matters independently of the completion itself.
+    Immutable — the processing pipeline rejects any modifications.
+
+    Attributes:
+        model_id: Model identifier (e.g., gpt-4o, claude-sonnet-4-20250514).
+        provider: Provider name (e.g., openai, anthropic, google).
+        capabilities: Declared model capabilities (e.g., vision, tool_use, extended_thinking).
+
+    Examples:
+        >>> ext = LLMExtension(
+        ...     model_id="claude-sonnet-4-20250514",
+        ...     provider="anthropic",
+        ...     capabilities=["vision", "tool_use", "extended_thinking"],
+        ... )
+        >>> ext.provider
+        'anthropic'
+        >>> "tool_use" in ext.capabilities
+        True
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    model_id: str | None = Field(default=None, description="Model identifier.")
+    provider: str | None = Field(default=None, description="Provider name.")
+    capabilities: list[str] = Field(default_factory=list, description="Declared model capabilities.")

--- a/cpex/framework/extensions/mcp.py
+++ b/cpex/framework/extensions/mcp.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/mcp.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+MCP extension models.
+Carries typed metadata about MCP entities (tools, resources, prompts)
+being processed. Gives consumers access to schemas and annotations.
+Immutable tier — shared reference, no modifications allowed.
+"""
+
+# Standard
+from typing import Any
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ToolMetadata(BaseModel):
+    """Typed metadata for an MCP tool.
+
+    Attributes:
+        name: Unique tool identifier.
+        title: Human-readable display name.
+        description: Description of tool functionality.
+        input_schema: JSON Schema defining expected parameters.
+        output_schema: JSON Schema for structured output.
+        server_id: ID of the server providing this tool.
+        namespace: Tool namespace (server/origin).
+        annotations: MCP annotations (e.g., readOnlyHint, destructiveHint).
+
+    Examples:
+        >>> meta = ToolMetadata(
+        ...     name="get_user",
+        ...     description="Retrieve user by ID",
+        ...     input_schema={"type": "object", "properties": {"id": {"type": "string"}}},
+        ...     server_id="user-service",
+        ... )
+        >>> meta.name
+        'get_user'
+        >>> meta.server_id
+        'user-service'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str = Field(description="Unique tool identifier.")
+    title: str | None = Field(default=None, description="Human-readable display name.")
+    description: str | None = Field(default=None, description="Description of tool functionality.")
+    input_schema: dict[str, Any] | None = Field(default=None, description="JSON Schema defining expected parameters.")
+    output_schema: dict[str, Any] | None = Field(default=None, description="JSON Schema for structured output.")
+    server_id: str | None = Field(default=None, description="ID of the server providing this tool.")
+    namespace: str | None = Field(default=None, description="Tool namespace (server/origin).")
+    annotations: dict[str, Any] = Field(default_factory=dict, description="MCP annotations.")
+
+
+class ResourceMetadata(BaseModel):
+    """Typed metadata for an MCP resource.
+
+    Attributes:
+        uri: Resource URI.
+        name: Resource name.
+        description: Resource description.
+        mime_type: MIME type (text/csv, application/json, etc.).
+        server_id: ID of the server providing this resource.
+        annotations: MCP annotations (classification, retention, access hints).
+
+    Examples:
+        >>> meta = ResourceMetadata(
+        ...     uri="file:///data/report.csv",
+        ...     name="Quarterly Report",
+        ...     mime_type="text/csv",
+        ... )
+        >>> meta.uri
+        'file:///data/report.csv'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    uri: str = Field(description="Resource URI.")
+    name: str | None = Field(default=None, description="Resource name.")
+    description: str | None = Field(default=None, description="Resource description.")
+    mime_type: str | None = Field(default=None, description="MIME type.")
+    server_id: str | None = Field(default=None, description="ID of the server providing this resource.")
+    annotations: dict[str, Any] = Field(default_factory=dict, description="MCP annotations.")
+
+
+class PromptMetadata(BaseModel):
+    """Typed metadata for an MCP prompt template.
+
+    Prompts use an argument list rather than JSON Schema for input
+    definition, following the MCP prompt specification. There is no
+    output schema — prompt output is always rendered messages.
+
+    Attributes:
+        name: Prompt template name.
+        description: Prompt description.
+        arguments: Argument definitions (each has name, description, required).
+        server_id: ID of the server providing this prompt.
+        annotations: MCP annotations.
+
+    Examples:
+        >>> meta = PromptMetadata(
+        ...     name="summarize",
+        ...     description="Summarize a document",
+        ...     arguments=[
+        ...         {"name": "text", "description": "Text to summarize", "required": True},
+        ...     ],
+        ... )
+        >>> meta.name
+        'summarize'
+        >>> meta.arguments[0]["name"]
+        'text'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str = Field(description="Prompt template name.")
+    description: str | None = Field(default=None, description="Prompt description.")
+    arguments: list[dict[str, Any]] | None = Field(default=None, description="Argument definitions.")
+    server_id: str | None = Field(default=None, description="ID of the server providing this prompt.")
+    annotations: dict[str, Any] = Field(default_factory=dict, description="MCP annotations.")
+
+
+class MCPExtension(BaseModel):
+    """Typed metadata about the MCP entity being processed.
+
+    Exactly one of tool, resource, or prompt is populated per message,
+    depending on the content type. Immutable — the processing pipeline
+    rejects any modifications.
+
+    Attributes:
+        tool: Tool metadata (populated for tool_call / tool_result content).
+        resource: Resource metadata (populated for resource / resource_ref content).
+        prompt: Prompt metadata (populated for prompt_request / prompt_result content).
+
+    Examples:
+        >>> ext = MCPExtension(
+        ...     tool=ToolMetadata(name="get_user", description="Retrieve user by ID"),
+        ... )
+        >>> ext.tool.name
+        'get_user'
+        >>> ext.resource is None
+        True
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    tool: ToolMetadata | None = Field(default=None, description="Tool metadata.")
+    resource: ResourceMetadata | None = Field(default=None, description="Resource metadata.")
+    prompt: PromptMetadata | None = Field(default=None, description="Prompt metadata.")

--- a/cpex/framework/extensions/meta.py
+++ b/cpex/framework/extensions/meta.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/meta.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Meta extension model.
+Host-provided operational metadata about the entity being processed.
+Set by the host system (gateway registration, static config, MCP manifest)
+before the plugin pipeline runs. Immutable tier — plugins can read
+this data for routing and policy decisions but cannot modify it.
+
+Protocol-agnostic: carries the same structure regardless of whether the
+entity came from MCP, A2A, gRPC, or REST.
+"""
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MetaExtension(BaseModel):
+    """Host-provided operational metadata about the entity being processed.
+
+    Tags drive route matching and policy group inheritance. Scope provides
+    a host-defined grouping (e.g., virtual server ID, namespace). Properties
+    carry arbitrary key-value metadata available in policy conditions.
+
+    Immutable — the processing pipeline rejects any modifications.
+    Tags are set by the host and static config before the pipeline runs.
+    For pipeline-accumulated labels, use ``SecurityExtension.labels`` instead.
+
+    Attributes:
+        tags: Entity tags (e.g., ``pii``, ``hr``, ``external-comms``).
+            Merged from static config and host-injected runtime tags.
+        scope: Host-defined grouping. ContextForge maps this to virtual
+            server ID, Kagenti to namespace, etc. CPEX core treats it
+            as an opaque string for matching.
+        properties: Arbitrary key-value metadata (e.g., ``owner``,
+            ``region``, ``data_classification``). Available in policy
+            conditions as ``meta.properties.{key}``.
+
+    Examples:
+        >>> ext = MetaExtension(
+        ...     tags=frozenset({"pii", "hr"}),
+        ...     scope="hr-services",
+        ...     properties={"owner": "hr-team", "data_classification": "confidential"},
+        ... )
+        >>> "pii" in ext.tags
+        True
+        >>> ext.scope
+        'hr-services'
+        >>> ext.properties["owner"]
+        'hr-team'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    tags: frozenset[str] = Field(default_factory=frozenset, description="Entity tags for routing and policy group inheritance.")
+    scope: str | None = Field(default=None, description="Host-defined grouping (opaque string for matching).")
+    properties: dict[str, str] = Field(default_factory=dict, description="Arbitrary key-value metadata.")

--- a/cpex/framework/extensions/meta.py
+++ b/cpex/framework/extensions/meta.py
@@ -55,6 +55,8 @@ class MetaExtension(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    tags: frozenset[str] = Field(default_factory=frozenset, description="Entity tags for routing and policy group inheritance.")
+    tags: frozenset[str] = Field(
+        default_factory=frozenset, description="Entity tags for routing and policy group inheritance."
+    )
     scope: str | None = Field(default=None, description="Host-defined grouping (opaque string for matching).")
     properties: dict[str, str] = Field(default_factory=dict, description="Arbitrary key-value metadata.")

--- a/cpex/framework/extensions/provenance.py
+++ b/cpex/framework/extensions/provenance.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/provenance.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Provenance extension model.
+Carries origin and threading information for lineage tracking
+across multi-turn conversations and multi-agent systems.
+Immutable tier — shared reference, no modifications allowed.
+"""
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ProvenanceExtension(BaseModel):
+    """Origin and threading information for the message.
+
+    Enables lineage tracking across multi-turn conversations and
+    multi-agent systems. Immutable — the processing pipeline rejects
+    any modifications.
+
+    Attributes:
+        source: Source identifier (e.g., "user", "agent:xyz", "mcp-server:abc").
+        message_id: Unique message identifier.
+        parent_id: Parent message ID (threading/replies).
+
+    Examples:
+        >>> ext = ProvenanceExtension(
+        ...     source="agent:weather-bot",
+        ...     message_id="msg-001",
+        ...     parent_id="msg-000",
+        ... )
+        >>> ext.source
+        'agent:weather-bot'
+        >>> ext.message_id
+        'msg-001'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    source: str | None = Field(default=None, description="Source identifier.")
+    message_id: str | None = Field(default=None, description="Unique message identifier.")
+    parent_id: str | None = Field(default=None, description="Parent message ID (threading/replies).")

--- a/cpex/framework/extensions/request.py
+++ b/cpex/framework/extensions/request.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/request.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Request extension model.
+Carries execution environment and request-level timing/tracing metadata.
+Immutable tier — shared reference, no modifications allowed.
+"""
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RequestExtension(BaseModel):
+    """Execution environment and request-level timing/tracing.
+
+    Available to all consumers without any capability requirement (base tier).
+    Immutable — the processing pipeline rejects any modifications.
+
+    Attributes:
+        environment: Execution environment (production, staging, dev).
+        request_id: Request correlation ID.
+        timestamp: ISO timestamp of the request.
+        trace_id: Distributed tracing ID (OpenTelemetry).
+        span_id: Distributed tracing span ID.
+
+    Examples:
+        >>> ext = RequestExtension(
+        ...     environment="production",
+        ...     request_id="req-abc-123",
+        ...     timestamp="2025-01-15T10:30:00Z",
+        ... )
+        >>> ext.environment
+        'production'
+        >>> ext.request_id
+        'req-abc-123'
+
+        >>> # Frozen: modifications require model_copy
+        >>> updated = ext.model_copy(update={"span_id": "span-456"})
+        >>> updated.span_id
+        'span-456'
+        >>> ext.span_id is None
+        True
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    environment: str | None = Field(default=None, description="Execution environment (production, staging, dev).")
+    request_id: str | None = Field(default=None, description="Request correlation ID.")
+    timestamp: str | None = Field(default=None, description="ISO timestamp of the request.")
+    trace_id: str | None = Field(default=None, description="Distributed tracing ID (OpenTelemetry).")
+    span_id: str | None = Field(default=None, description="Distributed tracing span ID.")

--- a/cpex/framework/extensions/security.py
+++ b/cpex/framework/extensions/security.py
@@ -1,0 +1,247 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/security.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Security extension models.
+Carries data classification, security labels, authenticated identity,
+access control profiles, and data governance policies.
+
+The SecurityExtension itself is monotonic tier — labels can only be
+added, never removed, during normal message flow. Its nested fields
+(subject, objects, data) are immutable tier.
+"""
+
+# Standard
+from enum import Enum
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+# ---------------------------------------------------------------------------
+# Subject
+# ---------------------------------------------------------------------------
+
+
+class SubjectType(str, Enum):
+    """Closed-set enumeration of subject types.
+
+    Attributes:
+        USER: Human user.
+        AGENT: Autonomous agent.
+        SERVICE: Backend service.
+        SYSTEM: System-level principal.
+
+    Examples:
+        >>> SubjectType.USER
+        <SubjectType.USER: 'user'>
+        >>> SubjectType("agent")
+        <SubjectType.AGENT: 'agent'>
+    """
+
+    USER = "user"
+    AGENT = "agent"
+    SERVICE = "service"
+    SYSTEM = "system"
+
+
+class SubjectExtension(BaseModel):
+    """Authenticated entity making the request.
+
+    Access to individual fields is controlled by declared capabilities
+    on the MessageView. Immutable — the processing pipeline rejects
+    any modifications.
+
+    Attributes:
+        id: Unique subject identifier.
+        type: Subject kind.
+        roles: Assigned roles (developer, admin, viewer, etc.).
+        permissions: Granted permissions (tools.execute, db.read, etc.).
+        teams: Team memberships (for multi-tenant scoping).
+        claims: Raw identity claims (JWT, SAML).
+
+    Examples:
+        >>> subject = SubjectExtension(
+        ...     id="user-alice",
+        ...     type=SubjectType.USER,
+        ...     roles={"admin", "developer"},
+        ...     permissions={"tools.execute", "db.read"},
+        ... )
+        >>> subject.id
+        'user-alice'
+        >>> "admin" in subject.roles
+        True
+        >>> "db.read" in subject.permissions
+        True
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(description="Unique subject identifier.")
+    type: SubjectType = Field(description="Subject kind.")
+    roles: frozenset[str] = Field(default_factory=frozenset, description="Assigned roles.")
+    permissions: frozenset[str] = Field(default_factory=frozenset, description="Granted permissions.")
+    teams: frozenset[str] = Field(default_factory=frozenset, description="Team memberships.")
+    claims: dict[str, str] = Field(default_factory=dict, description="Raw identity claims (JWT, SAML).")
+
+
+# ---------------------------------------------------------------------------
+# Object Security Profile
+# ---------------------------------------------------------------------------
+
+
+class ObjectSecurityProfile(BaseModel):
+    """Access control contract declared by or for an object.
+
+    Lives on extensions.security.objects, keyed by entity name/URI.
+    Evaluated on pre-hook views (tool_call, resource request, prompt
+    request). Immutable — the processing pipeline rejects any
+    modifications.
+
+    Attributes:
+        managed_by: Who enforces access control: host, tool, or both.
+        permissions: Required permissions to invoke.
+        trust_domain: Trust domain: internal, external, or privileged.
+        data_scope: Field names this entity accesses/returns.
+
+    Examples:
+        >>> profile = ObjectSecurityProfile(
+        ...     managed_by="tool",
+        ...     permissions=["read:compensation"],
+        ...     trust_domain="internal",
+        ...     data_scope=["salary", "bonus"],
+        ... )
+        >>> profile.managed_by
+        'tool'
+        >>> "read:compensation" in profile.permissions
+        True
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    managed_by: str = Field(default="host", description="Who enforces access control: host, tool, or both.")
+    permissions: list[str] = Field(default_factory=list, description="Required permissions to invoke.")
+    trust_domain: str | None = Field(default=None, description="Trust domain: internal, external, or privileged.")
+    data_scope: list[str] = Field(default_factory=list, description="Field names this entity accesses/returns.")
+
+
+# ---------------------------------------------------------------------------
+# Data Policy
+# ---------------------------------------------------------------------------
+
+
+class RetentionPolicy(BaseModel):
+    """Data retention constraints.
+
+    Attributes:
+        max_age_seconds: Maximum retention duration in seconds.
+        policy: Retention class: session, transient, persistent, or none.
+        delete_after: ISO timestamp after which data must be deleted.
+
+    Examples:
+        >>> ret = RetentionPolicy(policy="session", max_age_seconds=3600)
+        >>> ret.policy
+        'session'
+        >>> ret.max_age_seconds
+        3600
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    max_age_seconds: int | None = Field(default=None, description="Maximum retention duration in seconds.")
+    policy: str = Field(default="persistent", description="Retention class: session, transient, persistent, none.")
+    delete_after: str | None = Field(default=None, description="ISO timestamp after which data must be deleted.")
+
+
+class DataPolicy(BaseModel):
+    """Data governance policy for data returned by an entity.
+
+    Lives on extensions.security.data, keyed by entity name/URI.
+    Enforced on post-hook views (tool_result, resource response,
+    prompt result). Always enforced by the gateway — the tool
+    declares, the framework enforces. Immutable — the processing
+    pipeline rejects any modifications.
+
+    Attributes:
+        apply_labels: Labels to stamp on output (PII, financial, etc.).
+        allowed_actions: What downstream can do. None means unrestricted.
+        denied_actions: What downstream cannot do (export, forward, log_raw).
+        retention: How long data can be kept.
+
+    Examples:
+        >>> policy = DataPolicy(
+        ...     apply_labels=["PII", "financial"],
+        ...     denied_actions=["export", "forward", "log_raw"],
+        ...     retention=RetentionPolicy(policy="session", max_age_seconds=7200),
+        ... )
+        >>> "PII" in policy.apply_labels
+        True
+        >>> policy.retention.policy
+        'session'
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    apply_labels: list[str] = Field(default_factory=list, description="Labels to stamp on output.")
+    allowed_actions: list[str] | None = Field(
+        default=None, description="What downstream can do. None means unrestricted."
+    )
+    denied_actions: list[str] = Field(default_factory=list, description="What downstream cannot do.")
+    retention: RetentionPolicy | None = Field(default=None, description="How long data can be kept.")
+
+
+# ---------------------------------------------------------------------------
+# SecurityExtension
+# ---------------------------------------------------------------------------
+
+
+class SecurityExtension(BaseModel):
+    """Data classification, security labels, and security-relevant context.
+
+    Monotonic tier for labels — labels can only be added, never removed,
+    during normal message flow. Removal requires a privileged
+    declassification operation that is audited separately. The nested
+    fields (subject, objects, data) are immutable.
+
+    Attributes:
+        labels: Security/data labels (PII, CONFIDENTIAL, SECRET, etc.).
+        classification: Data classification level.
+        subject: Authenticated identity.
+        objects: Access control profiles, keyed by entity identifier.
+        data: Data governance policies, keyed by entity identifier.
+
+    Examples:
+        >>> ext = SecurityExtension(
+        ...     labels=frozenset({"PII", "CONFIDENTIAL"}),
+        ...     classification="confidential",
+        ...     subject=SubjectExtension(
+        ...         id="user-alice",
+        ...         type=SubjectType.USER,
+        ...         roles=frozenset({"admin"}),
+        ...     ),
+        ... )
+        >>> "PII" in ext.labels
+        True
+        >>> ext.subject.id
+        'user-alice'
+
+        >>> # Monotonic label addition via model_copy
+        >>> updated = ext.model_copy(update={"labels": ext.labels | frozenset({"financial"})})
+        >>> "financial" in updated.labels
+        True
+        >>> "PII" in updated.labels
+        True
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    labels: frozenset[str] = Field(default_factory=frozenset, description="Security/data labels.")
+    classification: str | None = Field(default=None, description="Data classification level.")
+    subject: SubjectExtension | None = Field(default=None, description="Authenticated identity.")
+    objects: dict[str, ObjectSecurityProfile] = Field(
+        default_factory=dict, description="Access control profiles, keyed by entity identifier."
+    )
+    data: dict[str, DataPolicy] = Field(
+        default_factory=dict, description="Data governance policies, keyed by entity identifier."
+    )

--- a/cpex/framework/extensions/tiers.py
+++ b/cpex/framework/extensions/tiers.py
@@ -1,0 +1,586 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/extensions/tiers.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Extension mutability tiers and capability-gated access.
+
+Defines the three mutability tiers (immutable, monotonic, mutable),
+the capability enum for gating extension visibility and writability,
+and the slot registry that maps each extension slot to its policy.
+
+Provides filter_extensions() for pre-hook capability filtering and
+validate_tier_constraints() for post-hook tier enforcement.
+"""
+
+# Standard
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from cpex.framework.extensions.constants import (
+    FIELD_AGENT,
+    FIELD_CLAIMS,
+    FIELD_CLASSIFICATION,
+    FIELD_COMPLETION,
+    FIELD_CUSTOM,
+    FIELD_DATA,
+    FIELD_FRAMEWORK,
+    FIELD_HTTP,
+    FIELD_LABELS,
+    FIELD_LLM,
+    FIELD_MCP,
+    FIELD_OBJECTS,
+    FIELD_PERMISSIONS,
+    FIELD_PROVENANCE,
+    FIELD_REQUEST,
+    FIELD_ROLES,
+    FIELD_SECURITY,
+    FIELD_SUBJECT,
+    FIELD_TEAMS,
+    SlotName,
+)
+from cpex.framework.extensions.extensions import Extensions
+from cpex.framework.extensions.security import SecurityExtension, SubjectExtension
+
+
+class MutabilityTier(str, Enum):
+    """Mutability tier for an extension slot.
+
+    Attributes:
+        IMMUTABLE: Set once, never changed. Pipeline rejects any delta.
+        MONOTONIC: Can only grow (add elements). Pipeline validates
+            before <= after.
+        MUTABLE: Freely modifiable through COW.
+    """
+
+    IMMUTABLE = "immutable"
+    MONOTONIC = "monotonic"
+    MUTABLE = "mutable"
+
+
+class Capability(str, Enum):
+    """Declared capabilities that a plugin can request.
+
+    Controls visibility (read) and writability (write/append) of
+    extension slots. Write/append capabilities imply their
+    corresponding read capability.
+
+    Attributes:
+        READ_SUBJECT: Access to subject.id and subject.type.
+        READ_ROLES: Access to subject.roles.
+        READ_TEAMS: Access to subject.teams.
+        READ_CLAIMS: Access to subject.claims.
+        READ_PERMISSIONS: Access to subject.permissions.
+        READ_AGENT: Access to AgentExtension.
+        READ_HEADERS: Read access to HTTP headers.
+        WRITE_HEADERS: Read + write access to HTTP headers.
+        READ_LABELS: Read access to security labels.
+        APPEND_LABELS: Read + append-only access to security labels.
+    """
+
+    READ_SUBJECT = "read_subject"
+    READ_ROLES = "read_roles"
+    READ_TEAMS = "read_teams"
+    READ_CLAIMS = "read_claims"
+    READ_PERMISSIONS = "read_permissions"
+    READ_AGENT = "read_agent"
+    READ_HEADERS = "read_headers"
+    WRITE_HEADERS = "write_headers"
+    READ_LABELS = "read_labels"
+    APPEND_LABELS = "append_labels"
+
+
+# Write/append capabilities that imply their read counterpart.
+_WRITE_IMPLIES_READ: dict[Capability, Capability] = {
+    Capability.WRITE_HEADERS: Capability.READ_HEADERS,
+    Capability.APPEND_LABELS: Capability.READ_LABELS,
+}
+
+# Subject sub-field capabilities that imply read_subject.
+_SUBJECT_IMPLIES_READ: frozenset[Capability] = frozenset(
+    {
+        Capability.READ_ROLES,
+        Capability.READ_TEAMS,
+        Capability.READ_CLAIMS,
+        Capability.READ_PERMISSIONS,
+    }
+)
+
+
+class AccessPolicy(str, Enum):
+    """Declares whether an extension slot requires capabilities for visibility.
+
+    Attributes:
+        UNRESTRICTED: Visible to all plugins regardless of capabilities.
+        CAPABILITY_GATED: Requires a declared capability for visibility.
+    """
+
+    UNRESTRICTED = "unrestricted"
+    CAPABILITY_GATED = "capability_gated"
+
+
+@dataclass(frozen=True)
+class SlotPolicy:
+    """Policy for a single extension slot or sub-field.
+
+    Attributes:
+        tier: The mutability tier.
+        access: Whether the slot is unrestricted or capability-gated.
+        read_cap: Capability required to see this slot (when capability-gated).
+        write_cap: Capability required to modify this slot.
+            None means no mutation path exists.
+    """
+
+    tier: MutabilityTier
+    access: AccessPolicy = AccessPolicy.UNRESTRICTED
+    read_cap: Capability | None = None
+    write_cap: Capability | None = None
+
+
+# ---------------------------------------------------------------------------
+# Slot Registry — single source of truth (internal only)
+# ---------------------------------------------------------------------------
+
+_SLOT_REGISTRY: dict[str, SlotPolicy] = {
+    # Unrestricted — always visible, always immutable
+    SlotName.REQUEST: SlotPolicy(MutabilityTier.IMMUTABLE),
+    SlotName.PROVENANCE: SlotPolicy(MutabilityTier.IMMUTABLE),
+    SlotName.COMPLETION: SlotPolicy(MutabilityTier.IMMUTABLE),
+    SlotName.LLM: SlotPolicy(MutabilityTier.IMMUTABLE),
+    SlotName.FRAMEWORK: SlotPolicy(MutabilityTier.IMMUTABLE),
+    SlotName.MCP: SlotPolicy(MutabilityTier.IMMUTABLE),
+    # Capability-gated, immutable
+    SlotName.AGENT: SlotPolicy(
+        MutabilityTier.IMMUTABLE,
+        access=AccessPolicy.CAPABILITY_GATED,
+        read_cap=Capability.READ_AGENT,
+    ),
+    # Subject — granular sub-field gating
+    SlotName.SECURITY_SUBJECT: SlotPolicy(
+        MutabilityTier.IMMUTABLE,
+        access=AccessPolicy.CAPABILITY_GATED,
+        read_cap=Capability.READ_SUBJECT,
+    ),
+    SlotName.SECURITY_SUBJECT_ROLES: SlotPolicy(
+        MutabilityTier.IMMUTABLE,
+        access=AccessPolicy.CAPABILITY_GATED,
+        read_cap=Capability.READ_ROLES,
+    ),
+    SlotName.SECURITY_SUBJECT_TEAMS: SlotPolicy(
+        MutabilityTier.IMMUTABLE,
+        access=AccessPolicy.CAPABILITY_GATED,
+        read_cap=Capability.READ_TEAMS,
+    ),
+    SlotName.SECURITY_SUBJECT_CLAIMS: SlotPolicy(
+        MutabilityTier.IMMUTABLE,
+        access=AccessPolicy.CAPABILITY_GATED,
+        read_cap=Capability.READ_CLAIMS,
+    ),
+    SlotName.SECURITY_SUBJECT_PERMISSIONS: SlotPolicy(
+        MutabilityTier.IMMUTABLE,
+        access=AccessPolicy.CAPABILITY_GATED,
+        read_cap=Capability.READ_PERMISSIONS,
+    ),
+    # Unrestricted — always visible sub-fields
+    SlotName.SECURITY_OBJECTS: SlotPolicy(MutabilityTier.IMMUTABLE),
+    SlotName.SECURITY_DATA: SlotPolicy(MutabilityTier.IMMUTABLE),
+    # Security labels — monotonic, capability-gated
+    SlotName.SECURITY_LABELS: SlotPolicy(
+        MutabilityTier.MONOTONIC,
+        access=AccessPolicy.CAPABILITY_GATED,
+        read_cap=Capability.READ_LABELS,
+        write_cap=Capability.APPEND_LABELS,
+    ),
+    # HTTP — capability-gated, writable with write cap
+    SlotName.HTTP: SlotPolicy(
+        MutabilityTier.IMMUTABLE,
+        access=AccessPolicy.CAPABILITY_GATED,
+        read_cap=Capability.READ_HEADERS,
+        write_cap=Capability.WRITE_HEADERS,
+    ),
+    # Unrestricted, mutable — no capability gate
+    SlotName.CUSTOM: SlotPolicy(MutabilityTier.MUTABLE),
+}
+
+# Read-only view — prevents mutation even if imported directly
+_slot_registry: Mapping[str, SlotPolicy] = MappingProxyType(_SLOT_REGISTRY)
+
+
+def _has_read_access(policy: SlotPolicy, capabilities: frozenset[str]) -> bool:
+    """Check if a plugin has read access to a slot.
+
+    A plugin has read access if:
+    - The slot has no read_cap (base tier, always visible), OR
+    - The plugin holds the read_cap, OR
+    - The plugin holds a write_cap that implies the read_cap, OR
+    - For subject sub-fields: any subject sub-field cap implies
+      read_subject.
+    """
+    if policy.access == AccessPolicy.UNRESTRICTED:
+        return True
+    if policy.read_cap.value in capabilities:
+        return True
+    # Check if any held write cap implies this read cap
+    for write_cap, implied_read in _WRITE_IMPLIES_READ.items():
+        if implied_read == policy.read_cap and write_cap.value in capabilities:
+            return True
+    # Check if any subject sub-field cap implies read_subject
+    if policy.read_cap == Capability.READ_SUBJECT:
+        for sub_cap in _SUBJECT_IMPLIES_READ:
+            if sub_cap.value in capabilities:
+                return True
+    return False
+
+
+def _has_subject_access(capabilities: frozenset[str]) -> bool:
+    """Check if a plugin has any subject-related capability."""
+    if Capability.READ_SUBJECT.value in capabilities:
+        return True
+    for sub_cap in _SUBJECT_IMPLIES_READ:
+        if sub_cap.value in capabilities:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Extension Filtering
+# ---------------------------------------------------------------------------
+
+
+def _build_filtered_subject(
+    subject: SubjectExtension,
+    capabilities: frozenset[str],
+) -> SubjectExtension:
+    """Build a filtered SubjectExtension containing only accessible fields.
+
+    Always includes id and type (base subject access). Individual
+    sub-fields (roles, teams, claims, permissions) are only populated
+    if the plugin holds the corresponding capability.
+    """
+    return subject.model_copy(
+        update={
+            FIELD_ROLES: subject.roles if Capability.READ_ROLES.value in capabilities else frozenset(),
+            FIELD_TEAMS: subject.teams if Capability.READ_TEAMS.value in capabilities else frozenset(),
+            FIELD_CLAIMS: subject.claims if Capability.READ_CLAIMS.value in capabilities else {},
+            FIELD_PERMISSIONS: (
+                subject.permissions if Capability.READ_PERMISSIONS.value in capabilities else frozenset()
+            ),
+        }
+    )
+
+
+def _build_filtered_security(
+    sec: SecurityExtension,
+    capabilities: frozenset[str],
+) -> SecurityExtension:
+    """Build a filtered SecurityExtension containing only accessible fields.
+
+    Unrestricted sub-fields (objects, data, classification) are always
+    included. Capability-gated sub-fields (labels, subject) are only
+    populated if the plugin holds the required capability.
+    """
+    fields: dict[str, Any] = {
+        # Unrestricted — always included
+        FIELD_OBJECTS: sec.objects,
+        FIELD_DATA: sec.data,
+        FIELD_CLASSIFICATION: sec.classification,
+    }
+
+    # Labels — capability-gated
+    if _has_read_access(_slot_registry[SlotName.SECURITY_LABELS], capabilities):
+        fields[FIELD_LABELS] = sec.labels
+    else:
+        fields[FIELD_LABELS] = frozenset()
+
+    # Subject — granular capability-gated
+    if sec.subject is not None and _has_subject_access(capabilities):
+        fields[FIELD_SUBJECT] = _build_filtered_subject(sec.subject, capabilities)
+    else:
+        fields[FIELD_SUBJECT] = None
+
+    return sec.model_copy(update=fields)
+
+
+def filter_extensions(
+    extensions: Extensions | None,
+    capabilities: frozenset[str],
+) -> Extensions | None:
+    """Build a new Extensions containing only slots the plugin can access.
+
+    Starts from an empty Extensions and copies in only the slots the
+    plugin has read access to. Slots not explicitly included are left
+    as None (the default). This is secure by default — if a new slot
+    is added to Extensions but not registered here, it remains hidden.
+
+    For the security extension, filtering is granular: unrestricted
+    sub-fields (objects, data) are always included, while labels and
+    subject sub-fields are gated by their respective capabilities.
+
+    Args:
+        extensions: The source Extensions model instance (or None).
+        capabilities: Plugin's declared capability strings.
+
+    Returns:
+        A new frozen Extensions with only accessible slots populated,
+        or None if input was None.
+    """
+    if extensions is None:
+        return None
+
+    fields: dict[str, Any] = {}
+
+    # Unrestricted top-level slots — always included when present
+    if extensions.request is not None:
+        fields[FIELD_REQUEST] = extensions.request
+    if extensions.provenance is not None:
+        fields[FIELD_PROVENANCE] = extensions.provenance
+    if extensions.completion is not None:
+        fields[FIELD_COMPLETION] = extensions.completion
+    if extensions.llm is not None:
+        fields[FIELD_LLM] = extensions.llm
+    if extensions.framework is not None:
+        fields[FIELD_FRAMEWORK] = extensions.framework
+    if extensions.mcp is not None:
+        fields[FIELD_MCP] = extensions.mcp
+    if extensions.custom is not None:
+        fields[FIELD_CUSTOM] = extensions.custom
+
+    # Capability-gated top-level slots — included only with access
+    if extensions.agent is not None:
+        if _has_read_access(_slot_registry[SlotName.AGENT], capabilities):
+            fields[FIELD_AGENT] = extensions.agent
+
+    if extensions.http is not None:
+        if _has_read_access(_slot_registry[SlotName.HTTP], capabilities):
+            fields[FIELD_HTTP] = extensions.http
+
+    # Security — granular sub-field filtering
+    if extensions.security is not None:
+        fields[FIELD_SECURITY] = _build_filtered_security(extensions.security, capabilities)
+
+    return Extensions(**fields)
+
+
+# ---------------------------------------------------------------------------
+# Tier Validation
+# ---------------------------------------------------------------------------
+
+
+class TierViolationError(Exception):
+    """Raised when a plugin violates a mutability tier constraint.
+
+    Attributes:
+        plugin_name: Name of the offending plugin.
+        slot: The extension slot that was violated.
+        tier: The mutability tier of the slot.
+        detail: Description of the violation.
+    """
+
+    def __init__(
+        self,
+        plugin_name: str,
+        slot: str,
+        tier: MutabilityTier,
+        detail: str,
+    ) -> None:
+        self.plugin_name = plugin_name
+        self.slot = slot
+        self.tier = tier
+        self.detail = detail
+        super().__init__(f"Plugin '{plugin_name}' violated {tier.value} tier on " f"'{slot}': {detail}")
+
+
+def _resolve_slot(ext: Extensions | None, dot_path: str) -> Any:
+    """Resolve a dot-notation slot path to its value."""
+    if ext is None:
+        return None
+    obj: Any = ext
+    for part in dot_path.split("."):
+        if obj is None:
+            return None
+        obj = getattr(obj, part, None)
+    return obj
+
+
+def _is_monotonic_superset(before: Any, after: Any) -> bool:
+    """Check that after is a superset of before for monotonic validation."""
+    if before is None or (isinstance(before, frozenset) and len(before) == 0):
+        return True
+    if after is None:
+        return isinstance(before, frozenset) and len(before) == 0
+    if isinstance(before, frozenset) and isinstance(after, frozenset):
+        return before <= after
+    return before == after
+
+
+def validate_tier_constraints(
+    before: Extensions | None,
+    after: Extensions | None,
+    capabilities: frozenset[str],
+    plugin_name: str,
+) -> None:
+    """Validate that tier constraints were respected after a plugin transform.
+
+    Compares the original (unfiltered) extensions against the modified
+    extensions. Raises TierViolationError on any violation.
+
+    Args:
+        before: Original Extensions before plugin execution.
+        after: Extensions after plugin execution.
+        capabilities: Plugin's declared capability strings.
+        plugin_name: Name of the plugin (for error messages).
+
+    Raises:
+        TierViolationError: If a tier constraint was violated.
+    """
+    if before is None and after is None:
+        return
+
+    for slot_name, policy in _slot_registry.items():
+        before_val = _resolve_slot(before, slot_name)
+        after_val = _resolve_slot(after, slot_name)
+
+        # No change — always fine
+        if before_val == after_val:
+            continue
+
+        # Mutable tier with no write_cap — freely modifiable
+        if policy.tier == MutabilityTier.MUTABLE and policy.write_cap is None:
+            continue
+
+        # Something changed — check if mutation is allowed
+        if policy.write_cap is None:
+            raise TierViolationError(
+                plugin_name,
+                slot_name,
+                policy.tier,
+                "slot has no write capability and cannot be modified",
+            )
+
+        if policy.write_cap.value not in capabilities:
+            raise TierViolationError(
+                plugin_name,
+                slot_name,
+                policy.tier,
+                f"plugin lacks '{policy.write_cap.value}' capability",
+            )
+
+        # Plugin has write capability — check tier-specific constraints
+        if policy.tier == MutabilityTier.MONOTONIC:
+            if not _is_monotonic_superset(before_val, after_val):
+                raise TierViolationError(
+                    plugin_name,
+                    slot_name,
+                    policy.tier,
+                    "monotonic slot had elements removed",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Selective Merge
+# ---------------------------------------------------------------------------
+
+
+def _merge_security(
+    original: SecurityExtension,
+    plugin_sec: SecurityExtension | None,
+    capabilities: frozenset[str],
+    plugin_name: str,
+) -> SecurityExtension | None:
+    """Accept writable security changes back into the original.
+
+    - subject, objects, data, classification: immutable — ignored.
+    - labels: monotonic — accepted only if the plugin holds
+      append_labels and the result is a superset of the original.
+
+    Returns None if nothing changed (caller should skip the update).
+    """
+    if plugin_sec is None:
+        return None
+
+    # Labels — monotonic, capability-gated
+    if Capability.APPEND_LABELS.value in capabilities and plugin_sec.labels != original.labels:
+        if not _is_monotonic_superset(original.labels, plugin_sec.labels):
+            raise TierViolationError(
+                plugin_name,
+                SlotName.SECURITY_LABELS,
+                MutabilityTier.MONOTONIC,
+                "monotonic slot had elements removed",
+            )
+        return original.model_copy(update={FIELD_LABELS: plugin_sec.labels})
+
+    return None
+
+
+def merge_extensions(
+    original: Extensions | None,
+    plugin_output: Extensions | None,
+    capabilities: frozenset[str],
+    plugin_name: str,
+) -> Extensions | None:
+    """Merge accepted plugin changes back into the original Extensions.
+
+    Only writable slots are read from the plugin's output:
+
+    - **Immutable** slots (request, provenance, agent, etc.) are
+      ignored — the original values are preserved.
+    - **Monotonic** slots (security.labels) are accepted only when
+      the plugin holds the write capability and the result is a
+      superset of the original.
+    - **Mutable** slots (custom) are accepted unconditionally.
+    - **Guarded-writable** slots (http) are accepted only when the
+      plugin holds the write capability.
+
+    If nothing changed, the original object is returned as-is.
+
+    This is the complement of ``filter_extensions`` (which controls
+    what a plugin *sees*).  ``merge_extensions`` controls what the
+    manager *accepts back*.
+
+    Args:
+        original: The authoritative Extensions before plugin execution.
+        plugin_output: The Extensions returned by the plugin.
+        capabilities: Plugin's declared capability strings.
+        plugin_name: Name of the plugin (for error messages).
+
+    Returns:
+        The original Extensions with accepted changes applied via
+        model_copy, or the original unchanged if nothing was accepted.
+
+    Raises:
+        TierViolationError: If a monotonic slot had elements removed.
+    """
+    if original is None:
+        return None
+    if plugin_output is None:
+        return original
+
+    updates: dict[str, Any] = {}
+
+    # HTTP — writable only with write_headers capability
+    if (
+        Capability.WRITE_HEADERS.value in capabilities
+        and plugin_output.http is not None
+        and plugin_output.http != original.http
+    ):
+        updates[FIELD_HTTP] = plugin_output.http
+
+    # Security — mixed tiers, delegate to helper
+    if original.security is not None:
+        merged_sec = _merge_security(original.security, plugin_output.security, capabilities, plugin_name)
+        if merged_sec is not None:
+            updates[FIELD_SECURITY] = merged_sec
+
+    # Custom — mutable, no capability gate
+    if plugin_output.custom != original.custom:
+        updates[FIELD_CUSTOM] = plugin_output.custom
+
+    if not updates:
+        return original
+
+    return original.model_copy(update=updates)

--- a/cpex/framework/extensions/tiers.py
+++ b/cpex/framework/extensions/tiers.py
@@ -34,6 +34,7 @@ from cpex.framework.extensions.constants import (
     FIELD_LABELS,
     FIELD_LLM,
     FIELD_MCP,
+    FIELD_META,
     FIELD_OBJECTS,
     FIELD_PERMISSIONS,
     FIELD_PROVENANCE,
@@ -154,6 +155,7 @@ _SLOT_REGISTRY: dict[str, SlotPolicy] = {
     SlotName.LLM: SlotPolicy(MutabilityTier.IMMUTABLE),
     SlotName.FRAMEWORK: SlotPolicy(MutabilityTier.IMMUTABLE),
     SlotName.MCP: SlotPolicy(MutabilityTier.IMMUTABLE),
+    SlotName.META: SlotPolicy(MutabilityTier.IMMUTABLE),
     # Capability-gated, immutable
     SlotName.AGENT: SlotPolicy(
         MutabilityTier.IMMUTABLE,
@@ -347,6 +349,8 @@ def filter_extensions(
         fields[FIELD_FRAMEWORK] = extensions.framework
     if extensions.mcp is not None:
         fields[FIELD_MCP] = extensions.mcp
+    if extensions.meta is not None:
+        fields[FIELD_META] = extensions.meta
     if extensions.custom is not None:
         fields[FIELD_CUSTOM] = extensions.custom
 

--- a/cpex/framework/extensions/tiers.py
+++ b/cpex/framework/extensions/tiers.py
@@ -29,6 +29,7 @@ from cpex.framework.extensions.constants import (
     FIELD_COMPLETION,
     FIELD_CUSTOM,
     FIELD_DATA,
+    FIELD_DELEGATION,
     FIELD_FRAMEWORK,
     FIELD_HTTP,
     FIELD_LABELS,
@@ -82,6 +83,10 @@ class Capability(str, Enum):
         WRITE_HEADERS: Read + write access to HTTP headers.
         READ_LABELS: Read access to security labels.
         APPEND_LABELS: Read + append-only access to security labels.
+        READ_LABELS: Read access to security labels.
+        APPEND_LABELS: Read + append-only access to security labels.
+        READ_DELEGATION: Read access to DelegationExtension (chain, depth, origin, actor).
+        APPEND_DELEGATION: Read + append-only access to the delegation chain.
     """
 
     READ_SUBJECT = "read_subject"
@@ -94,12 +99,15 @@ class Capability(str, Enum):
     WRITE_HEADERS = "write_headers"
     READ_LABELS = "read_labels"
     APPEND_LABELS = "append_labels"
+    READ_DELEGATION = "read_delegation"
+    APPEND_DELEGATION = "append_delegation"
 
 
 # Write/append capabilities that imply their read counterpart.
 _WRITE_IMPLIES_READ: dict[Capability, Capability] = {
     Capability.WRITE_HEADERS: Capability.READ_HEADERS,
     Capability.APPEND_LABELS: Capability.READ_LABELS,
+    Capability.APPEND_DELEGATION: Capability.READ_DELEGATION,
 }
 
 # Subject sub-field capabilities that imply read_subject.
@@ -204,6 +212,16 @@ _SLOT_REGISTRY: dict[str, SlotPolicy] = {
         access=AccessPolicy.CAPABILITY_GATED,
         read_cap=Capability.READ_HEADERS,
         write_cap=Capability.WRITE_HEADERS,
+    ),
+    # Delegation — monotonic (chain grows, never shrinks), capability-gated.
+    # Contains identity-adjacent information (subject IDs, audiences, scopes).
+    # Framework controls chain growth via with_new_hop(); merge validates
+    # monotonic growth (new chain must be superset of original).
+    SlotName.DELEGATION: SlotPolicy(
+        MutabilityTier.MONOTONIC,
+        access=AccessPolicy.CAPABILITY_GATED,
+        read_cap=Capability.READ_DELEGATION,
+        write_cap=Capability.APPEND_DELEGATION,
     ),
     # Unrestricted, mutable — no capability gate
     SlotName.CUSTOM: SlotPolicy(MutabilityTier.MUTABLE),
@@ -351,6 +369,10 @@ def filter_extensions(
         fields[FIELD_MCP] = extensions.mcp
     if extensions.meta is not None:
         fields[FIELD_META] = extensions.meta
+    # Capability-gated: delegation
+    if extensions.delegation is not None:
+        if _has_read_access(_slot_registry[SlotName.DELEGATION], capabilities):
+            fields[FIELD_DELEGATION] = extensions.delegation
     if extensions.custom is not None:
         fields[FIELD_CUSTOM] = extensions.custom
 
@@ -587,6 +609,39 @@ def merge_extensions(
         merged_sec = _merge_security(original.security, plugin_output.security, capabilities, plugin_name)
         if merged_sec is not None:
             updates[FIELD_SECURITY] = merged_sec
+
+    # Delegation — monotonic (chain must grow, never shrink), requires append_delegation
+    if (
+        Capability.APPEND_DELEGATION.value in capabilities
+        and plugin_output.delegation is not None
+        and original.delegation is not None
+        and plugin_output.delegation != original.delegation
+    ):
+        # Validate monotonic: new chain must be a superset (longer or equal, same prefix)
+        orig_chain = original.delegation.chain
+        new_chain = plugin_output.delegation.chain
+        if len(new_chain) < len(orig_chain):
+            raise TierViolationError(
+                plugin_name,
+                FIELD_DELEGATION,
+                MutabilityTier.MONOTONIC,
+                f"shrank delegation chain (was {len(orig_chain)} hops, now {len(new_chain)})",
+            )
+        if new_chain[: len(orig_chain)] != orig_chain:
+            raise TierViolationError(
+                plugin_name,
+                FIELD_DELEGATION,
+                MutabilityTier.MONOTONIC,
+                "modified existing delegation chain hops",
+            )
+        updates[FIELD_DELEGATION] = plugin_output.delegation
+    elif (
+        Capability.APPEND_DELEGATION.value in capabilities
+        and plugin_output.delegation is not None
+        and original.delegation is None
+    ):
+        # First delegation — accept (requires append_delegation capability)
+        updates[FIELD_DELEGATION] = plugin_output.delegation
 
     # Custom — mutable, no capability gate
     if plugin_output.custom != original.custom:

--- a/cpex/framework/extensions/tiers.py
+++ b/cpex/framework/extensions/tiers.py
@@ -388,11 +388,19 @@ class TierViolationError(Exception):
         tier: MutabilityTier,
         detail: str,
     ) -> None:
+        """Initialise a tier violation error.
+
+        Args:
+            plugin_name: Name of the offending plugin.
+            slot: The extension slot that was violated.
+            tier: The mutability tier of the slot.
+            detail: Description of the violation.
+        """
         self.plugin_name = plugin_name
         self.slot = slot
         self.tier = tier
         self.detail = detail
-        super().__init__(f"Plugin '{plugin_name}' violated {tier.value} tier on " f"'{slot}': {detail}")
+        super().__init__(f"Plugin '{plugin_name}' violated {tier.value} tier on '{slot}': {detail}")
 
 
 def _resolve_slot(ext: Extensions | None, dot_path: str) -> Any:

--- a/cpex/framework/external/mcp/client.py
+++ b/cpex/framework/external/mcp/client.py
@@ -560,6 +560,7 @@ class ExternalHookRef(HookRef):
         """
         self._plugin_ref = plugin_ref
         self._hook = hook
+        self._accepts_extensions = False  # External plugins use invoke_hook(), not direct method calls
         if hasattr(plugin_ref.plugin, INVOKE_HOOK):
             self._func: Callable[[PluginPayload, PluginContext], Awaitable[PluginResult]] = partial(
                 plugin_ref.plugin.invoke_hook, hook

--- a/cpex/framework/hooks/agents.py
+++ b/cpex/framework/hooks/agents.py
@@ -10,6 +10,7 @@ the base plugin layer including configurations, and contexts.
 """
 
 # Standard
+import warnings
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -74,6 +75,20 @@ class AgentPreInvokePayload(PluginPayload):
     model: Optional[str] = None
     system_prompt: Optional[str] = None
     parameters: Optional[Dict[str, Any]] = Field(default_factory=dict)
+
+    @field_validator("headers", mode="before")
+    @classmethod
+    def _warn_headers_deprecated(cls, v: object) -> object:
+        """Emit deprecation warning for headers field."""
+        if v is not None:
+            warnings.warn(
+                "AgentPreInvokePayload.headers is deprecated; "
+                "use extensions.http.headers instead. "
+                "This field will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return v
 
     @field_validator("messages", mode="before")
     @classmethod

--- a/cpex/framework/hooks/agents.py
+++ b/cpex/framework/hooks/agents.py
@@ -86,7 +86,7 @@ class AgentPreInvokePayload(PluginPayload):
                 "use extensions.http.headers instead. "
                 "This field will be removed in a future release.",
                 DeprecationWarning,
-                stacklevel=2,
+                stacklevel=4,
             )
         return v
 

--- a/cpex/framework/hooks/http.py
+++ b/cpex/framework/hooks/http.py
@@ -18,7 +18,7 @@ from pydantic import RootModel, field_validator
 from cpex.framework.models import PluginPayload, PluginResult
 
 
-class HttpHeaderPayload(RootModel[dict[str, str]]):
+class HttpHeaderPayload(RootModel[dict[str, str]], PluginPayload):
     """An HTTP dictionary of headers used in the pre/post HTTP forwarding hooks."""
 
     def __iter__(self):  # type: ignore[no-untyped-def]
@@ -114,7 +114,7 @@ class HttpPreRequestPayload(PluginPayload):
                 "use extensions.http.headers instead. "
                 "This field will be removed in a future release.",
                 DeprecationWarning,
-                stacklevel=2,
+                stacklevel=4,
             )
         return v
 
@@ -164,7 +164,7 @@ class HttpAuthResolveUserPayload(PluginPayload):
                 "use extensions.http.headers instead. "
                 "This field will be removed in a future release.",
                 DeprecationWarning,
-                stacklevel=2,
+                stacklevel=4,
             )
         return v
 

--- a/cpex/framework/hooks/http.py
+++ b/cpex/framework/hooks/http.py
@@ -8,16 +8,17 @@ Pydantic models for http hooks and payloads.
 """
 
 # Standard
+import warnings
 from enum import Enum
 
 # Third-Party
-from pydantic import RootModel
+from pydantic import RootModel, field_validator
 
 # First-Party
 from cpex.framework.models import PluginPayload, PluginResult
 
 
-class HttpHeaderPayload(RootModel[dict[str, str]], PluginPayload):
+class HttpHeaderPayload(RootModel[dict[str, str]]):
     """An HTTP dictionary of headers used in the pre/post HTTP forwarding hooks."""
 
     def __iter__(self):  # type: ignore[no-untyped-def]
@@ -103,6 +104,20 @@ class HttpPreRequestPayload(PluginPayload):
     client_port: int | None = None
     headers: HttpHeaderPayload
 
+    @field_validator("headers", mode="before")
+    @classmethod
+    def _warn_headers_deprecated(cls, v: object) -> object:
+        """Emit deprecation warning for headers field."""
+        if v is not None:
+            warnings.warn(
+                "HttpPreRequestPayload.headers is deprecated; "
+                "use extensions.http.headers instead. "
+                "This field will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return v
+
 
 class HttpPostRequestPayload(HttpPreRequestPayload):
     """Payload for HTTP post-request hook (middleware layer).
@@ -138,6 +153,20 @@ class HttpAuthResolveUserPayload(PluginPayload):
     headers: HttpHeaderPayload
     client_host: str | None = None
     client_port: int | None = None
+
+    @field_validator("headers", mode="before")
+    @classmethod
+    def _warn_headers_deprecated(cls, v: object) -> object:
+        """Emit deprecation warning for headers field."""
+        if v is not None:
+            warnings.warn(
+                "HttpAuthResolveUserPayload.headers is deprecated; "
+                "use extensions.http.headers instead. "
+                "This field will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return v
 
 
 class HttpAuthCheckPermissionPayload(PluginPayload):

--- a/cpex/framework/hooks/identity.py
+++ b/cpex/framework/hooks/identity.py
@@ -1,0 +1,287 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/hooks/identity.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Hook definitions for identity resolution and token delegation.
+
+Two hooks, two phases:
+- IdentityResolve: inbound — decode token, verify, map to SubjectExtension
+- TokenDelegate: outbound — exchange token for downstream tool credential
+
+See: docs/delegation-hooks-design.md
+
+These hooks produce CMF types (SubjectExtension, DelegationExtension)
+and complement the legacy HTTP auth hooks in http.py which operate
+on flat strings and dicts.
+"""
+
+# Standard
+from enum import Enum
+from typing import Any
+
+# Third-Party
+from pydantic import BaseModel, ConfigDict, Field
+
+# First-Party
+from cpex.framework.extensions.delegation import DelegationExtension
+from cpex.framework.extensions.security import SubjectExtension
+from cpex.framework.models import PluginPayload, PluginResult
+
+# ---------------------------------------------------------------------------
+# Hook Types
+# ---------------------------------------------------------------------------
+
+
+class IdentityHookType(str, Enum):
+    """Identity and delegation hook points.
+
+    Attributes:
+        IDENTITY_RESOLVE: Inbound — decode and validate token,
+            produce SubjectExtension.
+        TOKEN_DELEGATE: Outbound — exchange/mint token for
+            downstream tool invocation.
+
+    Examples:
+        >>> IdentityHookType.IDENTITY_RESOLVE
+        <IdentityHookType.IDENTITY_RESOLVE: 'identity_resolve'>
+        >>> IdentityHookType.TOKEN_DELEGATE.value
+        'token_delegate'
+    """
+
+    IDENTITY_RESOLVE = "identity_resolve"
+    TOKEN_DELEGATE = "token_delegate"
+
+
+# ---------------------------------------------------------------------------
+# IdentityResolve — Inbound
+# ---------------------------------------------------------------------------
+
+
+class IdentityPayload(PluginPayload):
+    """Payload for the identity resolution hook.
+
+    Carries the raw credential extracted from the inbound request.
+    The hook implementation decodes, validates, and maps it to a
+    SubjectExtension.
+
+    Attributes:
+        raw_token: The raw token string (JWT, opaque, API key, etc.).
+        source: How the credential was extracted.
+        headers: Full HTTP headers for custom auth extraction.
+        client_host: Client IP address (if available).
+        client_port: Client port (if available).
+
+    Examples:
+        >>> payload = IdentityPayload(
+        ...     raw_token="eyJhbGciOi...",
+        ...     source="bearer",
+        ...     headers={"authorization": "Bearer eyJhbGciOi..."},
+        ... )
+        >>> payload.source
+        'bearer'
+    """
+
+    raw_token: str = Field(description="Raw credential string.")
+    source: str = Field(
+        default="bearer",
+        description="Credential source: bearer, mtls, api_key, custom.",
+    )
+    headers: dict[str, str] = Field(
+        default_factory=dict,
+        description="Full HTTP headers for custom auth extraction.",
+    )
+    client_host: str | None = Field(default=None, description="Client IP address.")
+    client_port: int | None = Field(default=None, description="Client port.")
+
+
+class IdentityResult(PluginPayload):
+    """Result of identity resolution — returned as modified_payload.
+
+    Either provides a resolved SubjectExtension, or rejects with
+    a status code and reason. The framework validates the result
+    and seals the SubjectExtension as immutable.
+
+    Extends PluginPayload so it can be carried as the modified_payload
+    in PluginResult[IdentityResult]. This follows the same pattern as
+    HttpAuthCheckPermissionResultPayload.
+
+    Attributes:
+        subject: The resolved identity. None if rejected.
+        delegation: Initial delegation state from act claims.
+        rejected: Whether the identity was rejected.
+        reject_status: HTTP status code for rejection (401 or 403).
+        reject_reason: Human-readable rejection reason.
+        raw_claims: Full decoded claims for audit/policy (optional).
+
+    Examples:
+        >>> result = IdentityResult(
+        ...     subject=SubjectExtension(id="alice@corp.com", type="user"),
+        ... )
+        >>> result.rejected
+        False
+
+        >>> rejected = IdentityResult(
+        ...     rejected=True,
+        ...     reject_status=401,
+        ...     reject_reason="Token expired",
+        ... )
+    """
+
+    subject: SubjectExtension | None = Field(default=None, description="Resolved identity.")
+    delegation: DelegationExtension | None = Field(
+        default=None,
+        description="Initial delegation state (from act claims in JWT).",
+    )
+    rejected: bool = Field(default=False, description="Whether the identity was rejected.")
+    reject_status: int = Field(default=401, description="HTTP status code for rejection.")
+    reject_reason: str = Field(default="", description="Rejection reason.")
+    raw_claims: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Full decoded token claims (for audit/policy).",
+    )
+
+
+IdentityResolveResult = PluginResult[IdentityResult]
+
+
+# ---------------------------------------------------------------------------
+# TokenDelegate — Outbound
+# ---------------------------------------------------------------------------
+
+
+class AttenuationConfig(BaseModel):
+    """Configuration for token scope attenuation from DSL route config.
+
+    Attributes:
+        capabilities: Specific capabilities to grant.
+        resource_template: URI template with argument substitution.
+        actions: Allowed actions on the resource.
+        ttl_seconds: Token lifetime override.
+
+    Examples:
+        >>> config = AttenuationConfig(
+        ...     capabilities=["read:compensation"],
+        ...     resource_template="hr://employees/{{ args.employee_id }}",
+        ...     actions=["read"],
+        ...     ttl_seconds=60,
+        ... )
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    capabilities: list[str] = Field(default_factory=list)
+    resource_template: str | None = None
+    actions: list[str] = Field(default_factory=list)
+    ttl_seconds: int | None = None
+
+
+class DelegationPayload(PluginPayload):
+    """Payload for the token delegation hook.
+
+    Carries the target tool information and security profile.
+    The hook implementation exchanges/mints a token for the target.
+    Subject and existing delegation chain are read from the CMF
+    message extensions (not duplicated here).
+
+    Attributes:
+        target_name: Tool, agent, or resource being called.
+        target_type: Entity type: tool, agent, resource, service.
+        target_audience: Audience URI for the target (from config).
+        required_permissions: From ObjectSecurityProfile.permissions.
+        trust_domain: From ObjectSecurityProfile.trust_domain.
+        auth_enforced_by: Who enforces auth: caller, target, or both.
+        route_attenuation: Scope attenuation config from DSL route.
+        bearer_token: The caller's current bearer token (for exchange).
+
+    Examples:
+        >>> payload = DelegationPayload(
+        ...     target_name="get_compensation",
+        ...     target_type="tool",
+        ...     required_permissions=["read:compensation"],
+        ...     auth_enforced_by="target",
+        ...     bearer_token="eyJhbGciOi...",
+        ... )
+    """
+
+    target_name: str = Field(description="Tool/agent/resource being called.")
+    target_type: str = Field(default="tool", description="Entity type.")
+    target_audience: str | None = Field(default=None, description="Audience URI.")
+    required_permissions: list[str] = Field(default_factory=list, description="Required permissions.")
+    trust_domain: str | None = Field(default=None, description="Trust domain.")
+    auth_enforced_by: str = Field(default="caller", description="Auth enforcement: caller, target, both.")
+    route_attenuation: AttenuationConfig | None = Field(default=None, description="Scope attenuation config.")
+    bearer_token: str | None = Field(default=None, description="Caller's current bearer token.")
+
+
+class DelegationResult(PluginPayload):
+    """Result of token delegation — returned as modified_payload.
+
+    The delegated token is returned separately (never stored in
+    Extensions). The delegation_update is merged into Extensions
+    by the framework.
+
+    Extends PluginPayload so it can be carried as the modified_payload
+    in PluginResult[DelegationResult].
+
+    Attributes:
+        delegated_token: The credential for the downstream target.
+        delegation_update: Updated DelegationExtension (merged by framework).
+        forwarded_headers: Additional headers for the downstream request.
+        cache_key: Token cache key (for reuse).
+        cache_ttl: Seconds to cache the token.
+
+    Examples:
+        >>> result = DelegationResult(
+        ...     delegated_token="eyJhbGciOi...",
+        ...     forwarded_headers={"Authorization": "Bearer eyJhbGciOi..."},
+        ... )
+    """
+
+    delegated_token: str | None = Field(default=None, description="Credential for downstream.")
+    delegation_update: DelegationExtension = Field(
+        default_factory=DelegationExtension,
+        description="Updated delegation chain.",
+    )
+    forwarded_headers: dict[str, str] = Field(
+        default_factory=dict,
+        description="Additional headers for downstream.",
+    )
+    cache_key: str | None = Field(default=None, description="Token cache key.")
+    cache_ttl: int | None = Field(default=None, description="Cache TTL in seconds.")
+
+
+TokenDelegateResult = PluginResult[DelegationResult]
+
+
+# ---------------------------------------------------------------------------
+# Hook Registration
+# ---------------------------------------------------------------------------
+
+
+def _register_identity_hooks() -> None:
+    """Register identity hooks in the global registry.
+
+    Called at module load time. Idempotent.
+    """
+    from cpex.framework.hooks.registry import get_hook_registry
+
+    registry = get_hook_registry()
+
+    if not registry.is_registered(IdentityHookType.IDENTITY_RESOLVE):
+        registry.register_hook(
+            IdentityHookType.IDENTITY_RESOLVE,
+            IdentityPayload,
+            IdentityResolveResult,
+        )
+
+    if not registry.is_registered(IdentityHookType.TOKEN_DELEGATE):
+        registry.register_hook(
+            IdentityHookType.TOKEN_DELEGATE,
+            DelegationPayload,
+            TokenDelegateResult,
+        )
+
+
+_register_identity_hooks()

--- a/cpex/framework/hooks/identity.py
+++ b/cpex/framework/hooks/identity.py
@@ -22,7 +22,7 @@ from enum import Enum
 from typing import Any
 
 # Third-Party
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
 # First-Party
 from cpex.framework.extensions.delegation import DelegationExtension
@@ -81,9 +81,13 @@ class IdentityPayload(PluginPayload):
         ... )
         >>> payload.source
         'bearer'
+        >>> str(payload.raw_token)
+        '**********'
+        >>> payload.raw_token.get_secret_value()
+        'eyJhbGciOi...'
     """
 
-    raw_token: str = Field(description="Raw credential string.")
+    raw_token: SecretStr = Field(description="Raw credential string. Redacted on serialization.")
     source: str = Field(
         default="bearer",
         description="Credential source: bearer, mtls, api_key, custom.",
@@ -212,7 +216,9 @@ class DelegationPayload(PluginPayload):
     trust_domain: str | None = Field(default=None, description="Trust domain.")
     auth_enforced_by: str = Field(default="caller", description="Auth enforcement: caller, target, both.")
     route_attenuation: AttenuationConfig | None = Field(default=None, description="Scope attenuation config.")
-    bearer_token: str | None = Field(default=None, description="Caller's current bearer token.")
+    bearer_token: SecretStr | None = Field(
+        default=None, description="Caller's current bearer token. Redacted on serialization."
+    )
 
 
 class DelegationResult(PluginPayload):

--- a/cpex/framework/hooks/message.py
+++ b/cpex/framework/hooks/message.py
@@ -24,10 +24,12 @@ from cpex.framework.models import PluginPayload, PluginResult
 
 
 class MessageHookType(str, Enum):
-    """Message hook points.
+    """Message hook points — metadata on MessagePayload.
 
     The hook type indicates *where* in the pipeline the evaluation
-    is happening, enabling plugins to register for specific locations.
+    is happening. This is carried as metadata on the MessagePayload
+    so plugins can inspect it, but is NOT the hook type used for
+    dispatch. See CmfHookType for dispatch hook types.
 
     Attributes:
         EVALUATE: Generic message evaluation.
@@ -56,6 +58,37 @@ class MessageHookType(str, Enum):
     PROMPT_POST_FETCH = "prompt_post_fetch"
     RESOURCE_PRE_FETCH = "resource_pre_fetch"
     RESOURCE_POST_FETCH = "resource_post_fetch"
+
+
+class CmfHookType(str, Enum):
+    """CMF hook types — dispatch targets for CMF-based plugins.
+
+    These are the hook types that CMF plugins register for. They
+    parallel the legacy hook types (tool_pre_invoke, etc.) but use
+    MessagePayload instead of typed payloads like ToolPreInvokePayload.
+
+    This enables a clean migration path:
+    - Legacy plugins register for "tool_pre_invoke" and get ToolPreInvokePayload
+    - CMF plugins register for "cmf.tool_pre_invoke" and get MessagePayload
+    - The gateway fires both at the same interception point
+
+    The gateway converts legacy payloads to CMF Messages at each point.
+
+    Examples:
+        >>> CmfHookType.TOOL_PRE_INVOKE
+        <CmfHookType.TOOL_PRE_INVOKE: 'cmf.tool_pre_invoke'>
+        >>> CmfHookType.TOOL_PRE_INVOKE.value
+        'cmf.tool_pre_invoke'
+    """
+
+    TOOL_PRE_INVOKE = "cmf.tool_pre_invoke"
+    TOOL_POST_INVOKE = "cmf.tool_post_invoke"
+    LLM_INPUT = "cmf.llm_input"
+    LLM_OUTPUT = "cmf.llm_output"
+    RESOURCE_PRE_FETCH = "cmf.resource_pre_fetch"
+    RESOURCE_POST_FETCH = "cmf.resource_post_fetch"
+    PROMPT_PRE_FETCH = "cmf.prompt_pre_fetch"
+    PROMPT_POST_FETCH = "cmf.prompt_post_fetch"
 
 
 class MessagePayload(PluginPayload):
@@ -98,14 +131,22 @@ def _register_message_hooks() -> None:
 
     Called at module load time. Idempotent — skips registration
     if the hook is already registered.
+
+    Registers both the generic EVALUATE hook and all CMF-specific hooks.
     """
     # First-Party
     from cpex.framework.hooks.registry import get_hook_registry  # pylint: disable=import-outside-toplevel
 
     registry = get_hook_registry()
 
+    # Generic message evaluation hook (legacy)
     if not registry.is_registered(MessageHookType.EVALUATE):
         registry.register_hook(MessageHookType.EVALUATE, MessagePayload, MessageResult)
+
+    # CMF-specific hooks — same payload/result type, different dispatch points
+    for cmf_hook in CmfHookType:
+        if not registry.is_registered(cmf_hook):
+            registry.register_hook(cmf_hook, MessagePayload, MessageResult)
 
 
 _register_message_hooks()

--- a/cpex/framework/hooks/message.py
+++ b/cpex/framework/hooks/message.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Location: ./cpex/framework/hooks/message.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Hook definitions for CMF Message evaluation.
+
+Provides a unified entry point for policy evaluation on messages
+flowing through the system. Plugins receive a MessagePayload
+wrapping the CMF Message and can use Message.iter_views() for
+granular per-content-part inspection.
+"""
+
+# Standard
+from enum import Enum
+
+# Third-Party
+from pydantic import Field
+
+# First-Party
+from cpex.framework.cmf.message import Message
+from cpex.framework.models import PluginPayload, PluginResult
+
+
+class MessageHookType(str, Enum):
+    """Message hook points.
+
+    Attributes:
+        EVALUATE: Evaluate a message for policy decisions.
+
+    Examples:
+        >>> MessageHookType.EVALUATE
+        <MessageHookType.EVALUATE: 'evaluate'>
+        >>> MessageHookType.EVALUATE.value
+        'evaluate'
+    """
+
+    EVALUATE = "evaluate"
+
+
+class MessagePayload(PluginPayload):
+    """Payload for message evaluation hooks.
+
+    Wraps a CMF Message for processing through the plugin pipeline.
+    Plugins access the message and use iter_views() for per-content-part
+    policy evaluation.
+
+    Attributes:
+        message: The CMF message to evaluate.
+
+    Examples:
+        >>> from cpex.framework.cmf.message import Message, Role, TextContent
+        >>> msg = Message(
+        ...     role=Role.USER,
+        ...     content=[TextContent(text="Hello")],
+        ... )
+        >>> payload = MessagePayload(message=msg)
+        >>> payload.message.role
+        <Role.USER: 'user'>
+        >>> payload.message.content[0].text
+        'Hello'
+
+        >>> # Iterate views through the payload
+        >>> views = list(payload.message.iter_views())
+        >>> len(views)
+        1
+    """
+
+    message: Message = Field(description="The CMF message to evaluate.")
+
+
+MessageResult = PluginResult[MessagePayload]
+"""Result type for message evaluation hooks."""
+
+
+def _register_message_hooks() -> None:
+    """Register message hooks in the global registry.
+
+    Called at module load time. Idempotent — skips registration
+    if the hook is already registered.
+    """
+    # First-Party
+    from cpex.framework.hooks.registry import get_hook_registry  # pylint: disable=import-outside-toplevel
+
+    registry = get_hook_registry()
+
+    if not registry.is_registered(MessageHookType.EVALUATE):
+        registry.register_hook(MessageHookType.EVALUATE, MessagePayload, MessageResult)
+
+
+_register_message_hooks()

--- a/cpex/framework/hooks/message.py
+++ b/cpex/framework/hooks/message.py
@@ -26,17 +26,36 @@ from cpex.framework.models import PluginPayload, PluginResult
 class MessageHookType(str, Enum):
     """Message hook points.
 
+    The hook type indicates *where* in the pipeline the evaluation
+    is happening, enabling plugins to register for specific locations.
+
     Attributes:
-        EVALUATE: Evaluate a message for policy decisions.
+        EVALUATE: Generic message evaluation.
+        LLM_INPUT: Before model/LLM call (user messages going to LLM).
+        LLM_OUTPUT: After model/LLM call (LLM response).
+        TOOL_PRE_INVOKE: Before tool execution (tool call arguments).
+        TOOL_POST_INVOKE: After tool execution (tool result).
+        PROMPT_PRE_FETCH: Before prompt template fetch.
+        PROMPT_POST_FETCH: After prompt template fetch.
+        RESOURCE_PRE_FETCH: Before resource fetch.
+        RESOURCE_POST_FETCH: After resource fetch.
 
     Examples:
         >>> MessageHookType.EVALUATE
         <MessageHookType.EVALUATE: 'evaluate'>
-        >>> MessageHookType.EVALUATE.value
-        'evaluate'
+        >>> MessageHookType.LLM_INPUT
+        <MessageHookType.LLM_INPUT: 'llm_input'>
     """
 
     EVALUATE = "evaluate"
+    LLM_INPUT = "llm_input"
+    LLM_OUTPUT = "llm_output"
+    TOOL_PRE_INVOKE = "tool_pre_invoke"
+    TOOL_POST_INVOKE = "tool_post_invoke"
+    PROMPT_PRE_FETCH = "prompt_pre_fetch"
+    PROMPT_POST_FETCH = "prompt_post_fetch"
+    RESOURCE_PRE_FETCH = "resource_pre_fetch"
+    RESOURCE_POST_FETCH = "resource_post_fetch"
 
 
 class MessagePayload(PluginPayload):
@@ -48,6 +67,7 @@ class MessagePayload(PluginPayload):
 
     Attributes:
         message: The CMF message to evaluate.
+        hook: The hook location where this evaluation is happening.
 
     Examples:
         >>> from cpex.framework.cmf.message import Message, Role, TextContent
@@ -55,19 +75,18 @@ class MessagePayload(PluginPayload):
         ...     role=Role.USER,
         ...     content=[TextContent(text="Hello")],
         ... )
-        >>> payload = MessagePayload(message=msg)
-        >>> payload.message.role
-        <Role.USER: 'user'>
-        >>> payload.message.content[0].text
-        'Hello'
-
-        >>> # Iterate views through the payload
-        >>> views = list(payload.message.iter_views())
-        >>> len(views)
-        1
+        >>> payload = MessagePayload(
+        ...     message=msg, hook=MessageHookType.LLM_INPUT
+        ... )
+        >>> payload.hook
+        <MessageHookType.LLM_INPUT: 'llm_input'>
     """
 
     message: Message = Field(description="The CMF message to evaluate.")
+    hook: MessageHookType = Field(
+        default=MessageHookType.EVALUATE,
+        description="The hook location where this evaluation is happening.",
+    )
 
 
 MessageResult = PluginResult[MessagePayload]

--- a/cpex/framework/hooks/tools.py
+++ b/cpex/framework/hooks/tools.py
@@ -8,11 +8,12 @@ Pydantic models for tool hooks.
 """
 
 # Standard
+import warnings
 from enum import Enum
 from typing import Any, Optional
 
 # Third-Party
-from pydantic import Field
+from pydantic import Field, field_validator
 
 # First-Party
 from cpex.framework.hooks.http import HttpHeaderPayload
@@ -69,6 +70,20 @@ class ToolPreInvokePayload(PluginPayload):
     name: str
     args: Optional[dict[str, Any]] = Field(default_factory=dict)
     headers: Optional[HttpHeaderPayload] = None
+
+    @field_validator("headers", mode="before")
+    @classmethod
+    def _warn_headers_deprecated(cls, v: object) -> object:
+        """Emit deprecation warning for headers field."""
+        if v is not None:
+            warnings.warn(
+                "ToolPreInvokePayload.headers is deprecated; "
+                "use extensions.http.headers instead. "
+                "This field will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return v
 
 
 class ToolPostInvokePayload(PluginPayload):

--- a/cpex/framework/hooks/tools.py
+++ b/cpex/framework/hooks/tools.py
@@ -81,7 +81,7 @@ class ToolPreInvokePayload(PluginPayload):
                 "use extensions.http.headers instead. "
                 "This field will be removed in a future release.",
                 DeprecationWarning,
-                stacklevel=2,
+                stacklevel=4,
             )
         return v
 

--- a/cpex/framework/loader/plugin.py
+++ b/cpex/framework/loader/plugin.py
@@ -92,6 +92,9 @@ class PluginLoader:
     async def load_and_instantiate_plugin(self, config: PluginConfig) -> Plugin | None:
         """Load and instantiate a plugin, given a configuration.
 
+        The plugin receives a defensive copy of the config so it cannot
+        modify the authoritative config retained by the Manager/PluginRef.
+
         For external plugins, the transport type is determined by the presence
         of 'mcp', 'grpc', or 'unix_socket' configuration:
         - If 'grpc' is set, uses GrpcExternalPlugin for gRPC transport
@@ -107,6 +110,9 @@ class PluginLoader:
         Raises:
             ValueError: If an external plugin has no transport configured.
         """
+        # Defensive copy — the plugin never sees the authoritative config
+        plugin_config = config.model_copy()
+
         # Handle external plugins with transport selection
         if config.kind == EXTERNAL_PLUGIN_TYPE:
             plugin: Plugin
@@ -118,7 +124,7 @@ class PluginLoader:
                     GrpcExternalPlugin,
                 )  # pylint: disable=import-outside-toplevel
 
-                plugin = GrpcExternalPlugin(config)
+                plugin = GrpcExternalPlugin(plugin_config)
                 logger.info("Loading external plugin '%s' with gRPC transport", config.name)
             elif config.unix_socket:
                 # Use raw Unix socket transport (high-performance local IPC)
@@ -127,11 +133,11 @@ class PluginLoader:
                     UnixSocketExternalPlugin,
                 )  # pylint: disable=import-outside-toplevel
 
-                plugin = UnixSocketExternalPlugin(config)
+                plugin = UnixSocketExternalPlugin(plugin_config)
                 logger.info("Loading external plugin '%s' with Unix socket transport", config.name)
             elif config.mcp:
                 # Use MCP transport
-                plugin = ExternalPlugin(config)
+                plugin = ExternalPlugin(plugin_config)
                 logger.info("Loading external plugin '%s' with MCP transport", config.name)
             else:
                 # Defensive fallback: PluginConfig validation should prevent this path.
@@ -147,7 +153,7 @@ class PluginLoader:
             self.__register_plugin_type(config.kind)
         plugin_type = self._plugin_types[config.kind]
         if plugin_type:
-            plugin = plugin_type(config)
+            plugin = plugin_type(plugin_config)
             await plugin.initialize()
             return plugin
         return None

--- a/cpex/framework/manager.py
+++ b/cpex/framework/manager.py
@@ -40,6 +40,8 @@ from pydantic import BaseModel, RootModel
 from cpex.framework.base import HookRef, Plugin
 from cpex.framework.constants import EXTERNAL_PLUGIN_TYPE
 from cpex.framework.errors import PluginError, PluginViolationError, convert_exception_to_error
+from cpex.framework.extensions.extensions import Extensions
+from cpex.framework.extensions.tiers import filter_extensions
 from cpex.framework.hooks.policies import DefaultHookPolicy, HookPayloadPolicy, apply_policy
 from cpex.framework.loader.config import ConfigLoader
 from cpex.framework.loader.plugin import PluginLoader
@@ -55,8 +57,6 @@ from cpex.framework.models import (
     PluginPayload,
     PluginResult,
 )
-from cpex.framework.extensions.extensions import Extensions
-from cpex.framework.extensions.tiers import filter_extensions
 from cpex.framework.observability import ObservabilityProvider, current_trace_id
 from cpex.framework.registry import PluginInstanceRegistry
 from cpex.framework.settings import settings
@@ -650,7 +650,11 @@ class PluginExecutor:
     ) -> tuple[PluginResult, dict]:
         """Schedule fire-and-forget tasks and build a pipeline-halting result."""
         self._fire_and_forget_tasks(
-            fire_and_forget_refs, payload, global_context, res_local_contexts, fire_and_forget_semaphore,
+            fire_and_forget_refs,
+            payload,
+            global_context,
+            res_local_contexts,
+            fire_and_forget_semaphore,
             extensions=extensions,
         )
         if hook_type == HTTP_AUTH_CHECK_PERMISSION_HOOK and decision_plugin_name:

--- a/cpex/framework/manager.py
+++ b/cpex/framework/manager.py
@@ -38,6 +38,7 @@ from pydantic import BaseModel, RootModel
 
 # First-Party
 from cpex.framework.base import HookRef, Plugin
+from cpex.framework.constants import EXTERNAL_PLUGIN_TYPE
 from cpex.framework.errors import PluginError, PluginViolationError, convert_exception_to_error
 from cpex.framework.hooks.policies import DefaultHookPolicy, HookPayloadPolicy, apply_policy
 from cpex.framework.loader.config import ConfigLoader
@@ -54,6 +55,8 @@ from cpex.framework.models import (
     PluginPayload,
     PluginResult,
 )
+from cpex.framework.extensions.extensions import Extensions
+from cpex.framework.extensions.tiers import filter_extensions
 from cpex.framework.observability import ObservabilityProvider, current_trace_id
 from cpex.framework.registry import PluginInstanceRegistry
 from cpex.framework.settings import settings
@@ -137,6 +140,7 @@ class PluginExecutor:
         hook_type: str,
         local_contexts: Optional[PluginContextTable] = None,
         violations_as_exceptions: bool = False,
+        extensions: Optional[Extensions] = None,
     ) -> tuple[PluginResult, PluginContextTable | None]:
         """Execute plugins in priority order with timeout protection.
 
@@ -147,6 +151,7 @@ class PluginExecutor:
             hook_type: The hook type identifier (e.g., "tool_pre_invoke").
             local_contexts: Optional existing contexts from previous hook executions.
             violations_as_exceptions: Raise violations as exceptions rather than as returns.
+            extensions: Optional extensions to filter and pass to plugins that accept them.
 
         Returns:
             A tuple containing:
@@ -214,6 +219,7 @@ class PluginExecutor:
             allow_blocking=True,
             fire_and_forget_refs=fire_and_forget_refs,
             fire_and_forget_semaphore=fire_and_forget_semaphore,
+            extensions=extensions,
         )
         if halt_result is not None:
             return halt_result
@@ -236,6 +242,7 @@ class PluginExecutor:
             decision_plugin_name=decision_plugin_name,
             apply_modifications=True,
             allow_blocking=False,
+            extensions=extensions,
         )
         current_payload, decision_plugin_name = self._serial_phase_state
 
@@ -255,6 +262,7 @@ class PluginExecutor:
             decision_plugin_name=decision_plugin_name,
             apply_modifications=False,
             allow_blocking=False,
+            extensions=extensions,
         )
         current_payload, decision_plugin_name = self._serial_phase_state
 
@@ -275,6 +283,7 @@ class PluginExecutor:
                     violations_as_exceptions,
                     global_context,
                     combined_metadata,
+                    extensions=extensions,
                 )
                 if concurrent_semaphore:
                     coro = self._with_semaphore(concurrent_semaphore, coro)
@@ -317,11 +326,17 @@ class PluginExecutor:
                         fire_and_forget_semaphore,
                         hook_type,
                         decision_plugin_name,
+                        extensions=extensions,
                     )
 
         # FIRE_AND_FORGET: fire-and-forget background tasks (fires last with final payload snapshot)
         self._fire_and_forget_tasks(
-            fire_and_forget_refs, payload, global_context, res_local_contexts, fire_and_forget_semaphore
+            fire_and_forget_refs,
+            payload,
+            global_context,
+            res_local_contexts,
+            fire_and_forget_semaphore,
+            extensions=extensions,
         )
 
         if hook_type == HTTP_AUTH_CHECK_PERMISSION_HOOK and decision_plugin_name:
@@ -412,6 +427,7 @@ class PluginExecutor:
         allow_blocking: bool,
         fire_and_forget_refs: Optional[list[HookRef]] = None,
         fire_and_forget_semaphore: Optional[asyncio.Semaphore] = None,
+        extensions: Optional[Extensions] = None,
     ) -> Optional[tuple[PluginResult, PluginContextTable | None]]:
         """Run a serial execution phase (SEQUENTIAL, TRANSFORM, or AUDIT).
 
@@ -449,6 +465,7 @@ class PluginExecutor:
                 violations_as_exceptions,
                 global_context,
                 combined_metadata,
+                extensions=extensions,
             )
 
             if result.modified_payload is not None:
@@ -494,6 +511,7 @@ class PluginExecutor:
                         fire_and_forget_semaphore,
                         hook_type,
                         decision_plugin_name,
+                        extensions=extensions,
                     )
                 else:
                     logger.warning(
@@ -628,10 +646,12 @@ class PluginExecutor:
         fire_and_forget_semaphore: Optional[asyncio.Semaphore],
         hook_type: str,
         decision_plugin_name: Optional[str],
+        extensions: Optional[Extensions] = None,
     ) -> tuple[PluginResult, dict]:
         """Schedule fire-and-forget tasks and build a pipeline-halting result."""
         self._fire_and_forget_tasks(
-            fire_and_forget_refs, payload, global_context, res_local_contexts, fire_and_forget_semaphore
+            fire_and_forget_refs, payload, global_context, res_local_contexts, fire_and_forget_semaphore,
+            extensions=extensions,
         )
         if hook_type == HTTP_AUTH_CHECK_PERMISSION_HOOK and decision_plugin_name:
             combined_metadata[DECISION_PLUGIN_METADATA_KEY] = decision_plugin_name
@@ -664,6 +684,7 @@ class PluginExecutor:
         global_context: GlobalContext,
         res_local_contexts: dict,
         semaphore: Optional[asyncio.Semaphore],
+        extensions: Optional[Extensions] = None,
     ) -> None:
         """Schedule all FIRE_AND_FORGET plugins as fire-and-forget background tasks.
 
@@ -688,7 +709,9 @@ class PluginExecutor:
             )
             local_context = PluginContext(global_context=tmp_gc)
             res_local_contexts[local_context_key] = local_context
-            asyncio.create_task(self._run_fire_and_forget_task(ref, task_input, local_context, semaphore))
+            asyncio.create_task(
+                self._run_fire_and_forget_task(ref, task_input, local_context, semaphore, extensions=extensions)
+            )
 
     async def _run_fire_and_forget_task(
         self,
@@ -696,6 +719,7 @@ class PluginExecutor:
         payload: PluginPayload,
         local_context: PluginContext,
         semaphore: Optional[asyncio.Semaphore],
+        extensions: Optional[Extensions] = None,
     ) -> None:
         """Execute a plugin as a fire-and-forget background task.
 
@@ -705,9 +729,9 @@ class PluginExecutor:
         try:
             if semaphore:
                 async with semaphore:
-                    await self._execute_with_timeout(hook_ref, payload, local_context)
+                    await self._execute_with_timeout(hook_ref, payload, local_context, extensions=extensions)
             else:
-                await self._execute_with_timeout(hook_ref, payload, local_context)
+                await self._execute_with_timeout(hook_ref, payload, local_context, extensions=extensions)
         except Exception:
             logger.error("Plugin %s failed in fire-and-forget mode (ignored)", hook_ref.plugin_ref.name)
             if hook_ref.plugin_ref.on_error == OnError.DISABLE:
@@ -722,6 +746,7 @@ class PluginExecutor:
         violations_as_exceptions: bool,
         global_context: Optional[GlobalContext] = None,
         combined_metadata: Optional[dict[str, Any]] = None,
+        extensions: Optional[Extensions] = None,
     ) -> PluginResult:
         """Execute a single plugin with timeout protection.
 
@@ -732,6 +757,7 @@ class PluginExecutor:
             violations_as_exceptions: Raise violations as exceptions rather than as returns.
             global_context: Shared context for all plugins containing request metadata.
             combined_metadata: combination of the metadata of all plugins.
+            extensions: Optional extensions to filter and pass to plugins that accept them.
 
         Returns:
             A tuple containing:
@@ -745,7 +771,7 @@ class PluginExecutor:
         """
         try:
             # Execute plugin with timeout protection
-            result = await self._execute_with_timeout(hook_ref, payload, local_context)
+            result = await self._execute_with_timeout(hook_ref, payload, local_context, extensions=extensions)
             # Merge global state for modes that participate in the pipeline chain.
             # AUDIT and FIRE_AND_FORGET operate on isolated snapshots and should not
             # mutate shared state.
@@ -870,7 +896,11 @@ class PluginExecutor:
         return PluginResult(continue_processing=True)
 
     async def _execute_with_timeout(
-        self, hook_ref: HookRef, payload: PluginPayload, context: PluginContext
+        self,
+        hook_ref: HookRef,
+        payload: PluginPayload,
+        context: PluginContext,
+        extensions: Optional[Extensions] = None,
     ) -> PluginResult:
         """Execute a plugin with timeout protection.
 
@@ -878,6 +908,7 @@ class PluginExecutor:
             hook_ref: Reference to the hook and plugin to execute.
             payload: Payload to process.
             context: Plugin execution context.
+            extensions: Optional extensions to filter and pass if the plugin accepts them.
 
         Returns:
             Result from plugin execution.
@@ -916,7 +947,11 @@ class PluginExecutor:
 
         # Execute plugin
         try:
-            result = await asyncio.wait_for(hook_ref.hook(payload, context), timeout=self.timeout)
+            if hook_ref.accepts_extensions:
+                filtered = filter_extensions(extensions, hook_ref.plugin_ref.capabilities)
+                result = await asyncio.wait_for(hook_ref.hook(payload, context, filtered), timeout=self.timeout)
+            else:
+                result = await asyncio.wait_for(hook_ref.hook(payload, context), timeout=self.timeout)
         except Exception:
             if span_id is not None:
                 try:
@@ -1263,7 +1298,15 @@ class PluginManager:
                         # Fully instantiate enabled plugins
                         plugin = await self._loader.load_and_instantiate_plugin(plugin_config)
                         if plugin:
-                            self._registry.register(plugin)
+                            # For external plugins, initialize() merges the remote
+                            # config (mode, hooks, etc.) so the post-init config is
+                            # authoritative.  For internal plugins the original YAML
+                            # config is already complete.
+                            if plugin_config.kind == EXTERNAL_PLUGIN_TYPE:
+                                trusted = plugin.config.model_copy()
+                            else:
+                                trusted = plugin_config
+                            self._registry.register(plugin, trusted_config=trusted)
                             loaded_count += 1
                             logger.info("Loaded plugin: %s (mode: %s)", plugin_config.name, plugin_config.mode)
                         else:
@@ -1330,6 +1373,7 @@ class PluginManager:
         global_context: GlobalContext,
         local_contexts: Optional[PluginContextTable] = None,
         violations_as_exceptions: bool = False,
+        extensions: Optional[Extensions] = None,
     ) -> tuple[PluginResult, PluginContextTable | None]:
         """Invoke a set of plugins configured for the hook point in priority order.
 
@@ -1339,6 +1383,7 @@ class PluginManager:
             global_context: Shared context for all plugins with request metadata.
             local_contexts: Optional existing contexts from previous hook executions.
             violations_as_exceptions: Raise violations as exceptions rather than as returns.
+            extensions: Optional extensions to filter and pass to plugins that accept them.
 
         Returns:
             A tuple containing:
@@ -1361,7 +1406,13 @@ class PluginManager:
 
         # Execute plugins
         result = await self._get_executor().execute(
-            hook_refs, payload, global_context, hook_type, local_contexts, violations_as_exceptions
+            hook_refs,
+            payload,
+            global_context,
+            hook_type,
+            local_contexts,
+            violations_as_exceptions,
+            extensions=extensions,
         )
 
         return result

--- a/cpex/framework/manager.py
+++ b/cpex/framework/manager.py
@@ -31,6 +31,7 @@ Examples:
 import asyncio
 import logging
 import threading
+from dataclasses import dataclass
 from typing import Any, Literal, Optional, Union
 
 # Third-Party
@@ -73,6 +74,24 @@ CONTEXT_MAX_AGE = 3600  # 1 hour
 HTTP_AUTH_CHECK_PERMISSION_HOOK = "http_auth_check_permission"
 DECISION_PLUGIN_METADATA_KEY = "_decision_plugin"
 RESERVED_INTERNAL_METADATA_KEYS = frozenset({DECISION_PLUGIN_METADATA_KEY})
+
+
+@dataclass
+class PhaseState:
+    """State accumulated during a serial execution phase.
+
+    Replaces the nested tuple return type from _run_serial_phase,
+    improving readability and self-documentation.
+
+    Attributes:
+        payload: The current effective payload (may be modified by plugins).
+        decision_plugin: Name of the last plugin that modified the payload.
+        extensions: The current extensions (may be modified by plugins).
+    """
+
+    payload: Optional[PluginPayload] = None
+    decision_plugin: Optional[str] = None
+    extensions: Optional[Extensions] = None
 
 
 class PluginTimeoutError(Exception):
@@ -202,7 +221,7 @@ class PluginExecutor:
         concurrent_semaphore = asyncio.Semaphore(pool) if pool else None
 
         # SEQUENTIAL: sequential, chained execution — can halt pipeline
-        halt_result, (current_payload, decision_plugin_name, current_extensions) = await self._run_serial_phase(
+        halt_result, phase = await self._run_serial_phase(
             hook_refs=sequential_refs,
             mode_label="SEQUENTIAL",
             payload=payload,
@@ -222,11 +241,14 @@ class PluginExecutor:
             fire_and_forget_semaphore=fire_and_forget_semaphore,
             extensions=extensions,
         )
+        current_payload = phase.payload
+        decision_plugin_name = phase.decision_plugin
+        current_extensions = phase.extensions
         if halt_result is not None:
             return halt_result
 
         # TRANSFORM: serial, chained execution — can modify payloads but cannot halt pipeline
-        _, (current_payload, decision_plugin_name, current_extensions) = await self._run_serial_phase(
+        _, phase = await self._run_serial_phase(
             hook_refs=transform_refs,
             mode_label="TRANSFORM",
             payload=payload,
@@ -244,9 +266,12 @@ class PluginExecutor:
             current_extensions=current_extensions,
             extensions=extensions,
         )
+        current_payload = phase.payload
+        decision_plugin_name = phase.decision_plugin
+        current_extensions = phase.extensions
 
         # AUDIT: serial execution — observe-only (no modifications, no blocking)
-        _, (current_payload, decision_plugin_name, current_extensions) = await self._run_serial_phase(
+        _, phase = await self._run_serial_phase(
             hook_refs=audit_refs,
             mode_label="AUDIT",
             payload=payload,
@@ -434,7 +459,7 @@ class PluginExecutor:
         extensions: Optional[Extensions] = None,
     ) -> tuple[
         Optional[tuple[PluginResult, PluginContextTable | None]],
-        tuple[Optional[PluginPayload], Optional[str], Optional[Extensions]],
+        PhaseState,
     ]:
         """Run a serial execution phase (SEQUENTIAL, TRANSFORM, or AUDIT).
 
@@ -458,7 +483,6 @@ class PluginExecutor:
 
         Returns:
             A tuple of (halt_result, phase_state). halt_result is None if pipeline continues.
-            phase_state is (current_payload, decision_plugin_name, current_extensions).
         """
         for hook_ref in hook_refs:
             local_context = self._prepare_plugin_context(hook_ref, global_context, local_contexts, res_local_contexts)
@@ -510,7 +534,9 @@ class PluginExecutor:
                         hook_type,
                         violation_detail,
                     )
-                    state = (current_payload, decision_plugin_name, current_extensions)
+                    state = PhaseState(
+                        payload=current_payload, decision_plugin=decision_plugin_name, extensions=current_extensions
+                    )
                     halt = self._build_halt_result(
                         current_payload,
                         result.violation,
@@ -535,7 +561,9 @@ class PluginExecutor:
                         violation_detail,
                     )
 
-        return None, (current_payload, decision_plugin_name, current_extensions)
+        return None, PhaseState(
+            payload=current_payload, decision_plugin=decision_plugin_name, extensions=current_extensions
+        )
 
     def _apply_payload_modification(
         self,

--- a/cpex/framework/manager.py
+++ b/cpex/framework/manager.py
@@ -130,7 +130,6 @@ class PluginExecutor:
             default_hook_policy if default_hook_policy else settings.default_hook_policy
         )
         self._runtime_disabled: set[str] = set()
-        self._serial_phase_state: tuple[Optional[PluginPayload], Optional[str]] = (None, None)
 
     async def execute(
         self,
@@ -190,6 +189,7 @@ class PluginExecutor:
         res_local_contexts = {}
         combined_metadata: dict[str, Any] = {}
         current_payload: PluginPayload | None = None
+        current_extensions: Extensions | None = None
         decision_plugin_name: Optional[str] = None
 
         sequential_refs, transform_refs, audit_refs, concurrent_refs, fire_and_forget_refs = self._group_by_mode(
@@ -202,7 +202,7 @@ class PluginExecutor:
         concurrent_semaphore = asyncio.Semaphore(pool) if pool else None
 
         # SEQUENTIAL: sequential, chained execution — can halt pipeline
-        halt_result = await self._run_serial_phase(
+        halt_result, (current_payload, decision_plugin_name, current_extensions) = await self._run_serial_phase(
             hook_refs=sequential_refs,
             mode_label="SEQUENTIAL",
             payload=payload,
@@ -217,17 +217,16 @@ class PluginExecutor:
             decision_plugin_name=decision_plugin_name,
             apply_modifications=True,
             allow_blocking=True,
+            current_extensions=current_extensions,
             fire_and_forget_refs=fire_and_forget_refs,
             fire_and_forget_semaphore=fire_and_forget_semaphore,
             extensions=extensions,
         )
         if halt_result is not None:
             return halt_result
-        # Update mutable state from sequential phase
-        current_payload, decision_plugin_name = self._serial_phase_state
 
         # TRANSFORM: serial, chained execution — can modify payloads but cannot halt pipeline
-        await self._run_serial_phase(
+        _, (current_payload, decision_plugin_name, current_extensions) = await self._run_serial_phase(
             hook_refs=transform_refs,
             mode_label="TRANSFORM",
             payload=payload,
@@ -242,12 +241,12 @@ class PluginExecutor:
             decision_plugin_name=decision_plugin_name,
             apply_modifications=True,
             allow_blocking=False,
+            current_extensions=current_extensions,
             extensions=extensions,
         )
-        current_payload, decision_plugin_name = self._serial_phase_state
 
         # AUDIT: serial execution — observe-only (no modifications, no blocking)
-        await self._run_serial_phase(
+        _, (current_payload, decision_plugin_name, current_extensions) = await self._run_serial_phase(
             hook_refs=audit_refs,
             mode_label="AUDIT",
             payload=payload,
@@ -262,9 +261,9 @@ class PluginExecutor:
             decision_plugin_name=decision_plugin_name,
             apply_modifications=False,
             allow_blocking=False,
+            current_extensions=current_extensions,
             extensions=extensions,
         )
-        current_payload, decision_plugin_name = self._serial_phase_state
 
         # CONCURRENT: parallel execution with fail-fast on first blocking result
         if concurrent_refs:
@@ -344,7 +343,11 @@ class PluginExecutor:
 
         return (
             PluginResult(
-                continue_processing=True, modified_payload=current_payload, violation=None, metadata=combined_metadata
+                continue_processing=True,
+                modified_payload=current_payload,
+                modified_extensions=current_extensions,
+                violation=None,
+                metadata=combined_metadata,
             ),
             res_local_contexts,
         )
@@ -425,10 +428,14 @@ class PluginExecutor:
         decision_plugin_name: Optional[str],
         apply_modifications: bool,
         allow_blocking: bool,
+        current_extensions: Optional[Extensions] = None,
         fire_and_forget_refs: Optional[list[HookRef]] = None,
         fire_and_forget_semaphore: Optional[asyncio.Semaphore] = None,
         extensions: Optional[Extensions] = None,
-    ) -> Optional[tuple[PluginResult, PluginContextTable | None]]:
+    ) -> tuple[
+        Optional[tuple[PluginResult, PluginContextTable | None]],
+        tuple[Optional[PluginPayload], Optional[str], Optional[Extensions]],
+    ]:
         """Run a serial execution phase (SEQUENTIAL, TRANSFORM, or AUDIT).
 
         Args:
@@ -450,8 +457,8 @@ class PluginExecutor:
             fire_and_forget_semaphore: Semaphore for fire-and-forget tasks (only used when allow_blocking=True).
 
         Returns:
-            A halt result tuple if the pipeline was halted, or None to continue.
-            Updates ``self._serial_phase_state`` with the latest (current_payload, decision_plugin_name).
+            A tuple of (halt_result, phase_state). halt_result is None if pipeline continues.
+            phase_state is (current_payload, decision_plugin_name, current_extensions).
         """
         for hook_ref in hook_refs:
             local_context = self._prepare_plugin_context(hook_ref, global_context, local_contexts, res_local_contexts)
@@ -489,6 +496,10 @@ class PluginExecutor:
                         mode_label.lower(),
                     )
 
+            # Accumulate modified_extensions (last writer wins)
+            if result.modified_extensions is not None:
+                current_extensions = result.modified_extensions
+
             if not result.continue_processing:
                 violation_detail = f": [{result.violation.code}] {result.violation.reason}" if result.violation else ""
                 if allow_blocking:
@@ -499,8 +510,8 @@ class PluginExecutor:
                         hook_type,
                         violation_detail,
                     )
-                    self._serial_phase_state = (current_payload, decision_plugin_name)
-                    return self._build_halt_result(
+                    state = (current_payload, decision_plugin_name, current_extensions)
+                    halt = self._build_halt_result(
                         current_payload,
                         result.violation,
                         combined_metadata,
@@ -513,6 +524,7 @@ class PluginExecutor:
                         decision_plugin_name,
                         extensions=extensions,
                     )
+                    return halt, state
                 else:
                     logger.warning(
                         "%s plugin %s returned continue_processing=False on hook %s%s; "
@@ -523,8 +535,7 @@ class PluginExecutor:
                         violation_detail,
                     )
 
-        self._serial_phase_state = (current_payload, decision_plugin_name)
-        return None
+        return None, (current_payload, decision_plugin_name, current_extensions)
 
     def _apply_payload_modification(
         self,

--- a/cpex/framework/models.py
+++ b/cpex/framework/models.py
@@ -1192,6 +1192,8 @@ class PluginConfig(BaseModel):
         grpc (Optional[GRPCClientConfig]): Client-side gRPC configuration (gateway connecting to plugin).
     """
 
+    model_config = ConfigDict(frozen=True)
+
     name: str
     description: Optional[str] = None
     author: Optional[str] = None
@@ -1227,10 +1229,33 @@ class PluginConfig(BaseModel):
 
     conditions: list[PluginCondition] = Field(default_factory=list)  # When to apply
     applied_to: Optional[AppliedTo] = None  # Fields to apply to.
+    capabilities: frozenset[str] = Field(
+        default_factory=frozenset,
+        description="Declared capabilities (e.g., 'read_headers', 'append_labels').",
+    )
     config: Optional[dict[str, Any]] = None
     mcp: Optional[MCPClientConfig] = None
     grpc: Optional[GRPCClientConfig] = None
     unix_socket: Optional[UnixSocketClientConfig] = None
+
+    @field_validator("capabilities", mode="before")
+    @classmethod
+    def _validate_capabilities(cls, v: Any) -> frozenset[str]:
+        # First-Party
+        from cpex.framework.extensions.tiers import Capability  # pylint: disable=import-outside-toplevel
+
+        if isinstance(v, (list, set, frozenset)):
+            known = {c.value for c in Capability}
+            for cap in v:
+                if cap not in known:
+                    raise ValueError(f"Unknown capability: {cap!r}. Known: {sorted(known)}")
+            return frozenset(v)
+        return frozenset()
+
+    @field_serializer("capabilities")
+    def serialize_capabilities(self, value: frozenset[str]) -> list[str]:
+        """Serialize frozenset for JSON compatibility."""
+        return sorted(value)
 
     @model_validator(mode="after")
     def check_url_or_script_filled(self) -> Self:  # pylint: disable=bad-classmethod-argument

--- a/cpex/framework/models.py
+++ b/cpex/framework/models.py
@@ -1241,6 +1241,17 @@ class PluginConfig(BaseModel):
     @field_validator("capabilities", mode="before")
     @classmethod
     def _validate_capabilities(cls, v: Any) -> frozenset[str]:
+        """Validate that all declared capabilities are known.
+
+        Args:
+            v: Raw capabilities value from the config.
+
+        Returns:
+            A validated frozenset of capability strings.
+
+        Raises:
+            ValueError: If an unknown capability is declared.
+        """
         # First-Party
         from cpex.framework.extensions.tiers import Capability  # pylint: disable=import-outside-toplevel
 

--- a/cpex/framework/models.py
+++ b/cpex/framework/models.py
@@ -40,6 +40,7 @@ from cpex.framework.constants import (
     UDS,
     URL,
 )
+from cpex.framework.extensions.extensions import Extensions
 from cpex.framework.settings import (
     get_client_mtls_settings,
     get_grpc_client_mtls_settings,
@@ -1455,6 +1456,8 @@ class PluginResult(BaseModel, Generic[T]):
     Attributes:
             continue_processing (bool): Whether to stop processing.
             modified_payload (Optional[Any]): The modified payload if the plugin is a transformer.
+            modified_extensions (Optional[Extensions]): Modified extensions returned by the plugin
+                (e.g., updated HTTP headers from token delegation, appended security labels).
             violation (Optional[PluginViolation]): violation object.
             metadata (Optional[dict[str, Any]]): additional metadata.
 
@@ -1483,6 +1486,7 @@ class PluginResult(BaseModel, Generic[T]):
 
     continue_processing: bool = True
     modified_payload: Optional[T] = None
+    modified_extensions: Optional[Extensions] = None
     violation: Optional[PluginViolation] = None
     metadata: Optional[dict[str, Any]] = Field(default_factory=dict)
 

--- a/cpex/framework/pdp/__init__.py
+++ b/cpex/framework/pdp/__init__.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""External Policy Decision Point (PDP) resolvers.
+
+This module provides clients for delegating policy decisions to external
+PDPs (OPA, Cedar, AuthZen, or custom) from within the APL pipeline.
+
+The APL pipeline (Rust) defines the PdpResolver trait. These Python
+classes implement that interface, handling the HTTP calls while the
+Rust core stays synchronous and transport-agnostic.
+
+Usage in YAML policy:
+    policy:
+      - authzen("https://pdp.corp.com/access/v1/evaluation"):
+          timeout_ms: 500
+          on_error: deny
+
+Usage from Python (gateway integration):
+    from cpex.framework.pdp import AuthZenResolver, OpaResolver
+
+    resolver = AuthZenResolver("https://pdp.corp.com/access/v1/evaluation")
+    # Pass to pipeline executor as the PDP callback
+"""
+
+from cpex.framework.pdp.authzen import AuthZenResolver
+from cpex.framework.pdp.base import PdpResolver, PdpResult
+from cpex.framework.pdp.opa import OpaResolver
+
+__all__ = [
+    "AuthZenResolver",
+    "OpaResolver",
+    "PdpResolver",
+    "PdpResult",
+]

--- a/cpex/framework/pdp/authzen.py
+++ b/cpex/framework/pdp/authzen.py
@@ -1,0 +1,278 @@
+# -*- coding: utf-8 -*-
+"""AuthZen PDP resolver — OpenID AuthZen Access Evaluation API.
+
+AuthZen defines a standard interface for policy evaluation that is
+PDP-agnostic: the same API works whether the backend is OPA, Cedar,
+Topaz, Cerbos, OSO, or any other engine implementing the spec.
+
+AuthZen API (single evaluation):
+    POST /access/v1/evaluation
+    {
+      "subject": { "type": "user", "id": "alice@corp.com", "properties": {...} },
+      "action":  { "name": "read" },
+      "resource": { "type": "tool", "id": "get_compensation", "properties": {...} },
+      "context": { ... }
+    }
+    → { "decision": true }
+
+AuthZen API (batch evaluation):
+    POST /access/v1/evaluations
+    {
+      "evaluations": [
+        { "subject": ..., "action": ..., "resource": ..., "context": ... },
+        ...
+      ]
+    }
+    → { "evaluations": [{ "decision": true }, { "decision": false }] }
+
+Mapping from CPEX/APL types to AuthZen:
+    SubjectExtension  → subject  (type, id, properties: roles/permissions/teams)
+    route action      → action   (name)
+    tool/resource     → resource (type, id, properties)
+    everything else   → context  (delegation, session, authorization_details, args)
+
+References:
+    - OpenID AuthZen: https://openid.net/specs/openid-authzen-authorization-api-1_0.html
+    - AuthZen interop: https://authzen.org
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import httpx
+
+from cpex.framework.pdp.base import PdpError, PdpResolver, PdpResult
+
+logger = logging.getLogger(__name__)
+
+
+class AuthZenResolver(PdpResolver):
+    """AuthZen Access Evaluation API client.
+
+    Translates CPEX pipeline context into AuthZen's subject/action/resource/context
+    tuple and calls the evaluation endpoint.
+
+    Args:
+        endpoint: AuthZen evaluation endpoint URL. Supports {placeholder}
+            templates interpolated from input_data at request time.
+            Static:   "https://pdp.corp.com/access/v1/evaluation"
+            Template: "https://pdp.corp.com/access/v1/{tool}/evaluation"
+        timeout_ms: HTTP timeout in milliseconds. Default 500.
+        headers: Additional HTTP headers (e.g., API keys, bearer tokens).
+        fail_open: If True, allow on PDP errors. If False, raise PdpError.
+
+    Usage:
+        # Static endpoint
+        resolver = AuthZenResolver("https://pdp.corp.com/access/v1/evaluation")
+
+        # Template endpoint — per-tool policy sets
+        resolver = AuthZenResolver("https://pdp.corp.com/access/v1/{tool}/evaluation")
+
+        result = await resolver.resolve({
+            "tool": "get_compensation",
+            "action": "read",
+            ...
+        })
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        timeout_ms: int = 500,
+        headers: dict[str, str] | None = None,
+        fail_open: bool = False,
+    ):
+        """Initialize the AuthZen resolver.
+
+        Args:
+            endpoint: AuthZen evaluation endpoint URL. Supports {placeholder} templates.
+            timeout_ms: HTTP timeout in milliseconds. Default 500.
+            headers: Additional HTTP headers (e.g., API keys, bearer tokens).
+            fail_open: If True, allow on PDP errors. If False, raise PdpError.
+        """
+        self._endpoint_template = endpoint
+        self.fail_open = fail_open
+        self._client = httpx.AsyncClient(
+            timeout=httpx.Timeout(timeout_ms / 1000.0),
+            headers=headers or {},
+        )
+
+    def _resolve_endpoint(self, input_data: dict[str, Any]) -> str:
+        """Resolve the endpoint URL, interpolating any {placeholders}."""
+        if "{" not in self._endpoint_template:
+            return self._endpoint_template
+        flat = {k: str(v) for k, v in input_data.items() if isinstance(v, str)}
+        try:
+            return self._endpoint_template.format(**flat)
+        except KeyError:
+            logger.warning(
+                "AuthZen endpoint template has unresolved placeholders: %s",
+                self._endpoint_template,
+            )
+            return self._endpoint_template
+
+    async def resolve(self, input_data: dict[str, Any]) -> PdpResult:
+        """Evaluate a policy decision via AuthZen.
+
+        Transforms the flat input_data (from APL's build_pdp_input) into
+        the AuthZen subject/action/resource/context structure.
+        If the endpoint is a template, placeholders are resolved from input_data.
+        """
+        endpoint = self._resolve_endpoint(input_data)
+        request_body = self._build_request(input_data)
+
+        start = time.monotonic()
+        try:
+            response = await self._client.post(
+                endpoint,
+                json=request_body,
+            )
+            latency_ms = (time.monotonic() - start) * 1000
+            response.raise_for_status()
+            return self._parse_response(response.json(), latency_ms)
+
+        except httpx.TimeoutException as e:
+            latency_ms = (time.monotonic() - start) * 1000
+            logger.warning("AuthZen timeout after %.1fms: %s", latency_ms, endpoint)
+            if self.fail_open:
+                return PdpResult(
+                    allowed=True,
+                    reason="AuthZen timeout, fail-open",
+                    latency_ms=latency_ms,
+                )
+            raise PdpError(
+                f"AuthZen timeout after {latency_ms:.0f}ms",
+                endpoint=endpoint,
+                cause=e,
+            )
+
+        except httpx.HTTPStatusError as e:
+            latency_ms = (time.monotonic() - start) * 1000
+            logger.error(
+                "AuthZen HTTP %d from %s: %s",
+                e.response.status_code,
+                endpoint,
+                e.response.text[:200],
+            )
+            if self.fail_open:
+                return PdpResult(
+                    allowed=True,
+                    reason=f"AuthZen HTTP {e.response.status_code}, fail-open",
+                    latency_ms=latency_ms,
+                )
+            raise PdpError(
+                f"AuthZen HTTP {e.response.status_code}",
+                endpoint=endpoint,
+                cause=e,
+            )
+
+        except httpx.HTTPError as e:
+            latency_ms = (time.monotonic() - start) * 1000
+            logger.error("AuthZen connection error: %s", e)
+            if self.fail_open:
+                return PdpResult(
+                    allowed=True,
+                    reason="AuthZen unreachable, fail-open",
+                    latency_ms=latency_ms,
+                )
+            raise PdpError(
+                f"AuthZen connection error: {e}",
+                endpoint=endpoint,
+                cause=e,
+            )
+
+    def _build_request(self, input_data: dict[str, Any]) -> dict[str, Any]:
+        """Map CPEX pipeline context → AuthZen evaluation request.
+
+        AuthZen expects:
+            subject:  { type, id, properties }
+            action:   { name, properties }
+            resource: { type, id, properties }
+            context:  { ... everything else ... }
+
+        The input_data comes from APL's build_pdp_input() which extracts
+        namespaces from the AttributeBag and ContentSurface.
+        """
+        # --- Subject ---
+        subject_data = input_data.get("subject", {})
+        subject = {
+            "type": subject_data.get("type", "unknown"),
+            "id": subject_data.get("id", "unknown"),
+        }
+        # Everything else in subject_data goes into properties
+        subject_props = {k: v for k, v in subject_data.items() if k not in ("type", "id")}
+        if subject_props:
+            subject["properties"] = subject_props
+
+        # --- Action ---
+        action_name = input_data.get("action", "unknown")
+        if isinstance(action_name, dict):
+            action = action_name
+        else:
+            action = {"name": str(action_name)}
+
+        # --- Resource ---
+        resource_type = "tool"  # default for CPEX
+        resource_id = input_data.get("tool", "unknown")
+        if isinstance(resource_id, dict):
+            resource = resource_id
+        else:
+            resource = {"type": resource_type, "id": str(resource_id)}
+
+        # --- Context ---
+        # Everything that isn't subject/action/tool goes into context
+        context_keys = {"delegation", "session", "authorization_details", "args"}
+        context = {}
+        for key in context_keys:
+            if key in input_data:
+                context[key] = input_data[key]
+
+        # Include any other keys that aren't part of the standard mapping
+        standard_keys = {"subject", "action", "tool"} | context_keys
+        for key, value in input_data.items():
+            if key not in standard_keys:
+                context[key] = value
+
+        request: dict[str, Any] = {
+            "subject": subject,
+            "action": action,
+            "resource": resource,
+        }
+        if context:
+            request["context"] = context
+
+        return request
+
+    def _parse_response(self, body: dict[str, Any], latency_ms: float) -> PdpResult:
+        """Parse AuthZen evaluation response.
+
+        AuthZen response format:
+            { "decision": true }
+        or with context:
+            { "decision": true, "context": { "reason": { ... } } }
+        """
+        decision = body.get("decision", False)
+
+        # Extract reason from context if present
+        reason = None
+        resp_context = body.get("context", {})
+        if isinstance(resp_context, dict):
+            reason_obj = resp_context.get("reason", {})
+            if isinstance(reason_obj, str):
+                reason = reason_obj
+            elif isinstance(reason_obj, dict):
+                reason = reason_obj.get("message") or reason_obj.get("detail")
+
+        return PdpResult(
+            allowed=bool(decision),
+            reason=reason,
+            context=resp_context if isinstance(resp_context, dict) else {},
+            latency_ms=latency_ms,
+        )
+
+    async def close(self) -> None:
+        """Shut down the HTTP client."""
+        await self._client.aclose()

--- a/cpex/framework/pdp/base.py
+++ b/cpex/framework/pdp/base.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""Base classes for PDP resolvers.
+
+Defines the interface that all PDP resolvers implement, and the result
+type returned by PDP calls. These mirror the Rust PdpResolver trait
+and ExternalPdpResult struct in apl_core.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PdpResult:
+    """Result of an external PDP evaluation.
+
+    Maps to apl_core::ExternalPdpResult on the Rust side.
+    """
+
+    allowed: bool
+    """Whether the PDP allowed the request."""
+
+    reason: str | None = None
+    """Human-readable reason for the decision."""
+
+    context: dict[str, Any] = field(default_factory=dict)
+    """Additional context from the PDP (obligations, advice, etc.)."""
+
+    from_cache: bool = False
+    """Whether this result was served from cache."""
+
+    latency_ms: float = 0.0
+    """Round-trip latency of the PDP call in milliseconds."""
+
+
+class PdpResolver(ABC):
+    """Abstract base for external PDP resolvers.
+
+    Implementations handle the transport (HTTP, gRPC, in-process) and
+    protocol (AuthZen, OPA, Cedar) specifics. The APL pipeline calls
+    `resolve()` with the input built from the AttributeBag and
+    ContentSurface, and uses the returned PdpResult to allow/deny.
+
+    Resolvers are expected to be reusable across requests — create
+    once at gateway startup, call `resolve()` per-request, call
+    `close()` at shutdown.
+    """
+
+    @abstractmethod
+    async def resolve(self, input_data: dict[str, Any]) -> PdpResult:
+        """Evaluate a policy decision against the external PDP.
+
+        Args:
+            input_data: Context extracted from the APL pipeline.
+                Keys depend on the configured input_namespaces:
+                - "subject": identity attributes
+                - "authorization_details": RFC 9396 RAR details
+                - "delegation": delegation chain attributes
+                - "session": session state (labels, tool_calls, cost)
+                - "args": tool call arguments (from ContentSurface)
+                - "tool": tool name (from static_context)
+                - "action": route action (from static_context)
+
+        Returns:
+            PdpResult with the PDP's decision.
+
+        Raises:
+            PdpError: If the PDP call fails and cannot be handled
+                by the resolver's retry/fallback logic.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Clean up resources (HTTP clients, connections).
+
+        Called at gateway shutdown. Override if the resolver holds
+        persistent connections.
+        """
+        pass
+
+
+class PdpError(Exception):
+    """Raised when a PDP call fails irrecoverably."""
+
+    def __init__(self, message: str, endpoint: str, cause: Exception | None = None):
+        """Initialize a PDP error.
+
+        Args:
+            message: Human-readable error description.
+            endpoint: The PDP endpoint that failed.
+            cause: The underlying exception, if any.
+        """
+        super().__init__(message)
+        self.endpoint = endpoint
+        self.cause = cause

--- a/cpex/framework/pdp/opa.py
+++ b/cpex/framework/pdp/opa.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+"""OPA PDP resolver — Open Policy Agent Data API.
+
+OPA's Data API evaluates a Rego policy against an input document:
+
+    POST /v1/data/{policy_path}
+    { "input": { ... } }
+    → { "result": true }
+
+Unlike AuthZen, OPA's input is free-form — whatever the Rego policy
+expects. We pass the CPEX pipeline context as-is under the "input" key,
+so Rego policies can reference it directly:
+
+    package cpex.authz
+
+    default allow = false
+
+    allow {
+        some detail in input.authorization_details.types
+        detail == "tool_invocation"
+        "read" in input.authorization_details.actions
+        input.delegation.depth <= 3
+    }
+
+    deny[msg] {
+        input.session.labels[_] == "PII"
+        input.action == "forward"
+        msg := "Cannot forward PII-tainted data"
+    }
+
+References:
+    - OPA REST API: https://www.openpolicyagent.org/docs/latest/rest-api/
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import httpx
+
+from cpex.framework.pdp.base import PdpError, PdpResolver, PdpResult
+
+logger = logging.getLogger(__name__)
+
+
+class OpaResolver(PdpResolver):
+    """Open Policy Agent Data API client.
+
+    Sends CPEX pipeline context as OPA input and reads the decision
+    from the result.
+
+    Args:
+        endpoint: OPA policy data endpoint. Supports {placeholder} templates
+            that are interpolated from the input_data at request time.
+            Static:   "http://opa:8181/v1/data/cpex/authz/allow"
+            Template: "http://opa:8181/v1/data/cpex/tools/{tool}/allow"
+        timeout_ms: HTTP timeout in milliseconds. Default 500.
+        headers: Additional HTTP headers.
+        fail_open: If True, allow on OPA errors. If False, raise PdpError.
+
+    Usage:
+        # Static endpoint — same OPA package for all tools
+        resolver = OpaResolver("http://opa:8181/v1/data/cpex/authz/allow")
+
+        # Template endpoint — per-tool OPA packages
+        resolver = OpaResolver("http://opa:8181/v1/data/cpex/tools/{tool}/allow")
+
+        result = await resolver.resolve({
+            "tool": "get_compensation",
+            "action": "read",
+            ...
+        })
+        # With template: hits /v1/data/cpex/tools/get_compensation/allow
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        timeout_ms: int = 500,
+        headers: dict[str, str] | None = None,
+        fail_open: bool = False,
+    ):
+        """Initialize the OPA resolver.
+
+        Args:
+            endpoint: OPA policy data endpoint URL. Supports {placeholder} templates.
+            timeout_ms: HTTP timeout in milliseconds. Default 500.
+            headers: Additional HTTP headers.
+            fail_open: If True, allow on OPA errors. If False, raise PdpError.
+        """
+        self._endpoint_template = endpoint
+        self.fail_open = fail_open
+        self._client = httpx.AsyncClient(
+            timeout=httpx.Timeout(timeout_ms / 1000.0),
+            headers=headers or {},
+        )
+
+    def _resolve_endpoint(self, input_data: dict[str, Any]) -> str:
+        """Resolve the endpoint URL, interpolating any {placeholders}."""
+        if "{" not in self._endpoint_template:
+            return self._endpoint_template
+        # Flatten input_data to string values for interpolation
+        flat = {k: str(v) for k, v in input_data.items() if isinstance(v, str)}
+        try:
+            return self._endpoint_template.format(**flat)
+        except KeyError:
+            # Missing placeholder — use template as-is
+            logger.warning(
+                "OPA endpoint template has unresolved placeholders: %s",
+                self._endpoint_template,
+            )
+            return self._endpoint_template
+
+    async def resolve(self, input_data: dict[str, Any]) -> PdpResult:
+        """Evaluate a policy decision via OPA.
+
+        The input_data is passed directly as OPA's `input` document.
+        Rego policies reference fields as `input.delegation.depth`, etc.
+        If the endpoint is a template, placeholders are resolved from input_data.
+        """
+        endpoint = self._resolve_endpoint(input_data)
+        request_body = {"input": input_data}
+
+        start = time.monotonic()
+        try:
+            response = await self._client.post(
+                endpoint,
+                json=request_body,
+            )
+            latency_ms = (time.monotonic() - start) * 1000
+            response.raise_for_status()
+            return self._parse_response(response.json(), latency_ms)
+
+        except httpx.TimeoutException as e:
+            latency_ms = (time.monotonic() - start) * 1000
+            logger.warning("OPA timeout after %.1fms: %s", latency_ms, endpoint)
+            if self.fail_open:
+                return PdpResult(
+                    allowed=True,
+                    reason="OPA timeout, fail-open",
+                    latency_ms=latency_ms,
+                )
+            raise PdpError(
+                f"OPA timeout after {latency_ms:.0f}ms",
+                endpoint=endpoint,
+                cause=e,
+            )
+
+        except httpx.HTTPStatusError as e:
+            latency_ms = (time.monotonic() - start) * 1000
+            logger.error("OPA HTTP %d from %s", e.response.status_code, endpoint)
+            if self.fail_open:
+                return PdpResult(
+                    allowed=True,
+                    reason=f"OPA HTTP {e.response.status_code}, fail-open",
+                    latency_ms=latency_ms,
+                )
+            raise PdpError(
+                f"OPA HTTP {e.response.status_code}",
+                endpoint=endpoint,
+                cause=e,
+            )
+
+        except httpx.HTTPError as e:
+            latency_ms = (time.monotonic() - start) * 1000
+            logger.error("OPA connection error: %s", e)
+            if self.fail_open:
+                return PdpResult(
+                    allowed=True,
+                    reason="OPA unreachable, fail-open",
+                    latency_ms=latency_ms,
+                )
+            raise PdpError(
+                f"OPA connection error: {e}",
+                endpoint=endpoint,
+                cause=e,
+            )
+
+    def _parse_response(self, body: dict[str, Any], latency_ms: float) -> PdpResult:
+        """Parse OPA Data API response.
+
+        OPA returns different shapes depending on the policy:
+            { "result": true }                          — boolean policy
+            { "result": { "allow": true } }             — structured policy
+            { "result": { "allow": true, "deny": [] } } — allow + deny reasons
+        """
+        result = body.get("result")
+
+        if isinstance(result, bool):
+            return PdpResult(allowed=result, latency_ms=latency_ms)
+
+        if isinstance(result, dict):
+            allowed = result.get("allow", False)
+            reason = None
+
+            # Extract deny reasons if present
+            deny_reasons = result.get("deny", [])
+            if deny_reasons:
+                if isinstance(deny_reasons, list) and deny_reasons:
+                    reason = deny_reasons[0] if isinstance(deny_reasons[0], str) else str(deny_reasons[0])
+                elif isinstance(deny_reasons, str):
+                    reason = deny_reasons
+
+            return PdpResult(
+                allowed=bool(allowed),
+                reason=reason,
+                context=result,
+                latency_ms=latency_ms,
+            )
+
+        # Unexpected format — log and use fail mode
+        logger.warning("Unexpected OPA response format: %s", body)
+        return PdpResult(
+            allowed=self.fail_open,
+            reason=f"Unexpected OPA response: {type(result).__name__}",
+            latency_ms=latency_ms,
+        )
+
+    async def close(self) -> None:
+        """Shut down the HTTP client."""
+        await self._client.aclose()

--- a/cpex/framework/registry.py
+++ b/cpex/framework/registry.py
@@ -16,6 +16,7 @@ from typing import Optional
 # First-Party
 from cpex.framework.base import HookRef, Plugin, PluginRef
 from cpex.framework.external.mcp.client import ExternalHookRef
+from cpex.framework.models import PluginConfig
 
 # Use standard logging to avoid circular imports (plugins -> services -> plugins)
 logger = logging.getLogger(__name__)
@@ -67,11 +68,18 @@ class PluginInstanceRegistry:
         self._hooks_by_name: dict[str, dict[str, HookRef]] = {}
         self._priority_cache: dict[str, list[HookRef]] = {}
 
-    def register(self, plugin: Plugin) -> None:
+    def register(
+        self,
+        plugin: Plugin,
+        trusted_config: PluginConfig | None = None,
+    ) -> None:
         """Register a plugin instance.
 
         Args:
             plugin: plugin to be registered.
+            trusted_config: The authoritative config retained by the
+                Manager. If provided, PluginRef reads policy fields
+                from this copy rather than from the plugin.
 
         Raises:
             ValueError: if plugin is already registered.
@@ -79,7 +87,7 @@ class PluginInstanceRegistry:
         if plugin.name in self._plugins:
             raise ValueError(f"Plugin {plugin.name} already registered")
 
-        plugin_ref = PluginRef(plugin)
+        plugin_ref = PluginRef(plugin, trusted_config=trusted_config)
 
         self._plugins[plugin.name] = plugin_ref
 

--- a/cpex/framework/utils.py
+++ b/cpex/framework/utils.py
@@ -294,6 +294,8 @@ def get_matchable_value(payload: Any, hook_type: str) -> Optional[str]:
         "resource_post_fetch": "uri",
         "agent_pre_invoke": "agent_id",
         "agent_post_invoke": "agent_id",
+        "token_delegate": "target_name",
+        "identity_resolve": "raw_token",
     }
 
     field_name = field_map.get(hook_type)
@@ -347,6 +349,8 @@ def payload_matches(
         "resource_post_fetch": "resources",
         "agent_pre_invoke": "agents",
         "agent_post_invoke": "agents",
+        "token_delegate": "tools",
+        "identity_resolve": "tools",
     }
 
     # If no conditions, match everything

--- a/docs/cmf-message-spec-v2.md
+++ b/docs/cmf-message-spec-v2.md
@@ -1,0 +1,762 @@
+# Common Message Format (CMF) Specification
+
+**Status**: Draft
+**Version**: 2.0
+**Related**: [Plugin Framework Specification](plugin-framework-spec-v2.md)
+
+## Introduction
+
+The Common Message Format (CMF) defines a **provider-agnostic, structured representation** for interactions between users, agents, tools, and language models.
+
+CMF provides a canonical message model that supports interoperability, policy enforcement, access control, data governance, and end-to-end auditing across heterogeneous model providers and agent frameworks.
+
+The format explicitly separates:
+
+* **Transport** (provider-specific wire protocols)
+* **Canonical message representation** (CMF Message)
+* **Policy and enforcement surface** (MessageView abstraction)
+
+This separation allows transport adapters, processing pipelines, and policy engines to evolve independently while operating over a consistent enforcement-ready message model.
+
+```mermaid
+flowchart LR
+    A([Provider Wire Format]) --> B[Adapter]
+    B --> C([CMF Message])
+    C --> D[Processing Pipeline]
+    D --> E([CMF Message])
+    E --> F[Adapter]
+    F --> G([Wire Format])
+```
+
+## Table of Contents
+
+1. [Design Goals](#1-design-goals)
+2. [Message](#2-message)
+   - 2.1 [Role](#21-role)
+   - 2.2 [Content](#22-content)
+   - 2.3 [Channel](#23-channel)
+3. [Extensions](#3-extensions)
+   - 3.1 [Mutability Tiers](#31-mutability-tiers)
+   - 3.2 [Extension Types](#32-extension-types)
+   - 3.3 [RequestExtension (immutable)](#33-requestextension-immutable)
+   - 3.4 [AgentExtension (immutable)](#34-agentextension-immutable)
+   - 3.5 [HttpExtension (guarded)](#35-httpextension-guarded)
+   - 3.6 [SecurityExtension (monotonic)](#36-securityextension-monotonic)
+     - 3.6.1 [SubjectExtension (immutable)](#361-subjectextension-immutable)
+     - 3.6.2 [Objects (immutable)](#362-objects-immutable)
+     - 3.6.3 [Data (immutable)](#363-data-immutable)
+   - 3.7 [MCPExtension (immutable)](#37-mcpextension-immutable)
+   - 3.8 [CompletionExtension (immutable)](#38-completionextension-immutable)
+   - 3.9 [ProvenanceExtension (immutable)](#39-provenanceextension-immutable)
+   - 3.10 [LLMExtension (immutable)](#310-llmextension-immutable)
+   - 3.11 [FrameworkExtension (immutable)](#311-frameworkextension-immutable)
+   - 3.12 [MetaExtension (monotonic tags, mutable properties)](#312-metaextension-monotonic-tags-mutable-properties)
+   - 3.13 [Custom Extensions (mutable)](#313-custom-extensions-mutable)
+4. [MessageView](#4-messageview)
+   - 4.1 [Message vs. MessageView](#41-message-vs-messageview)
+   - 4.2 [Supporting Both LLM and Framework Formats](#42-supporting-both-llm-and-framework-formats)
+   - 4.3 [Core Attributes](#43-core-attributes)
+   - 4.4 [Direction](#44-direction)
+   - 4.5 [Flat Accessors (capability-gated)](#45-flat-accessors-capability-gated)
+   - 4.6 [Type-Specific Properties](#46-type-specific-properties)
+   - 4.7 [Serialization](#47-serialization)
+5. [Security Properties](#5-security-properties)
+   - 5.1 [Label Propagation](#51-label-propagation)
+   - 5.2 [Extension Tier Enforcement](#52-extension-tier-enforcement)
+
+## 1. Design Goals
+
+The CMF is designed to satisfy the following goals:
+
+* **Interoperable, canonical representation**
+  Define a provider-agnostic message format that decouples transport wire protocols from internal processing, enabling consistent handling across LLM providers, agent frameworks, tools, and enforcement systems.
+
+* **Complete and explicit enforcement surface**
+  Represent all policy-relevant data—including identity, access control metadata, governance attributes, execution context, and provenance—as structured, typed fields on the message.
+
+* **Integrity and safety by construction**
+  Protect security-relevant data through explicit mutability tiers (immutable, monotonic, guarded, mutable) enforced by the processing pipeline, and enable safe read-only inspection for policy evaluation.
+
+* **Extensibility without compromising correctness**
+  Support structured extensions while preserving interoperability, enforcement guarantees, and message integrity.
+
+To realize these goals, CMF defines the following abstractions:
+
+| Concept              | Purpose                                                                        |
+| -------------------- | ------------------------------------------------------------------------------ |
+| **Message**          | Canonical structure representing a single agent interaction.                   |
+| **Extensions**       | Structured metadata for identity, security, governance, and execution context. |
+| **Mutability Tiers** | Explicit contracts governing how fields may be modified.                       |
+| **MessageView**      | Read-only projection providing uniform access for policy evaluation.           |
+
+## 2. Message
+
+A `Message` represents a single turn in a conversation. It has four fields:
+
+```
+Message
+├── schema_version: str                 # Message schema version
+├── role: Role                          # WHO is speaking
+├── content: list[ContentPart]          # WHAT they said (multimodal parts)
+├── channel: Channel | None             # WHAT KIND of output (analysis, commentary, final)
+└── extensions: Extensions              # Everything: context, identity, security, completion, provenance
+```
+
+### 2.1 Role
+
+Role is a closed-set enumeration type.
+
+| Role | Meaning |
+|------|---------|
+| `system` | System-level instructions |
+| `developer` | Developer-provided instructions (Harmony concept) |
+| `user` | Human user input |
+| `assistant` | LLM/agent response |
+| `tool` | Tool execution result |
+
+### 2.2 Content
+
+Content is a list of typed `ContentPart`s for multimodal messages.
+
+This is the **wire format**, which preserves the LLM's response grouping. A single assistant message can contain text, thinking, and multiple tool calls, just as the provider API returns them.
+
+**ContentPart:**
+
+Each `ContentPart` must include a `ContentType` type discriminator.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `content_type` | `ContentType` | The content type |
+
+**ContentPart types:**
+
+| Content Type | Value Type | Description |
+|--------------|------------|-------------|
+| `text` | `str` | Plain text content |
+| `thinking` | `str` | Chain-of-thought / reasoning (may not be shown to end user) |
+| `tool_call` | `ToolCall` | Tool/function invocation request |
+| `tool_result` | `ToolResult` | Result from tool execution |
+| `resource` | `Resource` | Embedded resource with content (MCP) |
+| `resource_ref` | `ResourceReference` | Lightweight resource reference without embedded content |
+| `prompt_request` | `PromptRequest` | Prompt template invocation request (MCP) |
+| `prompt_result` | `PromptResult` | Rendered prompt template result |
+| `image` | `ImageSource` | Image content (URL or base64) |
+| `video` | `VideoSource` | Video content (URL or base64) |
+| `audio` | `AudioSource` | Audio content (URL or base64) |
+| `document` | `DocumentSource` | Document content (PDF, Word, etc.) |
+
+**ToolCall:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `tool_call_id` | `str` | Unique request correlation ID |
+| `name` | `str` | Tool name |
+| `arguments` | `dict[str, Any]` | Arguments as a JSON-serializable dict |
+| `namespace` | `str \| None` | Namespace for namespaced tools |
+
+**ToolResult:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `tool_call_id` | `str` | Correlation ID linking to the corresponding tool call |
+| `tool_name` | `str` | Name of the tool that was executed |
+| `content` | `JSONValue` | Result content, any JSON-serializable value |
+| `is_error` | `bool` | Whether the result represents an error |
+
+**Resource:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `resource_request_id` | `str` | Unique request correlation ID |
+| `uri` | `str` | Unique identifier (URI format) |
+| `name` | `str \| None` | Human-readable name |
+| `description` | `str \| None` | What this resource contains |
+| `resource_type` | `ResourceType` | `file`, `blob`, `uri`, `database`, `api`, `memory`, `artifact` |
+| `content` | `str \| None` | Text content (if embedded) |
+| `blob` | `bytes \| None` | Binary content (if embedded) |
+| `mime_type` | `str \| None` | MIME type of content |
+| `size_bytes` | `int \| None` | Size information |
+| `annotations` | `dict` | Metadata (classification, retention, etc.) |
+| `version` | `str \| None` | Version tracking |
+
+**ResourceReference:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `resource_request_id` | `str` | Correlation ID linking to the originating resource request |
+| `uri` | `str` | Resource URI |
+| `name` | `str \| None` | Human-readable name |
+| `resource_type` | `ResourceType` | Type of resource |
+| `range_start` | `int \| None` | Line number or byte offset (partial references) |
+| `range_end` | `int \| None` | End of range |
+| `selector` | `str \| None` | CSS/XPath/JSONPath selector |
+
+**ResourceType:**
+
+`ResourceType` is a closed-set enumeration.
+
+| Value | Description |
+|-------|-------------|
+| `file` | File-system resource |
+| `blob` | Binary large object |
+| `uri` | Generic URI-addressable resource |
+| `database` | Database entity |
+| `api` | API endpoint |
+| `memory` | In-memory or ephemeral resource |
+| `artifact` | Produced artifact (generated output, build result) |
+
+**PromptRequest:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `prompt_request_id` | `str` | Request ID for correlation |
+| `name` | `str` | Prompt template name |
+| `arguments` | `dict[str, Any]` | Arguments to pass to the template |
+| `server_id` | `str \| None` | Source server (multi-server scenarios) |
+
+**PromptResult:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `prompt_request_id` | `str` | ID of the corresponding prompt request |
+| `prompt_name` | `str` | Name of the prompt that was rendered |
+| `messages` | `list[Message]` | Rendered messages (prompts produce messages) |
+| `content` | `str \| None` | Single text result for simple prompts |
+| `is_error` | `bool` | Whether rendering failed |
+| `error_message` | `str \| None` | Error details if rendering failed |
+
+**ImageSource:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `type` | `"url" \| "base64"` | Source type |
+| `data` | `str` | URL or base64-encoded string |
+| `media_type` | `str \| None` | MIME type (e.g., `image/jpeg`) |
+
+**VideoSource:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `type` | `"url" \| "base64"` | Source type |
+| `data` | `str` | URL or base64-encoded string |
+| `media_type` | `str \| None` | MIME type (e.g., `video/mp4`) |
+| `duration_ms` | `int \| None` | Duration in milliseconds |
+
+**AudioSource:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `type` | `"url" \| "base64"` | Source type |
+| `data` | `str` | URL or base64-encoded string |
+| `media_type` | `str \| None` | MIME type (e.g., `audio/mp3`) |
+| `duration_ms` | `int \| None` | Duration in milliseconds |
+
+**DocumentSource:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `type` | `"url" \| "base64"` | Source type |
+| `data` | `str` | URL or base64-encoded string |
+| `media_type` | `str \| None` | MIME type (e.g., `application/pdf`) |
+| `title` | `str \| None` | Document title |
+
+### 2.3 Channel
+
+`Channel` is a closed-set enumeration that classifies the kind of output a message represents. It is **optional**, and when unset, it indicates a standard, unclassified message. Channels allow agentic frameworks and pipelines to route or filter messages by output type without inspecting content.
+
+| Channel | Description |
+|---------|-------------|
+| `analysis` | Intermediate analytical output, such as reasoning, evaluation, or investigation produced during task execution, not intended as the final response. |
+| `commentary` | Meta-level observations about the task or process, such as notes, warnings, or annotations produced alongside primary output. |
+| `final` | The terminal response for a task or conversation turn, such as the output intended for delivery to the end consumer. |
+
+## 3. Extensions
+
+Extensions are the sole carrier of all contextual data. Everything a consumer or policy engine needs (e.g., identity, security classification, HTTP context, entity metadata, agent lineage, execution environment, completion info, provenance) is stored as a typed message extension with an explicit mutability tier.
+
+```
+Extensions
+├── request: RequestExtension | None
+├── agent: AgentExtension | None
+├── http: HttpExtension | None
+├── security: SecurityExtension | None
+├── mcp: MCPExtension | None
+├── completion: CompletionExtension | None
+├── provenance: ProvenanceExtension | None
+├── llm: LLMExtension | None
+├── framework: FrameworkExtension | None
+├── meta: MetaExtension | None
+└── custom: dict[str, Any] | None
+```
+
+### 3.1 Mutability Tiers
+
+Every extension declares its mutability tier. The processing pipeline enforces these contracts during copy-on-write.
+
+| Tier | Copy Behavior | Pipeline Validation |
+|------|-------------|---------------------|
+| **Immutable** | Shared reference, not deep-copied | Rejects if changed in returned copy |
+| **Monotonic** | Copied, but only additive operations allowed | Rejects if any element was removed |
+| **Guarded** | Copied, but write requires a declared capability | Rejects if modified without the required capability |
+| **Mutable** | Normal deep copy, fully modifiable | Accepted as-is |
+
+### 3.2 Extension Types
+
+| Extension | Mutability | Contents |
+|-----------|-----------|----------|
+| `request` | Immutable | Execution environment, request ID, timestamp, distributed tracing |
+| `agent` | Immutable | Session ID, conversation ID, turn, agent lineage, original user intent |
+| `http` | Guarded | HTTP headers (readable with `read_headers`, writable with `write_headers`) |
+| `security` | Monotonic | Security labels, classification level, and the nested immutable fields below |
+| `security.subject` | Immutable | Authenticated identity: ID, type, roles, permissions, teams, claims |
+| `security.objects` | Immutable | Access control profiles keyed by entity |
+| `security.data` | Immutable | Data governance policies keyed by entity |
+| `mcp` | Immutable | Tool, resource, or prompt metadata (name, schema, annotations, server ID) |
+| `completion` | Immutable | Stop reason, token usage, model identifier, wire format, latency |
+| `provenance` | Immutable | Source identifier, message ID, parent message ID |
+| `llm` | Immutable | Model identifier, provider, model capabilities |
+| `framework` | Immutable | Agentic framework context (LangGraph, CrewAI, etc.) |
+| `meta` | Immutable | Host-provided entity tags, scope, and arbitrary properties |
+| `custom` | Mutable | Custom extensions |
+
+### 3.3 RequestExtension (immutable)
+
+Execution environment and request-level timing/tracing. Available to all consumers without any capability requirement (base tier).
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `environment` | `str \| None` | Execution environment (`production`, `staging`, `dev`) |
+| `request_id` | `str \| None` | Request correlation ID |
+| `timestamp` | `str \| None` | ISO timestamp of the request |
+| `trace_id` | `str \| None` | Distributed tracing ID (OpenTelemetry) |
+| `span_id` | `str \| None` | Distributed tracing span ID |
+
+### 3.4 AgentExtension (immutable)
+
+Agent execution context — session tracking, multi-agent lineage, and the original user intent. Immutable because the user's intent and session identity must not be modifiable by processing components.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `input` | `str \| None` | Original user intent that triggered this action |
+| `session_id` | `str \| None` | Broad session identifier |
+| `conversation_id` | `str \| None` | Specific dialogue/task within a session |
+| `turn` | `int \| None` | Position in conversation (0-indexed) |
+| `agent_id` | `str \| None` | Identifier of the producing agent |
+| `parent_agent_id` | `str \| None` | Spawning agent's ID (multi-agent lineage) |
+| `conversation` | `ConversationContext \| None` | Windowed conversation context |
+
+**ConversationContext:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `history` | `list[Message] \| None` | Windowed message history (recent turns) |
+| `summary` | `str \| None` | Summarized prior context |
+| `topics` | `list[str]` | Extracted topics or intents |
+
+### 3.5 HttpExtension (guarded)
+
+HTTP request context. Readable with `read_headers`, writable with `write_headers`. The write capability exists because consumers sometimes need to inject headers for downstream systems — e.g., adding an OAuth token for an API call, or a correlation ID for tracing.
+
+| Attribute | Read Capability | Write Capability | Type | Description |
+|-----------|----------------|-----------------|------|-------------|
+| `headers` | `read_headers` | `write_headers` | `dict[str, str]` | HTTP headers as key-value pairs |
+
+Sensitive headers (`Authorization`, `Cookie`, `X-API-Key`) are stripped when serialized for external policy engines. Consumers with `write_headers` can inject new headers; the pipeline audits all header modifications.
+
+### 3.6 SecurityExtension (monotonic and immutable)
+
+Data classification, security labels, and all security-relevant contextual data: subject identity, access control profiles, and data governance policies. The `SecurityExtension` labels are add-only during normal message flow. Its nested immutable fields (`subject`, `objects`, `data`) cannot be replaced or modified.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `labels` | `set[str]` | Security/data labels (`PII`, `CONFIDENTIAL`, `SECRET`, etc.) |
+| `classification` | `str \| None` | Data classification level |
+| `subject` | `SubjectExtension \| None` | Authenticated identity (see 3.6.1) |
+| `objects` | `dict[str, ObjectSecurityProfile]` | Access control profiles, keyed by entity identifier (see 3.6.2) |
+| `data` | `dict[str, DataPolicy]` | Data governance policies, keyed by entity identifier (see 3.6.3) |
+
+Requires `read_labels` capability to see labels. Any consumer can add labels (through copy-on-write), but the pipeline validates that no labels were removed (`before.labels ⊆ after.labels`). Removal requires a privileged declassification operation that is audited separately.
+
+#### 3.6.1 SubjectExtension (immutable)
+
+The authenticated entity making the request. Access to individual fields is controlled by declared capabilities.
+
+`SubjectType` is a closed-set enumeration: `user`, `agent`, `service`, `system`.
+
+| Attribute | Capability Required | Type | Description |
+|-----------|-------------------|------|-------------|
+| `id` | `read_subject` | `str` | Unique subject identifier |
+| `type` | `read_subject` | `SubjectType` | Subject kind |
+| `roles` | `read_roles` | `set[str]` | Assigned roles (`developer`, `admin`, `viewer`, etc.) |
+| `permissions` | `read_permissions` | `set[str]` | Granted permissions (`tools.execute`, `db.read`, etc.) |
+| `teams` | `read_teams` | `set[str]` | Team memberships (for multi-tenant scoping) |
+| `claims` | `read_claims` | `dict` | Raw identity claims (JWT, SAML) |
+
+#### 3.6.2 Objects (immutable)
+
+Access control profiles for entities referenced in the message, keyed by entity identifier (tool name, resource URI, prompt name). Each entry is an `ObjectSecurityProfile` declaring the entity's access requirements and data scope.
+
+```
+objects: dict[str, ObjectSecurityProfile] = {}
+```
+
+**ObjectSecurityProfile** (flat):
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `managed_by` | `str` | Who enforces access control: `"host"`, `"tool"`, or `"both"` |
+| `permissions` | `list[str]` | Required permissions to invoke (e.g., `["read:compensation"]`) |
+| `trust_domain` | `str \| None` | Trust domain: `"internal"`, `"external"`, `"privileged"` |
+| `data_scope` | `list[str]` | Field names this entity accesses/returns (e.g., `["salary", "bonus"]`) |
+
+For MCP/framework messages (single entity), this map has one entry. For LLM provider messages with multiple tool calls, it has one entry per entity. The host pipeline populates this map during message ingestion by looking up each entity's registered profile from an implementation-defined registry (e.g., tool registration metadata, MCP server manifests, or a policy store). Profile lookup is keyed by entity identifier — the tool name, resource URI, or prompt name that appears in the message content.
+
+The `MessageView` exposes a singular accessor — each view resolves its own profile from the map:
+
+```
+view.object → ObjectSecurityProfile | None
+  (resolved by: extensions.security.objects.get(view.name))
+```
+
+For the full model and policy integration, see the [Object Security Profile Spec](object-security-profile-spec.md).
+
+#### 3.6.3 Data (immutable)
+
+Data governance policies for entities referenced in the message, keyed by entity identifier (tool name, resource URI, prompt name). Each entry is a `DataPolicy` declaring labeling, action restrictions, and retention rules for the entity's output.
+
+```
+data: dict[str, DataPolicy] = {}
+```
+
+**DataPolicy:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `apply_labels` | `list[str]` | Labels to stamp on output (e.g., `["PII", "financial"]`) |
+| `allowed_actions` | `list[str] \| None` | What downstream can do. `None` = unrestricted. |
+| `denied_actions` | `list[str]` | What downstream cannot do (e.g., `["export", "forward"]`) |
+| `retention` | `RetentionPolicy \| None` | How long data can be kept |
+
+**RetentionPolicy:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `max_age_seconds` | `int \| None` | Maximum retention duration in seconds |
+| `policy` | `str` | Retention class: `"session"`, `"transient"`, `"persistent"`, `"none"` |
+| `delete_after` | `str \| None` | ISO timestamp after which data must be deleted |
+
+The `data` extension is evaluated on post views (tool results, resource responses, prompt results). When a tool returns data, the pipeline looks up its `DataPolicy`, stamps `apply_labels` onto the message's `SecurityExtension`, and enforces action restrictions downstream.
+
+The `MessageView` exposes a singular accessor:
+
+```
+view.data_policy → DataPolicy | None
+  (resolved by: extensions.security.data.get(view.name))
+```
+
+For the full model, action vocabulary, and policy integration, see the [Object Security Profile Spec](object-security-profile-spec.md).
+
+### 3.7 MCPExtension (immutable)
+
+Typed metadata about the MCP entity being processed. Gives consumers access to the schema and annotations of the tool, resource, or prompt being evaluated.
+
+**ToolMetadata** (`ext.mcp.metadata.tool`):
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `name` | `str` | Unique tool identifier |
+| `title` | `str \| None` | Human-readable display name |
+| `description` | `str \| None` | Description of tool functionality |
+| `input_schema` | `dict \| None` | JSON Schema defining expected parameters |
+| `output_schema` | `dict \| None` | JSON Schema for structured output |
+| `server_id` | `str \| None` | ID of the server providing this tool |
+| `namespace` | `str \| None` | Tool namespace (server/origin) |
+| `annotations` | `dict` | MCP annotations (e.g., `readOnlyHint`, `destructiveHint`) |
+
+**ResourceMetadata** (`ext.mcp.metadata.resource`):
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `uri` | `str` | Resource URI (`file:///path`, `db://table/id`, etc.) |
+| `name` | `str \| None` | Resource name |
+| `description` | `str \| None` | Resource description |
+| `mime_type` | `str \| None` | MIME type (`text/csv`, `application/json`, etc.) |
+| `server_id` | `str \| None` | ID of the server providing this resource |
+| `annotations` | `dict` | MCP annotations (classification, retention, access hints) |
+
+**PromptMetadata** (`ext.mcp.metadata.prompt`):
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `name` | `str` | Prompt template name |
+| `description` | `str \| None` | Prompt description |
+| `arguments` | `list[dict] \| None` | Argument definitions — each entry has `name`, `description`, `required` |
+| `server_id` | `str \| None` | ID of the server providing this prompt |
+| `annotations` | `dict` | MCP annotations |
+
+Note: Prompts use an argument list rather than JSON Schema for input definition, following the MCP prompt specification. There is no output schema — prompt output is always rendered messages.
+
+### 3.8 CompletionExtension (immutable)
+
+LLM completion information. Fields like `model` and `stop_reason` can drive policy decisions (e.g., "only allow gpt-4 for financial queries", "flag max_tokens responses for review").
+
+`StopReason` is a closed-set enumeration: `end`, `return`, `call`, `max_tokens`, `stop_sequence`.
+
+**TokenUsage:**
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `input_tokens` | `int` | Tokens consumed by the input |
+| `output_tokens` | `int` | Tokens generated in the output |
+| `total_tokens` | `int` | Total tokens (input + output) |
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `stop_reason` | `StopReason \| None` | Why the model stopped |
+| `tokens` | `TokenUsage \| None` | Token counts |
+| `model` | `str \| None` | Model identifier that generated this response |
+| `raw_format` | `str \| None` | Original wire format (`chatml`, `harmony`, `gemini`, `anthropic`) |
+| `created_at` | `str \| None` | ISO timestamp when the message was created |
+| `latency_ms` | `int \| None` | Response generation time in milliseconds |
+
+### 3.9 ProvenanceExtension (immutable)
+
+Origin and threading information for the message. Enables lineage tracking across multi-turn conversations and multi-agent systems.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `source` | `str \| None` | Source identifier (`"user"`, `"agent:xyz"`, `"mcp-server:abc"`) |
+| `message_id` | `str \| None` | Unique message identifier |
+| `parent_id` | `str \| None` | Parent message ID (threading/replies) |
+
+Note: `conversation_id`, `session_id`, and agent lineage (`agent_id`, `parent_agent_id`) live on `AgentExtension` (section 3.4) since they are per-request context, not per-message. `trace_id` and `span_id` live on `RequestExtension` (section 3.3) alongside `request_id`.
+
+### 3.10 LLMExtension (immutable)
+
+Model identity and capability metadata. Used for routing, policy evaluation, and audit when the producing model's identity matters independently of the completion itself.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `model_id` | `str \| None` | Model identifier (e.g., `gpt-4o`, `claude-sonnet-4-20250514`) |
+| `provider` | `str \| None` | Provider name (e.g., `openai`, `anthropic`, `google`) |
+| `capabilities` | `list[str]` | Declared model capabilities (e.g., `["vision", "tool_use", "extended_thinking"]`) |
+
+### 3.11 FrameworkExtension (immutable)
+
+Agentic framework context. Captures the framework-level execution environment for messages that originate from or pass through agentic orchestration layers.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `framework` | `str \| None` | Framework identifier (e.g., `langgraph`, `crewai`, `autogen`, `a2a`) |
+| `framework_version` | `str \| None` | Framework version |
+| `node_id` | `str \| None` | Framework-specific node or step identifier |
+| `graph_id` | `str \| None` | Graph or workflow identifier |
+| `metadata` | `dict[str, Any]` | Framework-specific metadata |
+
+### 3.12 MetaExtension (immutable)
+
+Host-provided operational metadata about the entity being processed. Set by the host system (gateway registration, static config, MCP manifest, admin UI) before the plugin pipeline runs. Plugins can read this data for routing and policy decisions but cannot modify it.
+
+`MetaExtension` is protocol-agnostic — it carries the same structure regardless of whether the entity came from MCP, A2A, gRPC, or REST.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `tags` | `set[str]` | Entity tags (e.g., `pii`, `hr`, `external-comms`). Merged from static config and host-injected runtime tags. Drive route matching and policy group inheritance. |
+| `scope` | `str \| None` | Host-defined grouping. ContextForge maps this to virtual server ID, Kagenti to namespace, etc. CPEX core treats it as an opaque string for matching. |
+| `properties` | `dict[str, str]` | Arbitrary key-value metadata (e.g., `owner`, `region`, `data_classification`). Available in policy conditions as `meta.properties.{key}`. |
+
+**Relationship to other extensions:**
+
+| Extension | Purpose | Who sets it | Mutable by plugins? |
+|-----------|---------|-------------|---------------------|
+| `meta.tags` | What this entity *is* (operational classification) | Host / config | No (immutable) |
+| `security.labels` | What *happened* during processing (data flow tracking) | Plugins / pipeline | Add-only (monotonic) |
+| `mcp` | Protocol-specific schema and annotations | MCP transport layer | No (immutable) |
+
+### 3.13 Custom Extensions (mutable)
+
+Custom extensions. Fully mutable through copy-on-write, no restrictions on modification.
+
+## 4. MessageView
+
+`Message` is the **storage format** — it preserves the wire structure exactly as the LLM sent it. `MessageView` is the **policy and interaction surface** — it decomposes a message into individually addressable parts, enriches each with computed semantics, and provides a uniform interface regardless of content type.
+
+### 4.1 Message vs. MessageView
+
+A single LLM response can contain text, reasoning, and multiple tool calls bundled together. That's one `Message` but potentially many things that need to be evaluated independently.
+
+**Message** (one object, wire format):
+```json
+{
+  "role": "assistant",
+  "content": [
+    {"content_type": "thinking", "text": "The user wants admin users. I'll query the database..."},
+    {"content_type": "text", "text": "Let me look that up for you."},
+    {"content_type": "tool_call", "name": "execute_sql", "arguments": {"query": "SELECT * FROM users WHERE role='admin'"}},
+    {"content_type": "tool_call", "name": "send_email", "arguments": {"to": "boss@company.com", "body": "..."}}
+  ]
+}
+```
+
+Calling `message.iter_views()` produces **four MessageViews**, each with a uniform interface:
+
+| # | `kind` | `name` | `action` | `is_pre` | `uri` | `content` |
+|---|--------|--------|----------|----------|-------|-----------|
+| 1 | `thinking` | — | `generate` | `false` | — | `"The user wants admin users..."` |
+| 2 | `text` | — | `send` | `false` | — | `"Let me look that up for you."` |
+| 3 | `tool_call` | `execute_sql` | `execute` | `true` | `tool://db-server/execute_sql` | `'{"query": "SELECT..."}'` |
+| 4 | `tool_call` | `send_email` | `execute` | `true` | `tool://email-server/send_email` | `'{"to": "boss@..."}'` |
+
+**What the view adds** that doesn't exist on the raw content parts:
+
+| Property | Raw ContentPart | MessageView |
+|----------|----------------|-------------|
+| Identity | No URI | Synthetic URI (`tool://ns/name`, `prompt://server/name`, `file:///path`) |
+| Direction | No concept | `is_pre`/`is_post` computed from kind + role |
+| Semantic action | No concept | `action`: `read`, `write`, `execute`, `invoke`, `send`, `receive`, `generate` |
+| Context | Not attached | Capability-gated flat accessors (`roles`, `labels`, `environment`, etc.) |
+| Content normalization | Type-specific | `content` always returns scannable text (serialized arguments for tool calls) |
+| Uniform query API | Type-specific fields | `has_role()`, `has_label()`, `matches_uri_pattern()`, `get_arg()`, etc. |
+
+### 4.2 Supporting Both LLM and Framework Formats
+
+The CMF naturally supports two messaging patterns through the same structure:
+
+| Pattern | Content | Views | Example |
+|---------|---------|-------|---------|
+| **LLM wire format** | Multiple ContentParts per message | Many views per message | OpenAI/Anthropic assistant response with text + thinking + tool calls |
+| **Framework/protocol format** | Single ContentPart per message | One view per message | MCP tool call, A2A task message, LangGraph node output |
+
+An MCP tool invocation is simply a Message with one `tool_call` content part:
+
+```json
+{"role": "assistant", "content": [{"content_type": "tool_call", "name": "get_user", "arguments": {"id": "123"}}]}
+```
+
+This produces one view. An OpenAI assistant response that bundles reasoning with two tool calls produces three views. The processing pipeline doesn't care — `iter_views()` yields the right number either way, and every view has the same interface.
+
+This means the CMF does not force a choice between "one action per message" (MCP, A2A) and "bundled response" (LLM providers). Both are first-class, and the same policies and routing rules work across both patterns without adaptation.
+
+### 4.3 Core Attributes
+
+`ViewKind` is a closed-set enumeration: `text`, `thinking`, `tool_call`, `tool_result`, `resource`, `resource_ref`, `prompt_request`, `prompt_result`, `image`, `video`, `audio`, `document`.
+
+`ViewAction` is a closed-set enumeration: `read`, `write`, `execute`, `invoke`, `send`, `receive`, `generate`.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `kind` | `ViewKind` | Content type of this view |
+| `role` | `Role` | Role of the parent message (`user`, `assistant`, `system`, `developer`, `tool`) |
+| `content` | `str \| None` | Scannable text. For tool calls and prompt requests: JSON-serialized arguments. For tool results: JSON-serialized content. For resources: embedded content string. |
+| `uri` | `str \| None` | Synthetic identity: `tool://ns/name`, `prompt://server/name`, `tool_result://name`, `file:///path` |
+| `name` | `str \| None` | Human-readable name (tool name, resource name, prompt name) |
+| `action` | `ViewAction` | Semantic action |
+| `args` | `dict \| None` | Alias for the underlying `arguments` dict on `tool_call` and `prompt_request` content parts; `None` for other kinds |
+| `mime_type` | `str \| None` | MIME type for resources and images |
+| `size_bytes` | `int \| None` | Content size in bytes (computed from content) |
+| `properties` | `dict` | Type-specific properties (see 4.6) |
+
+### 4.4 Direction
+
+Direction is determined by a combination of ViewKind and Role:
+
+| Content | Direction | Rule |
+|---------|-----------|------|
+| `tool_call`, `prompt_request`, `resource_ref` | **pre** | Always requests |
+| `tool_result`, `prompt_result`, `resource` | **post** | Always responses |
+| `text`, `thinking`, media | **pre** if role is user/system/developer/tool | Input to LLM |
+| `text`, `thinking`, media | **post** if role is assistant | Output from LLM |
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `is_pre` | `bool` | True if input/request (before processing) |
+| `is_post` | `bool` | True if output/response (after processing) |
+| `is_tool` | `bool` | True if `tool_call` or `tool_result` |
+| `is_prompt` | `bool` | True if `prompt_request` or `prompt_result` |
+| `is_resource` | `bool` | True if `resource` or `resource_ref` |
+| `is_text` | `bool` | True if `text` or `thinking` |
+| `is_media` | `bool` | True if `image`, `video`, `audio`, or `document` |
+
+### 4.5 Flat Accessors (capability-gated)
+
+MessageView provides flat accessor properties over extensions. These hide the underlying extension nesting — consumers write `view.roles`, not `view.extensions.security.subject.roles`. Availability depends on the consumer's declared capabilities — extensions for which access has not been granted are `None` on the view.
+
+| Accessor | Capability | Type | Reads From |
+|----------|-----------|------|------------|
+| `environment` | _(base)_ | `str \| None` | `ext.request.environment` |
+| `request_id` | _(base)_ | `str \| None` | `ext.request.request_id` |
+| `subject` | `read_subject` | `SubjectExtension \| None` | `ext.security.subject` |
+| `roles` | `read_roles` | `set[str]` | `ext.security.subject.roles` |
+| `permissions` | `read_permissions` | `set[str]` | `ext.security.subject.permissions` |
+| `teams` | `read_teams` | `set[str]` | `ext.security.subject.teams` |
+| `headers` | `read_headers` | `dict[str, str]` | `ext.http.headers` |
+| `labels` | `read_labels` | `set[str]` | `ext.security.labels` |
+| `agent_input` | `read_agent` | `str \| None` | `ext.agent.input` |
+| `session_id` | `read_agent` | `str \| None` | `ext.agent.session_id` |
+| `conversation_id` | `read_agent` | `str \| None` | `ext.agent.conversation_id` |
+| `turn` | `read_agent` | `int \| None` | `ext.agent.turn` |
+| `agent_id` | `read_agent` | `str \| None` | `ext.agent.agent_id` |
+| `parent_agent_id` | `read_agent` | `str \| None` | `ext.agent.parent_agent_id` |
+| `object` | `read_objects` | `ObjectSecurityProfile \| None` | `ext.security.objects.get(view.name)` |
+| `data_policy` | `read_data` | `DataPolicy \| None` | `ext.security.data.get(view.name)` |
+
+Helper methods:
+
+| Method | Description |
+|--------|-------------|
+| `has_role(role)` | Check if subject has a specific role |
+| `has_permission(perm)` | Check if subject has a specific permission |
+| `has_label(label)` | Check if a security label is present |
+| `has_header(name)` | Check if an HTTP header exists (case-insensitive) |
+| `get_header(name)` | Get header value (case-insensitive) |
+| `get_arg(name)` | Get a single argument value |
+| `has_arg(name)` | Check if an argument exists |
+| `matches_uri_pattern(glob)` | Glob match on URI (`*`, `**` wildcards) |
+| `has_content()` | True if scannable text content is available |
+
+### 4.6 Type-Specific Properties
+
+Each ViewKind exposes additional properties via `get_property(name)` or `properties`:
+
+| ViewKind | Property | Type | Description |
+|----------|----------|------|-------------|
+| `resource` | `resource_type` | `str` | `file`, `blob`, `uri`, `database`, `api`, `memory`, `artifact` |
+| `resource` | `version` | `str \| None` | Resource version |
+| `resource` | `annotations` | `dict \| None` | Resource annotations (classification, retention, etc.) |
+| `tool_call` | `namespace` | `str \| None` | Tool namespace (server/origin) |
+| `tool_call` | `tool_id` | `str \| None` | Call correlation ID |
+| `tool_result` | `is_error` | `bool` | Whether the tool execution errored |
+| `tool_result` | `tool_name` | `str` | Name of the tool that produced this result |
+| `prompt_request` | `server_id` | `str \| None` | Source server for the prompt |
+| `prompt_result` | `is_error` | `bool` | Whether prompt rendering errored |
+| `prompt_result` | `message_count` | `int` | Number of messages in the rendered prompt |
+
+### 4.7 Serialization
+
+| Method | Description |
+|--------|-------------|
+| `to_dict()` | Serialize to JSON-compatible dict. Options: `include_content`, `include_context` |
+| `to_opa_input()` | Wrap in OPA envelope: `{"input": {...view...}}` |
+
+Sensitive headers (`Authorization`, `Cookie`, `X-API-Key`) are automatically stripped from serialized output. The serialized `extensions` block is assembled from capability-gated extensions, mirroring the extension hierarchy.
+
+## 5. Security Properties
+
+### 5.1 Label Propagation
+
+Security labels on `extensions.security` are **monotonically accumulating** during normal message flow. A message that touches PII data carries the `PII` label for its lifetime. Labels propagate through the pipeline:
+
+- Tool result carries labels → subsequent messages inherit them
+- Multiple data sources → union of labels
+
+Removal requires explicit declassification, a privileged operation that is audited separately.
+
+### 5.2 Extension Tier Enforcement
+
+The four mutability tiers (immutable, monotonic, guarded, mutable) provide layered protection:
+
+| Layer | What it prevents | How |
+|-------|-----------------|-----|
+| **MessageView** | Accidental mutation through read path | Read-only by design; no mutation API |
+| **Capability gating** | Unauthorized access to sensitive extensions | Extensions not populated if capability not declared |
+| **Write validation** | Unauthorized modification through write path | Pipeline validates tier constraints on returned copies |

--- a/docs/cmf-message-spec-v2.md
+++ b/docs/cmf-message-spec-v2.md
@@ -1,8 +1,7 @@
 # Common Message Format (CMF) Specification
 
-**Status**: Draft
 **Version**: 2.0
-**Related**: [Plugin Framework Specification](plugin-framework-spec-v2.md)
+**Related**: [Plugin Framework Specification](../docs/plugin-framework-spec.md)
 
 ## Introduction
 

--- a/docs/plugin-framework-spec-v2.md
+++ b/docs/plugin-framework-spec-v2.md
@@ -1,9 +1,7 @@
-# Plugin Framework Specification
+# Plugin Framework (CPEX) Specification
 
-**Status**: Draft
 **Version**: 2.0
-**Code Name**: APEX
-**Related**: [CMF Message Specification](cdm-message-spec-v2.md)
+**Related**: [CMF Message Specification](cdm-message-spec.md)
 
 ## Introduction
 

--- a/docs/plugin-framework-spec-v2.md
+++ b/docs/plugin-framework-spec-v2.md
@@ -1,0 +1,1301 @@
+# Plugin Framework Specification
+
+**Status**: Draft
+**Version**: 2.0
+**Code Name**: APEX
+**Related**: [CMF Message Specification](cdm-message-spec-v2.md)
+
+## Introduction
+
+This document specifies a hook-based extensibility framework that enables policy enforcement, observability, and extensibility through composable, capability-gated plugins that attach to named hook points in a host system's execution lifecycle.
+
+The framework separates four concerns:
+
+* **Payload model** — what plugins operate on, defined as well-typed models.
+* **Plugin definition** — what a plugin does, declared via code or configuration.
+* **Execution semantics** — how the pipeline dispatches plugins and handles their results.
+* **Capability gating** — which payload extensions each plugin can observe and modify.
+
+The framework operates on any `PluginPayload` subclass. CMF `Message` and `MessageView` are built-in payload types for the common case of message-level policy enforcement, but the same plugin model, scheduling, and capability gating apply to any domain-specific payload.
+
+For the canonical message model, extensions, and `MessageView` abstraction, see the [CMF Message Specification](cdm-message-spec-v2.md).
+
+## Table of Contents
+
+1. [Design Goals](#1-design-goals)
+2. [Framework Model](#2-framework-model)
+   - 2.1 [Key Types](#21-key-types)
+   - 2.2 [PluginPayload](#22-pluginpayload)
+   - 2.3 [CMF Integration](#23-cmf-integration)
+   - 2.4 [PluginResult & PluginViolation](#24-pluginresult--pluginviolation)
+3. [Plugin Definition](#3-plugin-definition)
+   - 3.1 [Function Hooks](#31-function-hooks)
+   - 3.2 [Class-Based Plugins](#32-class-based-plugins)
+   - 3.3 [Plugin Sets](#33-plugin-sets)
+   - 3.4 [Registration & Scoping](#34-registration--scoping)
+4. [Plugin Behavior](#4-plugin-behavior)
+   - 4.1 [Plugin Modes](#41-plugin-modes)
+   - 4.2 [Error Handling](#42-error-handling)
+   - 4.3 [Copy-on-Write Semantics](#43-copy-on-write-semantics)
+5. [Execution Model](#5-execution-model)
+   - 5.1 [Hook Invocation](#51-hook-invocation)
+   - 5.2 [Scheduling](#52-scheduling)
+6. [Capability-Gated Extensions](#6-capability-gated-extensions)
+   - 6.1 [Capability Model](#61-capability-model)
+   - 6.2 [Extension Filtering](#62-extension-filtering)
+   - 6.3 [Capability in Practice](#63-capability-in-practice)
+7. [Configuration](#7-configuration)
+   - 7.1 [Plugin Configuration](#71-plugin-configuration)
+   - 7.2 [External Plugins](#72-external-plugins)
+   - 7.3 [YAML Configuration](#73-yaml-configuration)
+   - 7.4 [Global Settings](#74-global-settings)
+8. [Plugin Manager & Lifecycle](#8-plugin-manager--lifecycle)
+   - 8.1 [Plugin Context](#81-plugin-context)
+   - 8.2 [Manager Lifecycle & Execution Flow](#82-manager-lifecycle--execution-flow)
+   - 8.3 [Class Diagram](#83-class-diagram)
+9. [Properties](#9-properties)
+
+## 1. Design Goals
+
+* **Payload-agnostic** — Operates on any typed, frozen Pydantic payload. CMF messages are a built-in payload type, not the only one. Domain-specific hooks define domain-specific payloads.
+* **Composable** — Multiple plugins attach to the same hook point and execute in priority order. Plugins are grouped into reusable sets.
+* **Minimal intrusion** — Plugins are opt-in. Without registered plugins, hook invocations are no-ops with zero overhead.
+* **Fail-safe** — Plugin failures are isolated. Error handling behavior is configurable per-plugin, independent of mode.
+* **Least privilege** — Plugins declare capabilities. The framework filters payload extensions per-plugin so each sees only the data it needs.
+* **Safe mutation** — Plugins that modify payloads operate on copies. The original payload is preserved for audit, rollback, and parallel inspection.
+
+## 2. Framework Model
+
+This section introduces the type system that the rest of the specification builds on. Understanding these types first makes the behavioral contracts, execution model, and capability system that follow concrete and unambiguous.
+
+### 2.1 Key Types
+
+| Type | Role |
+|------|------|
+| `PluginPayload` | Base type for all hook payloads. Frozen (immutable) Pydantic model with optional extensions. Plugins use `model_copy(update={...})` to propose modifications. CMF [Message](cdm-message-spec-v2.md) defines a canonical representation for messages. |
+| `PluginResult[T]` | Generic result: `continue_processing`, `modified_payload`, `violation`, `metadata`. |
+| `PipelineResult[T]` | Aggregate result from a full hook invocation. Wraps `PluginResult` with factory methods (`allowed`, `denied`). |
+| `PluginViolation` | Structured policy failure: `reason`, `description`, `code`, `details`. |
+| `PluginMode` | Enumeration: `OBSERVE`, `VALIDATE`, `MODIFY`. |
+| `OnError` | Enumeration: `FAIL`, `IGNORE`, `DISABLE`. |
+| `Plugin` | Abstract base class with `initialize()`, `shutdown()`, and `@hook`-decorated methods. |
+| `PluginConfig` | Plugin declaration: `name`, `kind`, `mode`, `on_error`, `priority`, `capabilities`, `config`. |
+| `PluginContext` | Per-invocation execution state: `local_state`, `global_state`. |
+| `PluginManager` | Singleton managing plugin lifecycle and dispatch. |
+| `PluginSet` | Composable, reusable grouping of related hooks and plugins. |
+| `@hook` | Decorator for registering async functions or methods as hook handlers. |
+| `@plugin` | Convenience decorator for marking a plain class as a multi-hook plugin. |
+
+### 2.2 PluginPayload
+
+`PluginPayload` is the generic base type for all hook payloads. It is a frozen Pydantic model that optionally carries CMF extensions, making capability gating available to any payload type, including CMF messages.
+
+```python
+class PluginPayload(BaseModel, frozen=True):
+    """Base type for all hook payloads.
+
+    Frozen (immutable). Plugins propose modifications via model_copy(update={...}).
+    Subclasses define domain-specific fields.
+    """
+    extensions: Extensions | None = None
+```
+
+**Design rationale:**
+
+* **Frozen** — Payloads are immutable by default. Mutation is only possible through copy-on-write in `modify` mode.
+* **Optional extensions** — Payloads that carry extensions get automatic capability filtering. Payloads without extensions skip filtering entirely.
+* **Pydantic** — Provides validation, serialization, and `model_copy()` for COW semantics.
+
+Domain-specific payloads subclass `PluginPayload` and add their own fields:
+
+```python
+class CompletionPayload(PluginPayload):
+    """Hook payload for LLM completion lifecycle."""
+    prompt: str
+    model: str
+    parameters: dict[str, Any] = {}
+
+class ToolInvocationPayload(PluginPayload):
+    """Hook payload for tool execution lifecycle."""
+    tool_name: str
+    arguments: dict[str, Any]
+    server_id: str | None = None
+```
+
+These payloads participate in the same plugin pipeline — same modes, same scheduling, same result types. When they carry extensions, capability gating works identically to CMF message payloads.
+
+### 2.3 CMF Integration
+
+CMF `Message` and `MessageView` are the primary built-in payload types. They are used by the standard hook points that process message-level interactions — the common case for policy enforcement, content scanning, and observability in agentic systems.
+
+```python
+class MessagePayload(PluginPayload):
+    """CMF message payload — the primary built-in type.
+
+    Wraps a CMF Message and its decomposed views for policy evaluation.
+    Extensions are always present (inherited from the message).
+    """
+    message: Message
+    views: list[MessageView]
+    extensions: Extensions          # Always present for CMF payloads
+```
+
+`MessagePayload` provides plugins with both the wire-format `Message` and the decomposed `MessageView` list. Plugins that need to scan individual tool calls, resources, or prompt requests operate on views. Plugins that need the full message structure (e.g., for serialization or forwarding) operate on the message directly.
+
+**How CMF payloads relate to generic payloads:**
+
+| Aspect | `PluginPayload` | `MessagePayload` |
+|--------|-----------------|-------------------|
+| Extensions | Optional | Always present |
+| Capability filtering | Applied when extensions exist | Always applied |
+| `MessageView` accessors | Not available | Available via `views` |
+| COW tier enforcement | Applied when extensions exist | Always enforced |
+
+Plugins can be written against `PluginPayload` for maximum generality, or against `MessagePayload` (or any other subclass) when they need domain-specific fields:
+
+```python
+# Generic — works with any payload that has extensions
+@hook("any_hook", mode="validate")
+async def check_labels(payload: PluginPayload, ctx):
+    if payload.extensions and "RESTRICTED" in payload.extensions.security.labels:
+        return block("Restricted content")
+
+# CMF-specific — accesses message views
+@hook("message_pre_send", mode="validate")
+async def check_tool_calls(payload: MessagePayload, ctx):
+    for view in payload.views:
+        if view.kind == "tool_call" and view.name == "execute_sql":
+            if not view.has_permission("db.read"):
+                return block("Missing db.read permission")
+```
+
+### 2.4 PluginResult & PluginViolation
+
+A plugin evaluates a payload and returns a `PluginResult`, which expresses one of three decisions:
+
+| Decision | `continue_processing` | `modified_payload` | `violation` | Effect |
+|----------|----------------------|-------------------|-------------|--------|
+| **Allow** | `True` | `None` | `None` | Payload continues unchanged |
+| **Deny** | `False` | `None` | `PluginViolation(...)` | Pipeline halts; violation reported |
+| **Modify** | `True` | `PluginPayload(...)` | `None` | Modified copy replaces the current payload |
+
+These outcomes form the complete set of plugin decisions. Returning `None` is equivalent to Allow. Plugins cannot alter control flow beyond these three outcomes.
+
+```python
+class PluginResult(Generic[T]):
+    continue_processing: bool = True
+    modified_payload: T | None = None
+    violation: PluginViolation | None = None
+    metadata: dict[str, Any] = {}
+```
+
+The `PluginViolation` type carries structured policy failure information:
+
+```python
+class PluginViolation:
+    reason: str                    # Short human-readable summary
+    description: str | None        # Optional detailed explanation
+    code: str | None               # Machine-readable identifier
+    details: dict[str, Any]        # Structured diagnostic data
+```
+
+Violations propagate to the caller and may be logged, surfaced to users, or used for auditing.
+
+## 3. Plugin Definition
+
+The framework supports three mechanisms for defining plugins, in order of simplicity.
+
+### 3.1 Function Hooks
+
+The simplest plugin is a plain async function decorated with `@hook`:
+
+```python
+from framework import hook, block
+
+@hook("generation_pre_call", mode="validate", priority=10)
+async def enforce_budget(payload, ctx):
+    if estimate_tokens(payload) > 4000:
+        return block("Token budget exceeded")
+
+@hook("tool_post_invoke", mode="observe")
+async def log_tool_call(payload, ctx):
+    print(f"[tool] {payload.tool_name} → {payload.latency_ms}ms")
+```
+
+**Parameters:**
+
+- `hook_type: str` — the hook point name (required).
+- `mode: str` — `"observe"`, `"validate"` (default), or `"modify"`.
+- `priority: int` — lower numbers execute first (default: `50`).
+
+The `block()` helper is shorthand for returning a deny result:
+
+```python
+def block(reason: str, *, description: str = None, code: str = "", details: dict = None) -> PluginResult:
+    return PluginResult(
+        continue_processing=False,
+        violation=PluginViolation(
+            reason=reason, description=description, code=code, details=details or {}
+        ),
+    )
+```
+
+### 3.2 Class-Based Plugins
+
+For plugins that need shared state across multiple hooks, use the `@plugin` decorator or subclass the `Plugin` base class.
+
+**`@plugin` decorator** — marks a plain class as a multi-hook plugin. Parameters:
+
+- `name: str` — unique plugin identifier (required).
+- `priority: int` — default priority for all hooks in this plugin (default: `50`). Per-handler `@hook` priorities override this.
+- `on_error: str` — default error handling for all hooks (default: `"fail"`).
+- `capabilities: list[str]` — extension capabilities for all hooks (default: `[]`).
+
+```python
+from framework import plugin, hook, PluginResult
+
+@plugin("pii-redactor", priority=5)
+class PIIRedactor:
+    def __init__(self, patterns: list[str] | None = None):
+        self.patterns = patterns or [r"\d{3}-\d{2}-\d{4}"]
+
+    @hook("generation_pre_call", mode="modify")
+    async def redact_input(self, payload, ctx):
+        redacted = self._redact(payload.prompt)
+        if redacted != payload.prompt:
+            modified = payload.model_copy(update={"prompt": redacted})
+            return PluginResult(continue_processing=True, modified_payload=modified)
+
+    @hook("generation_post_call", mode="modify")
+    async def redact_output(self, payload, ctx):
+        ...
+
+    def _redact(self, text: str) -> str:
+        for pattern in self.patterns:
+            text = re.sub(pattern, "[REDACTED]", text)
+        return text
+```
+
+**`Plugin` base class** — for plugins that need lifecycle hooks (`initialize`/`shutdown`):
+
+```python
+from framework import Plugin, hook
+
+class MetricsCollector(Plugin):
+    def __init__(self, endpoint: str):
+        self.endpoint = endpoint
+        self._buffer = []
+
+    async def initialize(self):
+        self._client = await connect(self.endpoint)
+
+    async def shutdown(self):
+        await self._client.flush(self._buffer)
+        await self._client.close()
+
+    @hook("generation_post_call", mode="observe")
+    async def collect(self, payload, ctx):
+        self._buffer.append({"latency": payload.latency_ms})
+```
+
+### 3.3 Plugin Sets
+
+`PluginSet` groups related hooks and plugins into composable, reusable units:
+
+```python
+from framework import PluginSet
+
+security = PluginSet("security", [
+    enforce_budget,
+    PIIRedactor(patterns=[r"\d{3}-\d{2}-\d{4}"]),
+])
+
+observability = PluginSet("observability", [
+    log_tool_call,
+    MetricsCollector(endpoint="https://..."),
+])
+```
+
+`PluginSet` accepts standalone hook functions, `@plugin`-decorated class instances, `Plugin` subclass instances, and other `PluginSet` instances (nesting). Sets are inert containers; they do not register anything themselves. Registration happens when they are passed to `register()` or associated with a specific block of code using a context manager.
+
+### 3.4 Registration & Scoping
+
+**Global** — fires for all hook invocations:
+
+```python
+from framework import register
+
+register(observability)
+register([security, observability])
+register(enforce_budget)
+```
+
+**Context manager** — fires within a `with` block:
+
+Plugins can be activated for a specific block of code using context managers:
+
+```python
+from framework import plugin_scope
+
+# Factory — accepts any mix of hooks, plugins, and sets
+with plugin_scope(enforce_budget, PIIRedactor()):
+    result = generate("Name the planets.")
+# plugins deregistered here
+
+# @plugin instance as context manager
+guard = PIIRedactor()
+with guard:
+    result = generate("Summarize the customer record.")
+
+# PluginSet as context manager
+with observability:
+    result = generate("What is the capital of France?")
+```
+
+All forms support `async with`. Scopes stack cleanly — each exit deregisters only its own plugins. The same instance cannot be active in two overlapping scopes simultaneously; create separate instances for concurrent use.
+
+## 4. Plugin Behavior
+
+### 4.1 Plugin Modes
+
+Each plugin declares a **mode**, which defines its authority level over pipeline execution and payload mutation.
+
+```python
+class PluginMode(StrEnum):
+    OBSERVE = "observe"
+    VALIDATE = "validate"
+    MODIFY = "modify"
+```
+
+Modes are strictly hierarchical in authority:
+
+```
+OBSERVE  <  VALIDATE  <  MODIFY
+```
+
+Each mode grants specific capabilities:
+
+| Mode | Can Observe | Can Modify | Can Deny | Pipeline Waits | Typical Use Cases |
+|------|-------------|------------|----------|----------------|-------------------|
+| `observe` | Yes | No | No | No | Audit logging, telemetry, analytics |
+| `validate` | Yes | No | Yes | Yes | Authorization, policy enforcement, rate limiting |
+| `modify` | Yes | Yes (COW) | Yes | Yes | Redaction, normalization, header injection |
+
+#### Mode semantics
+
+**`observe`**
+
+* Receives a read-only view of the payload
+* Cannot modify or deny execution
+* Executes asynchronously
+* Results are ignored
+* Used for side effects only
+
+**`validate`**
+
+* Receives a read-only view of the payload
+* May allow or deny execution
+* Cannot modify the payload
+* Used for policy enforcement and validation
+
+**`modify`**
+
+* Receives a mutable copy of the payload (copy-on-write)
+* May modify, allow, or deny execution
+* Modifications propagate to downstream plugins and the caller
+
+#### Scheduling model (derived from mode)
+
+Execution scheduling is determined automatically from mode:
+
+* **Observe plugins** — Executed asynchronously. Never block the pipeline. May run in parallel.
+* **Validate plugins** — Executed in parallel. Pipeline waits for completion. Safe parallelism due to read-only access.
+* **Modify plugins** — Executed sequentially. Each plugin receives the output of the previous plugin. Ensures deterministic transformation order.
+
+Plugin authors do not control scheduling directly. Scheduling is derived from mode to guarantee safety and correctness.
+
+#### Mode progression and rollout
+
+Modes support progressive deployment:
+
+```
+observe  →  validate  →  modify
+ async      enforce      enforce + correct
+```
+
+This allows operators to:
+
+* Start with observe mode to measure impact
+* Promote to validate mode to enforce policy
+* Promote to modify mode to automatically correct violations
+
+### 4.2 Error Handling
+
+Error handling behavior is controlled by the `on_error` attribute, independent of mode.
+
+```python
+class OnError(StrEnum):
+    FAIL = "fail"
+    IGNORE = "ignore"
+    DISABLE = "disable"
+```
+
+| Value | Behavior |
+|-------|----------|
+| `fail` | Pipeline halts and error propagates |
+| `ignore` | Error logged; pipeline continues |
+| `disable` | Plugin automatically disabled after error |
+
+#### Semantics
+
+**`fail` (default)**
+
+* Plugin failures halt execution
+* Ensures fail-safe enforcement
+* Recommended for security-critical plugins
+
+**`ignore`**
+
+* Plugin failures are logged
+* Pipeline continues execution
+* Recommended for observability and non-critical plugins
+
+**`disable`**
+
+* Plugin is automatically transitioned to a disabled state
+* Prevents repeated failures from affecting pipeline stability
+* Useful for experimental or external plugins
+
+#### Error isolation
+
+Each plugin executes in isolation:
+
+* Exceptions do not crash the host system
+* Failures are contained to the plugin invocation
+* Behavior is controlled exclusively by `on_error`
+
+Example configuration:
+
+```yaml
+plugins:
+  - name: audit_logger
+    mode: observe
+    on_error: ignore
+
+  - name: rbac_authorizer
+    mode: validate
+    on_error: fail
+
+  - name: pii_redactor
+    mode: modify
+    on_error: disable
+```
+
+### 4.3 Copy-on-Write Semantics
+
+Only `modify` plugins receive mutable payloads. All modifications use copy-on-write semantics:
+
+* Original payload is never mutated
+* Modified copies propagate forward
+* Original remains available for audit and rollback
+
+For payloads that carry extensions, COW copies respect extension mutability tiers: immutable extensions are shared by reference, monotonic extensions are validated add-only, guarded extensions require write capabilities. See [CMF Message Specification — Mutability Tiers](cdm-message-spec-v2.md#31-mutability-tiers). Payloads without extensions skip tier enforcement.
+
+This ensures:
+
+* Deterministic execution
+* Safe parallel validation
+* Full auditability
+* Isolation between plugins
+
+#### COW validation
+
+After a modify plugin returns a modified payload, the pipeline validates the modification against extension mutability tiers using `validate_cow(original, modified, capabilities)`. The validation checks:
+
+| Tier | Validation Rule |
+|------|----------------|
+| **Immutable** | `original.ext is modified.ext` (reference equality). Any change is rejected. |
+| **Monotonic** | `original.labels ⊆ modified.labels`. Removal of any element is rejected. |
+| **Guarded** | Modification is accepted only if the plugin declared the corresponding write capability (e.g., `write_headers` for `ext.http`). |
+| **Mutable** | No validation. Any change is accepted. |
+
+If validation fails, the pipeline rejects the modification and applies the plugin's `on_error` behavior. The original payload is preserved.
+
+```python
+@hook("message_pre_send", mode="modify")
+async def redact_pii(payload: MessagePayload, ctx):
+    if contains_pii(payload.message.get_text_content()):
+        redacted_content = redact(payload.message.content)
+        redacted_message = payload.message.model_copy(update={"content": redacted_content})
+        redacted_labels = payload.extensions.security.labels | {"PII_REDACTED"}
+        redacted_security = payload.extensions.security.model_copy(update={"labels": redacted_labels})
+        redacted_extensions = payload.extensions.model_copy(update={"security": redacted_security})
+        modified = payload.model_copy(update={
+            "message": redacted_message,
+            "extensions": redacted_extensions,
+        })
+        return PluginResult(modified_payload=modified)
+    return PluginResult()  # Allow, no modification
+```
+
+## 5. Execution Model
+
+### 5.1 Hook Invocation
+
+Hook point names (e.g., `generation_pre_call`, `tool_post_invoke`, `message_pre_send`) are defined by the host system that integrates the plugin framework. This specification does not prescribe a fixed set of hook points — each host defines the hook points appropriate to its execution lifecycle and places `invoke_hook()` calls at those sites. Hook names used in examples throughout this specification are illustrative.
+
+The pipeline dispatches plugins through a single entry point placed at hook invocation sites:
+
+```python
+async def invoke_hook(
+    hook_type: str, payload: PluginPayload, context: PluginContext
+) -> PluginResult:
+    # 1. Resolve registered plugins for this hook_type
+    # 2. For each plugin in priority order:
+    #       if mode is observe   → dispatch asynchronously with read-only view
+    #       elif mode is validate → await with read-only view
+    #       elif mode is modify   → await with mutable copy
+    # 3. Return the aggregate result
+```
+
+`PipelineResult` is a convenience wrapper around `PluginResult` returned by the pipeline after all hooks for an invocation have run. It aggregates individual plugin results and provides factory methods for the common outcomes:
+
+* `PipelineResult.allowed(payload)` — all plugins allowed; returns the (possibly modified) payload.
+* `PipelineResult.denied(results)` — at least one plugin denied; carries the violation(s).
+
+Callers treat `PipelineResult` identically to `PluginResult` — it exposes the same `continue_processing`, `modified_payload`, and `violation` fields.
+
+The caller (typically a framework base class) invokes the hook and processes one of three outcomes:
+
+1. **Continue unchanged**: `PluginResult(continue_processing=True)` with no `modified_payload`.
+2. **Continue with modified payload**: `PluginResult(continue_processing=True, modified_payload=...)`. The caller uses the modified payload in place of the original.
+3. **Block execution**: `PluginResult(continue_processing=False, violation=...)`. The caller halts and reports the violation.
+
+Hooks cannot redirect control flow or alter the calling method's logic beyond these outcomes. This is enforced by the `PluginResult` type.
+
+### 5.2 Scheduling
+
+The scheduler determines plugin execution order and concurrency based solely on plugin mode and priority. Plugin authors do not control scheduling directly.
+
+Scheduling is designed to maximize parallelism while preserving correctness and deterministic transformation ordering.
+
+#### Scheduling rules by mode
+
+Plugins are scheduled according to their mode:
+
+| Mode | Execution | Concurrency | Mutability |
+|------|-----------|-------------|------------|
+| `observe` | Asynchronous | Parallel | Read-only |
+| `validate` | Awaited | Parallel | Read-only |
+| `modify` | Awaited | Sequential | Copy-on-write |
+
+Execution guarantees:
+
+* Observe plugins never block the pipeline.
+* Validate plugins execute concurrently and the pipeline waits for all results.
+* Modify plugins execute sequentially to preserve transformation ordering.
+
+These guarantees ensure safe parallelism and deterministic behavior.
+
+#### Execution phases
+
+Given a priority-ordered list of plugins, the scheduler processes plugins in phases based on mode:
+
+1. Dispatch all observe plugins asynchronously
+2. Execute validate plugins in parallel and await completion
+3. Execute modify plugins sequentially
+4. Return the final result
+
+Observe plugins may still be running after the pipeline completes.
+
+#### Transformation chaining
+
+Modify plugins form a deterministic transformation chain.
+
+Each modify plugin receives the output of the previous modify plugin:
+
+```
+Original Payload
+    ↓
+Modify Plugin A
+    ↓
+Modified Payload A
+    ↓
+Modify Plugin B
+    ↓
+Modified Payload B
+    ↓
+Final Payload
+```
+
+If any modify plugin denies execution, the pipeline halts immediately and downstream plugins are not executed.
+
+#### Priority and ordering
+
+Plugins execute in ascending priority order (lower value executes first).
+
+Within each mode:
+
+* Observe plugins may execute in any order
+* Validate plugins may execute in any order
+* Modify plugins execute strictly in priority order
+
+Default priority is `50`.
+
+Example ordering:
+
+```
+P=0   observe    audit_logger
+P=10  validate   rbac_authorizer
+P=20  validate   quota_enforcer
+P=30  modify     pii_redactor
+P=40  modify     header_injector
+```
+
+Execution schedule:
+
+```
+1. Dispatch audit_logger (async)
+2. Execute rbac_authorizer and quota_enforcer (parallel)
+3. Execute pii_redactor (sequential)
+4. Execute header_injector (sequential)
+```
+
+Priority can be set per-handler, per-plugin, or per-set. Most specific wins: per-handler > per-plugin > per-set.
+
+#### Short-circuit behavior
+
+The pipeline halts immediately if any validate or modify plugin returns a deny result.
+
+Observe plugins cannot deny execution and never affect pipeline control flow.
+
+Example:
+
+```
+validate_plugin_A → allow
+validate_plugin_B → deny
+modify_plugin_C   → not executed
+```
+
+Result: execution stops at validate_plugin_B.
+
+#### Hook payload policies
+
+Each hook point may declare a `HookPayloadPolicy` that constrains which payload fields modify plugins are allowed to change. The policy lists the writable fields; modifications to any other field are rejected by COW validation.
+
+```python
+class HookPayloadPolicy(frozen=True):
+    writable_fields: frozenset[str]    # Payload fields modify plugins may change
+```
+
+When no policy is registered for a hook, the `DefaultHookPolicy` determines behavior:
+
+| Default | Behavior |
+|---------|----------|
+| `ALLOW` | All payload fields are writable (default) |
+| `DENY` | No payload fields are writable; modify plugins are rejected at registration |
+
+Hook payload policies are registered on the `PluginManager` and are independent of plugin capabilities — capabilities control *extension* visibility, while hook policies control *field-level* write scope.
+
+#### Capability filtering and isolation
+
+Before invocation, the framework constructs a capability-filtered view of the payload for each plugin. Filtering applies to any `PluginPayload` that carries extensions (see [§6.2](#62-extension-filtering)). Payloads without extensions skip this step.
+
+This ensures:
+
+* Plugins can only access declared extensions
+* Validate plugins cannot modify payloads
+* Modify plugins can only modify authorized extensions
+* Observe plugins cannot mutate state
+
+Each plugin invocation is isolated and receives its own filtered view.
+
+#### Example scheduling timeline
+
+Given:
+
+```
+observe:  metrics, audit_log
+validate: rbac, quota
+modify:   redact, normalize
+```
+
+Execution timeline:
+
+```
+time →
+│
+├─ metrics        (async) ────────────────►
+├─ audit_log      (async) ────────────────►
+│
+├─ rbac           (parallel) ──────┐
+├─ quota          (parallel) ──────┘
+│
+├─ redact         (sequential) ───►
+│
+├─ normalize      (sequential) ───►
+│
+└─ return result
+```
+
+Observe plugins may continue executing after the result is returned.
+
+#### Determinism guarantees
+
+The scheduler guarantees deterministic outcomes:
+
+* Validate plugins cannot modify payloads, so execution order does not affect results
+* Modify plugins execute sequentially, ensuring consistent transformations
+* Observe plugins cannot affect pipeline state
+
+This ensures reproducible execution independent of system concurrency.
+
+#### Zero-overhead fast path
+
+If no plugins are registered for a hook, invocation returns immediately without allocation, scheduling, or copying.
+
+This ensures negligible overhead when the framework is unused.
+
+## 6. Capability-Gated Extensions
+
+Plugins declare which extensions they need. The pipeline builds payload views with only the granted extensions visible — ungated extensions appear as `None`. Capability gating applies to any `PluginPayload` that carries extensions, not only CMF messages.
+
+For the full extension model and mutability tiers, see [CMF Message Specification — Extensions](cdm-message-spec-v2.md#3-extensions).
+
+### 6.1 Capability Model
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Base (always available, no capability required)                  │
+│  Content: kind, content, uri, name, args, mime_type, size        │
+│  Semantic: action, is_pre, is_post, role                         │
+│  Request: environment, request_id, timestamp                     │
+│  Informational: completion, provenance, mcp, llm, framework      │
+├──────────────────────────────────────────────────────────────────┤
+│  Read capabilities (control extension visibility on views):      │
+│  + read_subject          → ext.security.subject (id, type)       │
+│  + read_roles            → ext.security.subject.roles            │
+│  + read_teams            → ext.security.subject.teams            │
+│  + read_claims           → ext.security.subject.claims           │
+│  + read_permissions      → ext.security.subject.permissions      │
+│  + read_headers          → ext.http.headers (sanitized)          │
+│  + read_labels           → ext.security.labels                   │
+│  + read_objects          → ext.security.objects                   │
+│  + read_data             → ext.security.data                     │
+│  + read_agent            → ext.agent (input, session, etc.)      │
+├──────────────────────────────────────────────────────────────────┤
+│  Write capabilities (control COW modification rights):           │
+│  + write_headers         → modify ext.http.headers               │
+│  + write_custom          → modify ext.custom                     │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+A plugin that only needs content for scanning gets no subject, no headers, no labels. A plugin doing role-based authorization declares `read_subject` + `read_roles` and gets exactly that.
+
+The base tier and informational extensions shown above apply to CMF `MessageView` accessors. Informational extensions (`completion`, `provenance`, `mcp`, `llm`, `framework`) are always visible because they carry no security-sensitive data — they describe the message's origin and processing context. The `custom` extension requires `write_custom` to modify but is always readable. For non-CMF payloads, the base tier includes the payload's own fields; capability gating controls only the extensions.
+
+### 6.2 Extension Filtering
+
+The pipeline filters extensions per-plugin before dispatch. No intermediate context object is needed — the extensions themselves are the gating surface. This filter applies to any `PluginPayload` whose `extensions` field is not `None`.
+
+```python
+class ExtensionFilter:
+    def __init__(self, capabilities: list[str]):
+        self.caps = set(capabilities)
+
+    def filter(self, extensions: Extensions) -> Extensions:
+        """Return a filtered copy with only granted extensions visible."""
+        filtered = Extensions()
+
+        # Base tier — always visible
+        filtered.request = extensions.request
+
+        # Capability-gated: subject and security fields
+        if extensions.security:
+            sec = None
+            if "read_subject" in self.caps and extensions.security.subject:
+                subject = extensions.security.subject
+                sec = SecurityExtension(
+                    subject=SubjectExtension(
+                        id=subject.id,
+                        type=subject.type,
+                        roles=subject.roles if "read_roles" in self.caps else None,
+                        permissions=subject.permissions if "read_permissions" in self.caps else None,
+                        teams=subject.teams if "read_teams" in self.caps else None,
+                        claims=subject.claims if "read_claims" in self.caps else None,
+                    ),
+                )
+            if "read_labels" in self.caps:
+                sec = sec or SecurityExtension()
+                sec.labels = extensions.security.labels
+            if "read_objects" in self.caps:
+                sec = sec or SecurityExtension()
+                sec.objects = extensions.security.objects
+            if "read_data" in self.caps:
+                sec = sec or SecurityExtension()
+                sec.data = extensions.security.data
+            filtered.security = sec
+
+        if "read_headers" in self.caps:
+            filtered.http = extensions.http
+        if "read_agent" in self.caps:
+            filtered.agent = extensions.agent
+
+        # Immutable informational extensions — always visible
+        filtered.completion = extensions.completion
+        filtered.provenance = extensions.provenance
+        filtered.mcp = extensions.mcp
+        filtered.llm = extensions.llm
+        filtered.framework = extensions.framework
+
+        # Custom — always readable, writable with write_custom
+        filtered.custom = extensions.custom
+
+        return filtered
+```
+
+Ungated extensions are `None` on the view. Existing `MessageView` accessors handle this naturally — `view.roles` returns an empty set if the subject extension was not granted, `view.has_role("admin")` returns `False`.
+
+### 6.3 Capability in Practice
+
+The same tool call viewed by three plugins with different capabilities:
+
+**Content-only plugin** (no capabilities):
+```json
+{
+  "kind": "tool_call",
+  "action": "execute",
+  "is_pre": true,
+  "name": "execute_sql",
+  "uri": "tool://db-server/execute_sql",
+  "content": "{\"query\": \"SELECT * FROM users\"}",
+  "arguments": {"query": "SELECT * FROM users"},
+  "context": {
+    "environment": "production"
+  }
+}
+```
+
+**Authorization plugin** (`read_subject` + `read_roles`):
+```json
+{
+  "kind": "tool_call",
+  "action": "execute",
+  "is_pre": true,
+  "name": "execute_sql",
+  "uri": "tool://db-server/execute_sql",
+  "content": "{\"query\": \"SELECT * FROM users\"}",
+  "arguments": {"query": "SELECT * FROM users"},
+  "context": {
+    "environment": "production",
+    "security": {
+      "subject": {
+        "id": "user-alice",
+        "type": "user",
+        "roles": ["developer", "db-reader"]
+      }
+    }
+  }
+}
+```
+
+**Full-context plugin** (all capabilities):
+```json
+{
+  "kind": "tool_call",
+  "action": "execute",
+  "is_pre": true,
+  "name": "execute_sql",
+  "uri": "tool://db-server/execute_sql",
+  "content": "{\"query\": \"SELECT * FROM users\"}",
+  "arguments": {"query": "SELECT * FROM users"},
+  "context": {
+    "environment": "production",
+    "request_id": "req-7f2a",
+    "security": {
+      "subject": {
+        "id": "user-alice",
+        "type": "user",
+        "roles": ["developer", "db-reader"],
+        "teams": ["platform"],
+        "permissions": ["tools.execute", "db.read"],
+        "claims": {"sub": "user-alice", "department": "engineering"}
+      },
+      "labels": ["internal"]
+    },
+    "headers": {"x-request-id": "req-7f2a", "x-forwarded-for": "10.0.1.5"},
+    "agent": {
+      "input": "Show me all users",
+      "session_id": "sess-9f3a",
+      "conversation_id": "conv-17eb",
+      "turn": 4
+    }
+  }
+}
+```
+
+## 7. Configuration
+
+### 7.1 Plugin Configuration
+
+Each plugin is described by a `PluginConfig`:
+
+```python
+class PluginConfig:
+    name: str                          # Unique plugin identifier
+    kind: str                          # Class path or "external"
+    description: str | None = None     # Human-readable purpose
+    author: str | None = None          # Maintainer or team
+    version: str | None = None         # Semantic version
+    tags: list[str] = []               # Searchable categorization
+    mode: PluginMode = PluginMode.VALIDATE
+    on_error: OnError = OnError.FAIL   # Error handling behavior
+    priority: int = 50                 # Execution order (lower = first)
+    capabilities: list[str] = []       # Extension capabilities (see 6.1)
+    config: dict[str, Any] = {}        # Plugin-specific settings
+```
+
+**`kind`** — For native plugins, this is the class path (e.g., `plugins.security.rate_limiter.RateLimiter`). The framework dynamically imports and instantiates the class. For external plugins, use `"external"` — connection details are specified separately.
+
+**`mode`** — The plugin's authority level: `observe`, `validate`, or `modify` (see [4.1](#41-plugin-modes)).
+
+**`on_error`** — Error handling behavior: `fail`, `ignore`, or `disable` (see [4.2](#42-error-handling)).
+
+**`capabilities`** — Extension capabilities the plugin requires (see [6.1](#61-capability-model)). The pipeline filters extensions before dispatching. Ungated extensions are `None`.
+
+**`priority`** — Controls execution order. Lower numbers run first. Plugins at the same priority may be parallelized when their modes permit.
+
+### 7.2 External Plugins
+
+External plugins run as separate processes — MCP servers, HTTP services, or WASM modules. The framework serializes the capability-filtered payload and sends it to the external plugin. The plugin returns a `PluginResult` as JSON. External plugins never see extensions they have not been granted.
+
+```yaml
+plugins:
+  - name: openai_moderation
+    kind: "external"
+    description: "OpenAI content moderation"
+    capabilities: [read_subject, read_labels]
+    priority: 30
+    mode: validate
+    on_error: fail
+    mcp:
+      proto: "streamablehttp"
+      url: "http://moderation-plugin:3000/mcp"
+```
+
+Supported transports:
+
+| Field | Transport | Description |
+|-------|-----------|-------------|
+| `proto` | all | Protocol: `stdio`, `sse`, `streamablehttp`, `websocket` |
+| `url` | HTTP-based | Service URL |
+| `uds` | streamablehttp | Unix domain socket path |
+| `script` | stdio | Script path to execute |
+| `cmd` | stdio | Command array |
+| `env` | stdio | Environment variable overrides |
+| `cwd` | stdio | Working directory |
+
+### 7.3 YAML Configuration
+
+For deployment-time overrides, plugins can be loaded from YAML. This is useful for enabling/disabling plugins or changing modes and priorities without code changes:
+
+```yaml
+plugins:
+  - name: rate_limiter
+    kind: "plugins.security.rate_limiter.RateLimiter"
+    capabilities: [read_subject]
+    priority: 10
+    mode: validate
+    on_error: fail
+    config:
+      max_requests_per_minute: 60
+
+  - name: pii_detector
+    kind: "plugins.compliance.pii_detector.PIIDetector"
+    tags: [security, pii, compliance]
+    priority: 50
+    mode: validate
+
+  - name: pii_redactor
+    kind: "plugins.compliance.pii_redactor.PIIRedactor"
+    capabilities: [read_labels]
+    priority: 50
+    mode: modify
+    on_error: disable
+
+  - name: rbac_authorizer
+    kind: "plugins.auth.rbac.RBACAuthorizer"
+    capabilities: [read_subject, read_roles, read_permissions]
+    priority: 80
+    mode: validate
+
+  - name: opa_policy
+    kind: "external"
+    description: "OPA sidecar policy evaluation"
+    capabilities: [read_subject, read_roles, read_labels, read_agent]
+    priority: 100
+    mode: validate
+    mcp:
+      proto: "streamablehttp"
+      url: "http://opa-sidecar:8181/mcp"
+
+  - name: token_injector
+    kind: "plugins.auth.token_injector.TokenInjector"
+    capabilities: [read_subject, write_headers]
+    priority: 200
+    mode: modify
+
+  - name: audit_logger
+    kind: "plugins.audit.logger.AuditLogger"
+    capabilities: [read_subject, read_labels]
+    mode: observe
+    on_error: ignore
+    priority: 0
+
+  - name: telemetry
+    kind: "external"
+    mode: observe
+    on_error: ignore
+    priority: 0
+    mcp:
+      proto: "streamablehttp"
+      url: "http://telemetry:9090/mcp"
+```
+
+YAML configuration is secondary to programmatic registration. When both are present, programmatic registrations and YAML-configured plugins coexist, ordered by priority.
+
+### 7.4 Global Settings
+
+```yaml
+plugin_settings:
+  plugin_timeout: 30                  # Default timeout (seconds)
+  on_error: fail                      # Global default error behavior
+  observe_pool_size: 4                # Thread pool for async observe plugins
+  validate_pool_size: 4               # Thread pool for async validate plugins
+  cow_validation: strict              # strict | warn | disabled
+  short_circuit_on_deny: true         # Stop pipeline on first deny
+```
+
+## 8. Plugin Manager & Lifecycle
+
+### 8.1 Plugin Context
+
+Each plugin receives a `PluginContext` with execution state:
+
+```
+PluginContext
+├── local_state: dict      # Per-plugin, per-request. Private to the plugin.
+└── global_state: dict     # Shared across plugins. Use with care.
+```
+
+All data needed for policy evaluation comes from the payload's extensions (filtered by capabilities). `PluginContext` is purely for transient execution state — counters, caches, intermediate results.
+
+### 8.2 Manager Lifecycle & Execution Flow
+
+The `PluginManager` owns the plugin lifecycle and execution pipeline. A host system typically maintains a single `PluginManager` instance for its lifetime. The manager must be initialized before dispatching hooks and shut down gracefully to flush observe queues and disconnect external transports.
+
+**Lifecycle:**
+
+```mermaid
+stateDiagram-v2
+    [*] --> Initialize
+    Initialize --> Load: Parse config, validate schemas
+    Load --> Ready: Import classes, connect transports,<br>call plugin.initialize()
+    Ready --> Ready: invoke_hook()
+    Ready --> Shutdown: Graceful teardown
+    Shutdown --> [*]: Flush observe queues,<br>disconnect transports
+
+    state Ready {
+        [*] --> Resolve: Registered plugins for hook_type
+        Resolve --> Filter: Capability-gate extensions per plugin
+        Filter --> Schedule: Mode-aware dispatch
+        Schedule --> [*]: Return PluginResult
+    }
+```
+
+**Execution flow:**
+
+```python
+class PluginManager:
+    async def invoke_hook(
+        self, hook_type: str, payload: PluginPayload, context: PluginContext
+    ) -> PluginResult:
+        plugins = self._resolve(hook_type)
+        if not plugins:
+            return PipelineResult.allowed(payload)
+
+        # Phase 1: Dispatch observe plugins asynchronously
+        observe = [p for p in plugins if p.mode == PluginMode.OBSERVE]
+        self._dispatch_async(observe, payload, context)
+
+        # Phase 2: Execute validate plugins in parallel
+        validate = [p for p in plugins if p.mode == PluginMode.VALIDATE]
+        if validate:
+            results = await gather(
+                [p.invoke(payload, context) for p in validate]
+            )
+            if any_deny(results):
+                return PipelineResult.denied(results)
+
+        # Phase 3: Execute modify plugins sequentially
+        current = payload
+        modify = [p for p in plugins if p.mode == PluginMode.MODIFY]
+        for plugin in modify:
+            view = current
+            if current.extensions is not None:
+                filtered = ExtensionFilter(plugin.capabilities).filter(
+                    current.extensions
+                )
+                view = current.model_copy(update={"extensions": filtered})
+            result = await plugin.invoke(view, context)
+            if result.modified_payload:
+                if current.extensions is not None:
+                    validate_cow(current, result.modified_payload, plugin.capabilities)
+                current = result.modified_payload
+            if not result.continue_processing:
+                return PipelineResult.denied([result])
+
+        return PipelineResult.allowed(current)
+```
+
+### 8.3 Class Diagram
+
+```mermaid
+classDiagram
+    direction TB
+
+    class PluginPayload {
+        <<frozen>>
+        +extensions: Extensions | None
+        +model_copy(update) PluginPayload
+    }
+
+    class MessagePayload {
+        <<frozen>>
+        +message: Message
+        +views: list~MessageView~
+        +extensions: Extensions
+    }
+
+    class Plugin {
+        <<abstract>>
+        +__init__(config: PluginConfig)
+        +initialize()* async
+        +shutdown()* async
+        +hook_name(payload, context)* async PluginResult
+    }
+
+    class PluginManager {
+        -timeout: int
+        -hook_policies: dict~str, HookPayloadPolicy~
+        +invoke_hook(hook_type, payload, context) PipelineResult
+        +has_hooks_for(hook_type: str) bool
+        +initialize() async
+        +shutdown() async
+    }
+
+    class PluginConfig {
+        +name: str
+        +kind: str
+        +mode: PluginMode
+        +on_error: OnError
+        +priority: int
+        +capabilities: list~str~
+        +config: dict
+    }
+
+    class PluginMode {
+        <<enumeration>>
+        OBSERVE
+        VALIDATE
+        MODIFY
+    }
+
+    class OnError {
+        <<enumeration>>
+        FAIL
+        IGNORE
+        DISABLE
+    }
+
+    class HookPayloadPolicy {
+        <<frozen>>
+        +writable_fields: frozenset~str~
+    }
+
+    class DefaultHookPolicy {
+        <<enumeration>>
+        ALLOW
+        DENY
+    }
+
+    class PluginResult~T~ {
+        +continue_processing: bool
+        +modified_payload: T | None
+        +violation: PluginViolation | None
+        +metadata: dict
+    }
+
+    class PipelineResult~T~ {
+        +continue_processing: bool
+        +modified_payload: T | None
+        +violation: PluginViolation | None
+        +allowed(payload) PipelineResult$
+        +denied(results) PipelineResult$
+    }
+
+    class PluginViolation {
+        +reason: str
+        +description: str
+        +code: str
+        +details: dict
+    }
+
+    class PluginContext {
+        +local_state: dict
+        +global_state: dict
+    }
+
+    class PluginSet {
+        +name: str
+        +items: list
+        +flatten() list
+    }
+
+    class hook {
+        <<decorator>>
+        +__call__(hook_type, mode, priority)
+    }
+
+    PluginPayload <|-- MessagePayload : extends
+    Plugin --> PluginConfig : configured by
+    Plugin ..> PluginPayload : receives
+    Plugin ..> PluginResult : returns
+    Plugin ..> PluginContext : receives
+    Plugin ..> hook : decorated by
+
+    PluginManager --> Plugin : manages 0..*
+    PluginManager --> HookPayloadPolicy : enforces per hook
+    PluginManager --> PluginSet : loads from
+
+    PluginConfig --> PluginMode : has
+    PluginConfig --> OnError : has
+
+    PluginResult --> PluginViolation : may contain
+    %%PluginResult --> PluginPayload : wraps modified
+    PipelineResult --|> PluginResult : extends
+    PluginManager ..> PipelineResult : returns
+```
+
+## 9. Properties
+
+| Property | Description |
+|----------|-------------|
+| **Payload-agnostic** | The framework operates on any `PluginPayload` subclass. CMF messages are a built-in type, not a prerequisite. Domain-specific hooks use domain-specific payloads with the same execution model. |
+| **Least privilege** | Plugins only see extensions they declare. A content scanner never sees the subject. |
+| **Auditable** | Capability declarations are static records of what each plugin can access. Plugin decisions are structured and loggable. |
+| **Progressive disclosure** | Start with no capabilities, add as needed. Start with `observe`, promote to `validate`, then `modify`. |
+| **No intermediate objects** | Gating happens by filtering extensions on the payload, not by constructing a separate context object. |
+| **Read/write separation** | Read capabilities control visibility; write capabilities control COW modification rights. The `validate` mode is read-only by design. |
+| **Safe parallelism** | Validate and observe plugins are read-only and can safely execute in parallel. Modify plugins execute sequentially to maintain transformation ordering. |
+| **Zero overhead when unused** | Without registered plugins, hook invocations short-circuit immediately. No allocation, no dispatch. |

--- a/docs/specs/cmf-message-spec.md
+++ b/docs/specs/cmf-message-spec.md
@@ -1,7 +1,7 @@
 # Common Message Format (CMF) Specification
 
 **Version**: 2.0
-**Related**: [Plugin Framework Specification](../docs/plugin-framework-spec.md)
+**Related**: [Plugin Framework Specification](../docs/specs/plugin-framework-spec.md)
 
 ## Introduction
 

--- a/docs/specs/cmf-message-spec.md
+++ b/docs/specs/cmf-message-spec.md
@@ -1,7 +1,7 @@
 # Common Message Format (CMF) Specification
 
 **Version**: 2.0
-**Related**: [Plugin Framework Specification](../docs/specs/plugin-framework-spec.md)
+**Related**: [Plugin Framework Specification](../specs/plugin-framework-spec.md)
 
 ## Introduction
 

--- a/docs/specs/plugin-framework-spec.md
+++ b/docs/specs/plugin-framework-spec.md
@@ -1,7 +1,7 @@
 # Plugin Framework (CPEX) Specification
 
 **Version**: 2.0
-**Related**: [CMF Message Specification](../docs/specs/cmf-message-spec.md)
+**Related**: [CMF Message Specification](../specs/cmf-message-spec.md)
 
 ## Introduction
 
@@ -16,7 +16,7 @@ The framework separates four concerns:
 
 The framework operates on any `PluginPayload` subclass. CMF `Message` and `MessageView` are built-in payload types for the common case of message-level policy enforcement, but the same plugin model, scheduling, and capability gating apply to any domain-specific payload.
 
-For the canonical message model, extensions, and `MessageView` abstraction, see the [CMF Message Specification](../docs/specs/cmf-message-spec.md).
+For the canonical message model, extensions, and `MessageView` abstraction, see the [CMF Message Specification](../specs/cmf-message-spec.md).
 
 ## Table of Contents
 
@@ -70,7 +70,7 @@ This section introduces the type system that the rest of the specification build
 
 | Type | Role |
 |------|------|
-| `PluginPayload` | Base type for all hook payloads. Frozen (immutable) Pydantic model with optional extensions. Plugins use `model_copy(update={...})` to propose modifications. CMF [Message](../docs/specs/cmf-message-spec.md) defines a canonical representation for messages. |
+| `PluginPayload` | Base type for all hook payloads. Frozen (immutable) Pydantic model with optional extensions. Plugins use `model_copy(update={...})` to propose modifications. CMF [Message](../specs/cmf-message-spec.md) defines a canonical representation for messages. |
 | `PluginResult[T]` | Generic result: `continue_processing`, `modified_payload`, `violation`, `metadata`. |
 | `PipelineResult[T]` | Aggregate result from a full hook invocation. Wraps `PluginResult` with factory methods (`allowed`, `denied`). |
 | `PluginViolation` | Structured policy failure: `reason`, `description`, `code`, `details`. |
@@ -497,7 +497,7 @@ Only `modify` plugins receive mutable payloads. All modifications use copy-on-wr
 * Modified copies propagate forward
 * Original remains available for audit and rollback
 
-For payloads that carry extensions, COW copies respect extension mutability tiers: immutable extensions are shared by reference, monotonic extensions are validated add-only, guarded extensions require write capabilities. See [CMF Message Specification — Mutability Tiers](../docs/specs/cmf-message-spec.md#31-mutability-tiers). Payloads without extensions skip tier enforcement.
+For payloads that carry extensions, COW copies respect extension mutability tiers: immutable extensions are shared by reference, monotonic extensions are validated add-only, guarded extensions require write capabilities. See [CMF Message Specification — Mutability Tiers](../specs/cmf-message-spec.md#31-mutability-tiers). Payloads without extensions skip tier enforcement.
 
 This ensures:
 
@@ -758,7 +758,7 @@ This ensures negligible overhead when the framework is unused.
 
 Plugins declare which extensions they need. The pipeline builds payload views with only the granted extensions visible — ungated extensions appear as `None`. Capability gating applies to any `PluginPayload` that carries extensions, not only CMF messages.
 
-For the full extension model and mutability tiers, see [CMF Message Specification — Extensions](../docs/specs/cmf-message-spec.md#3-extensions).
+For the full extension model and mutability tiers, see [CMF Message Specification — Extensions](../specs/cmf-message-spec.md#3-extensions).
 
 ### 6.1 Capability Model
 

--- a/docs/specs/plugin-framework-spec.md
+++ b/docs/specs/plugin-framework-spec.md
@@ -1,7 +1,7 @@
 # Plugin Framework (CPEX) Specification
 
 **Version**: 2.0
-**Related**: [CMF Message Specification](cdm-message-spec.md)
+**Related**: [CMF Message Specification](../docs/specs/cmf-message-spec.md)
 
 ## Introduction
 
@@ -16,7 +16,7 @@ The framework separates four concerns:
 
 The framework operates on any `PluginPayload` subclass. CMF `Message` and `MessageView` are built-in payload types for the common case of message-level policy enforcement, but the same plugin model, scheduling, and capability gating apply to any domain-specific payload.
 
-For the canonical message model, extensions, and `MessageView` abstraction, see the [CMF Message Specification](cdm-message-spec-v2.md).
+For the canonical message model, extensions, and `MessageView` abstraction, see the [CMF Message Specification](../docs/specs/cmf-message-spec.md).
 
 ## Table of Contents
 
@@ -70,7 +70,7 @@ This section introduces the type system that the rest of the specification build
 
 | Type | Role |
 |------|------|
-| `PluginPayload` | Base type for all hook payloads. Frozen (immutable) Pydantic model with optional extensions. Plugins use `model_copy(update={...})` to propose modifications. CMF [Message](cdm-message-spec-v2.md) defines a canonical representation for messages. |
+| `PluginPayload` | Base type for all hook payloads. Frozen (immutable) Pydantic model with optional extensions. Plugins use `model_copy(update={...})` to propose modifications. CMF [Message](../docs/specs/cmf-message-spec.md) defines a canonical representation for messages. |
 | `PluginResult[T]` | Generic result: `continue_processing`, `modified_payload`, `violation`, `metadata`. |
 | `PipelineResult[T]` | Aggregate result from a full hook invocation. Wraps `PluginResult` with factory methods (`allowed`, `denied`). |
 | `PluginViolation` | Structured policy failure: `reason`, `description`, `code`, `details`. |
@@ -497,7 +497,7 @@ Only `modify` plugins receive mutable payloads. All modifications use copy-on-wr
 * Modified copies propagate forward
 * Original remains available for audit and rollback
 
-For payloads that carry extensions, COW copies respect extension mutability tiers: immutable extensions are shared by reference, monotonic extensions are validated add-only, guarded extensions require write capabilities. See [CMF Message Specification — Mutability Tiers](cdm-message-spec-v2.md#31-mutability-tiers). Payloads without extensions skip tier enforcement.
+For payloads that carry extensions, COW copies respect extension mutability tiers: immutable extensions are shared by reference, monotonic extensions are validated add-only, guarded extensions require write capabilities. See [CMF Message Specification — Mutability Tiers](../docs/specs/cmf-message-spec.md#31-mutability-tiers). Payloads without extensions skip tier enforcement.
 
 This ensures:
 
@@ -758,7 +758,7 @@ This ensures negligible overhead when the framework is unused.
 
 Plugins declare which extensions they need. The pipeline builds payload views with only the granted extensions visible — ungated extensions appear as `None`. Capability gating applies to any `PluginPayload` that carries extensions, not only CMF messages.
 
-For the full extension model and mutability tiers, see [CMF Message Specification — Extensions](cdm-message-spec-v2.md#3-extensions).
+For the full extension model and mutability tiers, see [CMF Message Specification — Extensions](../docs/specs/cmf-message-spec.md#3-extensions).
 
 ### 6.1 Capability Model
 

--- a/tests/unit/cpex/fixtures/configs/extensions_aware_plugin.yaml
+++ b/tests/unit/cpex/fixtures/configs/extensions_aware_plugin.yaml
@@ -1,0 +1,24 @@
+plugins:
+  - name: "ExtensionsAwarePlugin"
+    kind: "plugins.extensions_aware.ExtensionsAwarePlugin"
+    description: "Test plugin that accepts extensions"
+    author: "Test"
+    version: "0.1"
+    hooks:
+      - "tool_pre_invoke"
+    mode: "sequential"
+    priority: 10
+    capabilities:
+      - "read_subject"
+      - "read_roles"
+      - "read_labels"
+
+plugin_dirs:
+  - "./tests/unit/cpex/fixtures"
+
+plugin_settings:
+  parallel_execution_within_band: true
+  plugin_timeout: 30
+  fail_on_plugin_error: false
+  enable_plugin_api: true
+  plugin_health_check_interval: 60

--- a/tests/unit/cpex/fixtures/configs/extensions_custom_plugin.yaml
+++ b/tests/unit/cpex/fixtures/configs/extensions_custom_plugin.yaml
@@ -1,0 +1,22 @@
+plugins:
+  - name: "ExtensionsCustomPlugin"
+    kind: "plugins.extensions_aware.ExtensionsCustomPlugin"
+    description: "Test plugin that reads labels and writes custom extensions"
+    author: "Test"
+    version: "0.1"
+    hooks:
+      - "tool_pre_invoke"
+    mode: "sequential"
+    priority: 10
+    capabilities:
+      - "read_labels"
+
+plugin_dirs:
+  - "./tests/unit/cpex/fixtures"
+
+plugin_settings:
+  parallel_execution_within_band: true
+  plugin_timeout: 30
+  fail_on_plugin_error: false
+  enable_plugin_api: true
+  plugin_health_check_interval: 60

--- a/tests/unit/cpex/fixtures/configs/extensions_label_plugin.yaml
+++ b/tests/unit/cpex/fixtures/configs/extensions_label_plugin.yaml
@@ -1,0 +1,23 @@
+plugins:
+  - name: "ExtensionsLabelPlugin"
+    kind: "plugins.extensions_aware.ExtensionsLabelPlugin"
+    description: "Test plugin that adds labels to extensions"
+    author: "Test"
+    version: "0.1"
+    hooks:
+      - "tool_pre_invoke"
+    mode: "sequential"
+    priority: 10
+    capabilities:
+      - "read_labels"
+      - "append_labels"
+
+plugin_dirs:
+  - "./tests/unit/cpex/fixtures"
+
+plugin_settings:
+  parallel_execution_within_band: true
+  plugin_timeout: 30
+  fail_on_plugin_error: false
+  enable_plugin_api: true
+  plugin_health_check_interval: 60

--- a/tests/unit/cpex/fixtures/plugins/extensions_aware.py
+++ b/tests/unit/cpex/fixtures/plugins/extensions_aware.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""Test plugin that accepts extensions as a third parameter.
+
+Used to test the accepts_extensions=True path through
+_execute_with_timeout in the PluginManager.
+"""
+
+from cpex.framework import Plugin
+from cpex.framework.decorator import hook
+from cpex.framework.extensions.extensions import Extensions
+from cpex.framework.hooks.tools import ToolPreInvokePayload
+from cpex.framework.models import PluginContext, PluginResult
+
+
+class ExtensionsAwarePlugin(Plugin):
+    """A plugin that receives and uses filtered extensions."""
+
+    @hook("tool_pre_invoke")
+    async def tool_pre_invoke(
+        self,
+        payload: ToolPreInvokePayload,
+        context: PluginContext,
+        extensions: Extensions,
+    ) -> PluginResult:
+        """Check extensions for required role. Denies if role missing."""
+        if extensions and extensions.security and extensions.security.subject:
+            roles = extensions.security.subject.roles or frozenset()
+            if "required_role" in roles:
+                return PluginResult(continue_processing=True)
+
+        # Allow if no extensions provided (backward compat)
+        if extensions is None:
+            return PluginResult(continue_processing=True)
+
+        return PluginResult(continue_processing=True)
+
+
+class ExtensionsLabelPlugin(Plugin):
+    """A plugin that reads labels from extensions and adds a label."""
+
+    @hook("tool_pre_invoke")
+    async def tool_pre_invoke(
+        self,
+        payload: ToolPreInvokePayload,
+        context: PluginContext,
+        extensions: Extensions,
+    ) -> PluginResult:
+        """If extensions have security, add 'PLUGIN_TOUCHED' label."""
+        if extensions and extensions.security:
+            new_labels = extensions.security.labels | frozenset({"PLUGIN_TOUCHED"})
+            new_security = extensions.security.model_copy(update={"labels": new_labels})
+            modified_ext = extensions.model_copy(update={"security": new_security})
+            return PluginResult(
+                continue_processing=True,
+                modified_extensions=modified_ext,
+            )
+        return PluginResult(continue_processing=True)
+
+
+class ExtensionsCustomPlugin(Plugin):
+    """A plugin that reads labels and writes to custom extensions."""
+
+    @hook("tool_pre_invoke")
+    async def tool_pre_invoke(
+        self,
+        payload: ToolPreInvokePayload,
+        context: PluginContext,
+        extensions: Extensions,
+    ) -> PluginResult:
+        """Read labels, write observation to custom extensions."""
+        pii_detected = False
+        if extensions and extensions.security:
+            pii_detected = "PII" in extensions.security.labels
+
+        custom = dict(extensions.custom) if extensions and extensions.custom else {}
+        custom["pii_detected"] = pii_detected
+        modified_ext = extensions.model_copy(update={"custom": custom})
+        return PluginResult(
+            continue_processing=True,
+            modified_extensions=modified_ext,
+        )

--- a/tests/unit/cpex/framework/cmf/test_message.py
+++ b/tests/unit/cpex/framework/cmf/test_message.py
@@ -1,0 +1,603 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/cpex/framework/cmf/test_message.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Unit tests for CMF message models.
+"""
+
+# Standard
+from typing import Any
+
+# Third-Party
+import pytest
+
+# First-Party
+from cpex.framework.cmf.message import (
+    AudioContentPart,
+    AudioSource,
+    Channel,
+    ContentPart,
+    ContentType,
+    DocumentContentPart,
+    DocumentSource,
+    ImageContentPart,
+    ImageSource,
+    Message,
+    PromptRequest,
+    PromptRequestContentPart,
+    PromptResult,
+    PromptResultContentPart,
+    Resource,
+    ResourceContentPart,
+    ResourceReference,
+    ResourceRefContentPart,
+    ResourceType,
+    Role,
+    TextContent,
+    ThinkingContent,
+    ToolCall,
+    ToolCallContentPart,
+    ToolResult,
+    ToolResultContentPart,
+    VideoContentPart,
+    VideoSource,
+)
+
+
+# ---------------------------------------------------------------------------
+# Enum Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRole:
+    """Tests for the Role enum."""
+
+    def test_values(self):
+        assert Role.SYSTEM.value == "system"
+        assert Role.DEVELOPER.value == "developer"
+        assert Role.USER.value == "user"
+        assert Role.ASSISTANT.value == "assistant"
+        assert Role.TOOL.value == "tool"
+
+    def test_from_string(self):
+        assert Role("user") == Role.USER
+        assert Role("assistant") == Role.ASSISTANT
+
+    def test_invalid_value(self):
+        with pytest.raises(ValueError):
+            Role("invalid")
+
+    def test_member_count(self):
+        assert len(Role) == 5
+
+
+class TestChannel:
+    """Tests for the Channel enum."""
+
+    def test_values(self):
+        assert Channel.ANALYSIS.value == "analysis"
+        assert Channel.COMMENTARY.value == "commentary"
+        assert Channel.FINAL.value == "final"
+
+    def test_from_string(self):
+        assert Channel("final") == Channel.FINAL
+
+    def test_member_count(self):
+        assert len(Channel) == 3
+
+
+class TestContentType:
+    """Tests for the ContentType enum."""
+
+    def test_all_types_present(self):
+        expected = {
+            "text", "thinking", "tool_call", "tool_result",
+            "resource", "resource_ref", "prompt_request", "prompt_result",
+            "image", "video", "audio", "document",
+        }
+        assert {ct.value for ct in ContentType} == expected
+
+    def test_member_count(self):
+        assert len(ContentType) == 12
+
+
+class TestResourceType:
+    """Tests for the ResourceType enum."""
+
+    def test_all_types_present(self):
+        expected = {"file", "blob", "uri", "database", "api", "memory", "artifact"}
+        assert {rt.value for rt in ResourceType} == expected
+
+    def test_member_count(self):
+        assert len(ResourceType) == 7
+
+
+# ---------------------------------------------------------------------------
+# ContentPart Base Class Tests
+# ---------------------------------------------------------------------------
+
+
+class TestContentPart:
+    """Tests for the ContentPart base class."""
+
+    def test_subclass_relationship(self):
+        part = TextContent(text="hello")
+        assert isinstance(part, ContentPart)
+
+    def test_wrapper_subclass_relationship(self):
+        part = ToolCallContentPart(
+            content=ToolCall(tool_call_id="tc1", name="test"),
+        )
+        assert isinstance(part, ContentPart)
+
+    def test_frozen(self):
+        part = TextContent(text="hello")
+        with pytest.raises(Exception):
+            part.text = "world"
+
+
+# ---------------------------------------------------------------------------
+# Domain Object Tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolCallDomain:
+    """Tests for the ToolCall domain object."""
+
+    def test_creation(self):
+        call = ToolCall(
+            tool_call_id="tc_001",
+            name="get_user",
+            arguments={"user_id": "123"},
+        )
+        assert call.tool_call_id == "tc_001"
+        assert call.name == "get_user"
+        assert call.arguments == {"user_id": "123"}
+
+    def test_default_arguments(self):
+        call = ToolCall(tool_call_id="tc_002", name="list_users")
+        assert call.arguments == {}
+
+    def test_default_namespace(self):
+        call = ToolCall(tool_call_id="tc_003", name="test")
+        assert call.namespace is None
+
+    def test_with_namespace(self):
+        call = ToolCall(
+            tool_call_id="tc_004",
+            name="get_user",
+            namespace="user-service",
+        )
+        assert call.namespace == "user-service"
+
+    def test_frozen(self):
+        call = ToolCall(tool_call_id="tc_005", name="test")
+        with pytest.raises(Exception):
+            call.name = "other"
+
+
+class TestToolResultDomain:
+    """Tests for the ToolResult domain object."""
+
+    def test_creation(self):
+        result = ToolResult(
+            tool_call_id="tc_001",
+            tool_name="get_user",
+            content={"name": "Alice"},
+        )
+        assert result.tool_call_id == "tc_001"
+        assert result.tool_name == "get_user"
+        assert result.content == {"name": "Alice"}
+        assert result.is_error is False
+
+    def test_error_result(self):
+        result = ToolResult(
+            tool_call_id="tc_002",
+            tool_name="fail_tool",
+            content="Something went wrong",
+            is_error=True,
+        )
+        assert result.is_error is True
+
+    def test_default_content(self):
+        result = ToolResult(tool_call_id="tc_003", tool_name="test")
+        assert result.content is None
+        assert result.is_error is False
+
+
+class TestImageSourceDomain:
+    """Tests for the ImageSource domain object."""
+
+    def test_url_image(self):
+        img = ImageSource(type="url", data="https://example.com/photo.jpg")
+        assert img.type == "url"
+        assert img.media_type is None
+
+    def test_base64_image(self):
+        img = ImageSource(
+            type="base64",
+            data="iVBORw0KGgo...",
+            media_type="image/png",
+        )
+        assert img.type == "base64"
+        assert img.media_type == "image/png"
+
+
+class TestVideoSourceDomain:
+    """Tests for the VideoSource domain object."""
+
+    def test_creation(self):
+        vid = VideoSource(type="url", data="https://example.com/clip.mp4")
+        assert vid.duration_ms is None
+
+    def test_with_duration(self):
+        vid = VideoSource(
+            type="url",
+            data="https://example.com/clip.mp4",
+            duration_ms=30000,
+        )
+        assert vid.duration_ms == 30000
+
+
+class TestAudioSourceDomain:
+    """Tests for the AudioSource domain object."""
+
+    def test_creation(self):
+        aud = AudioSource(type="url", data="https://example.com/track.mp3")
+        assert aud.type == "url"
+
+
+class TestDocumentSourceDomain:
+    """Tests for the DocumentSource domain object."""
+
+    def test_creation(self):
+        doc = DocumentSource(
+            type="base64",
+            data="JVBERi0xLjQ...",
+            media_type="application/pdf",
+            title="Annual Report",
+        )
+        assert doc.title == "Annual Report"
+
+
+class TestResourceDomain:
+    """Tests for the Resource domain object."""
+
+    def test_creation(self):
+        res = Resource(
+            resource_request_id="rr_001",
+            uri="file:///data/report.csv",
+            name="Q4 Report",
+            resource_type=ResourceType.FILE,
+            content="col1,col2\n1,2",
+            mime_type="text/csv",
+        )
+        assert res.uri == "file:///data/report.csv"
+        assert res.resource_type == ResourceType.FILE
+
+    def test_minimal_creation(self):
+        res = Resource(
+            resource_request_id="rr_002",
+            uri="db://users/42",
+            resource_type=ResourceType.DATABASE,
+        )
+        assert res.name is None
+        assert res.content is None
+        assert res.blob is None
+
+    def test_blob_resource(self):
+        res = Resource(
+            resource_request_id="rr_003",
+            uri="blob://data",
+            resource_type=ResourceType.BLOB,
+            blob=b"\x00\x01\x02",
+        )
+        assert res.blob == b"\x00\x01\x02"
+
+
+class TestResourceReferenceDomain:
+    """Tests for the ResourceReference domain object."""
+
+    def test_creation(self):
+        ref = ResourceReference(
+            resource_request_id="rr_004",
+            uri="file:///path/to/file.txt",
+            resource_type=ResourceType.FILE,
+        )
+        assert ref.uri == "file:///path/to/file.txt"
+
+    def test_with_range(self):
+        ref = ResourceReference(
+            resource_request_id="rr_005",
+            uri="file:///code.py",
+            resource_type=ResourceType.FILE,
+            range_start=10,
+            range_end=50,
+        )
+        assert ref.range_start == 10
+        assert ref.range_end == 50
+
+    def test_with_selector(self):
+        ref = ResourceReference(
+            resource_request_id="rr_006",
+            uri="api://data",
+            resource_type=ResourceType.API,
+            selector="$.results[0]",
+        )
+        assert ref.selector == "$.results[0]"
+
+
+class TestPromptRequestDomain:
+    """Tests for the PromptRequest domain object."""
+
+    def test_creation(self):
+        req = PromptRequest(
+            prompt_request_id="pr_001",
+            name="summarize",
+            arguments={"text": "Long document..."},
+        )
+        assert req.name == "summarize"
+        assert req.arguments == {"text": "Long document..."}
+
+    def test_defaults(self):
+        req = PromptRequest(prompt_request_id="pr_002", name="test")
+        assert req.arguments == {}
+        assert req.server_id is None
+
+
+class TestPromptResultDomain:
+    """Tests for the PromptResult domain object."""
+
+    def test_creation(self):
+        result = PromptResult(
+            prompt_request_id="pr_001",
+            prompt_name="summarize",
+            content="This document discusses...",
+        )
+        assert result.prompt_name == "summarize"
+        assert result.is_error is False
+
+    def test_error_result(self):
+        result = PromptResult(
+            prompt_request_id="pr_002",
+            prompt_name="fail_prompt",
+            is_error=True,
+            error_message="Template not found",
+        )
+        assert result.is_error is True
+        assert result.error_message == "Template not found"
+
+    def test_defaults(self):
+        result = PromptResult(prompt_request_id="pr_003", prompt_name="test")
+        assert result.messages == []
+        assert result.content is None
+
+
+# ---------------------------------------------------------------------------
+# ContentPart Wrapper Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTextContent:
+    """Tests for TextContent."""
+
+    def test_creation(self):
+        part = TextContent(text="Hello, world!")
+        assert part.content_type == ContentType.TEXT
+        assert part.text == "Hello, world!"
+
+    def test_frozen(self):
+        part = TextContent(text="original")
+        with pytest.raises(Exception):
+            part.text = "modified"
+
+    def test_model_copy(self):
+        part = TextContent(text="original")
+        modified = part.model_copy(update={"text": "updated"})
+        assert part.text == "original"
+        assert modified.text == "updated"
+
+
+class TestThinkingContent:
+    """Tests for ThinkingContent."""
+
+    def test_creation(self):
+        part = ThinkingContent(text="Let me analyze this...")
+        assert part.content_type == ContentType.THINKING
+        assert part.text == "Let me analyze this..."
+
+
+class TestToolCallContentPart:
+    """Tests for ToolCallContentPart wrapper."""
+
+    def test_creation(self):
+        call = ToolCall(tool_call_id="tc_001", name="get_user", arguments={"user_id": "123"})
+        part = ToolCallContentPart(content=call)
+        assert part.content_type == ContentType.TOOL_CALL
+        assert part.content.name == "get_user"
+        assert part.content.arguments == {"user_id": "123"}
+
+    def test_frozen(self):
+        part = ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="test"))
+        with pytest.raises(Exception):
+            part.content = ToolCall(tool_call_id="tc2", name="other")
+
+
+class TestToolResultContentPart:
+    """Tests for ToolResultContentPart wrapper."""
+
+    def test_creation(self):
+        result = ToolResult(tool_call_id="tc_001", tool_name="get_user", content={"name": "Alice"})
+        part = ToolResultContentPart(content=result)
+        assert part.content_type == ContentType.TOOL_RESULT
+        assert part.content.tool_name == "get_user"
+        assert part.content.is_error is False
+
+
+class TestResourceContentPart:
+    """Tests for ResourceContentPart wrapper."""
+
+    def test_creation(self):
+        res = Resource(
+            resource_request_id="rr_001",
+            uri="file:///data/report.csv",
+            resource_type=ResourceType.FILE,
+        )
+        part = ResourceContentPart(content=res)
+        assert part.content_type == ContentType.RESOURCE
+        assert part.content.uri == "file:///data/report.csv"
+
+
+class TestImageContentPart:
+    """Tests for ImageContentPart wrapper."""
+
+    def test_creation(self):
+        img = ImageSource(type="url", data="https://example.com/photo.jpg")
+        part = ImageContentPart(content=img)
+        assert part.content_type == ContentType.IMAGE
+        assert part.content.type == "url"
+
+
+class TestDocumentContentPart:
+    """Tests for DocumentContentPart wrapper."""
+
+    def test_creation(self):
+        doc = DocumentSource(
+            type="base64", data="JVBERi0xLjQ...",
+            media_type="application/pdf", title="Annual Report",
+        )
+        part = DocumentContentPart(content=doc)
+        assert part.content_type == ContentType.DOCUMENT
+        assert part.content.title == "Annual Report"
+
+
+# ---------------------------------------------------------------------------
+# Message Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMessage:
+    """Tests for the Message model."""
+
+    def test_simple_message(self):
+        msg = Message(
+            role=Role.USER,
+            content=[TextContent(text="Hello")],
+        )
+        assert msg.role == Role.USER
+        assert msg.schema_version == "2.0"
+        assert msg.channel is None
+        assert msg.extensions is None
+        assert len(msg.content) == 1
+
+    def test_empty_content(self):
+        msg = Message(role=Role.SYSTEM)
+        assert msg.content == []
+
+    def test_multi_part_message(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[
+                ThinkingContent(text="Reasoning..."),
+                TextContent(text="Here is the answer."),
+                ToolCallContentPart(
+                    content=ToolCall(tool_call_id="tc_001", name="search", arguments={"q": "test"}),
+                ),
+            ],
+        )
+        assert len(msg.content) == 3
+        assert msg.content[0].content_type == ContentType.THINKING
+        assert msg.content[1].content_type == ContentType.TEXT
+        assert msg.content[2].content_type == ContentType.TOOL_CALL
+
+    def test_with_channel(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[TextContent(text="Final answer.")],
+            channel=Channel.FINAL,
+        )
+        assert msg.channel == Channel.FINAL
+
+    def test_frozen(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="Hi")])
+        with pytest.raises(Exception):
+            msg.role = Role.ASSISTANT
+
+    def test_model_copy(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="Hi")])
+        updated = msg.model_copy(update={"channel": Channel.FINAL})
+        assert msg.channel is None
+        assert updated.channel == Channel.FINAL
+        assert updated.role == Role.USER
+
+    def test_deserialization_from_dict(self):
+        msg = Message.model_validate({
+            "role": "user",
+            "content": [
+                {"content_type": "text", "text": "Hello"},
+                {"content_type": "tool_call", "content": {"tool_call_id": "tc1", "name": "foo", "arguments": {}}},
+            ],
+        })
+        assert msg.role == Role.USER
+        assert len(msg.content) == 2
+        assert isinstance(msg.content[0], TextContent)
+        assert isinstance(msg.content[1], ToolCallContentPart)
+
+    def test_deserialization_all_content_types(self):
+        msg = Message.model_validate({
+            "role": "assistant",
+            "content": [
+                {"content_type": "text", "text": "hi"},
+                {"content_type": "thinking", "text": "hmm"},
+                {"content_type": "tool_call", "content": {"tool_call_id": "t1", "name": "x", "arguments": {}}},
+                {"content_type": "tool_result", "content": {"tool_call_id": "t1", "tool_name": "x"}},
+                {"content_type": "resource", "content": {"resource_request_id": "r1", "uri": "file:///a", "resource_type": "file"}},
+                {"content_type": "resource_ref", "content": {"resource_request_id": "r2", "uri": "db://b", "resource_type": "database"}},
+                {"content_type": "prompt_request", "content": {"prompt_request_id": "p1", "name": "s"}},
+                {"content_type": "prompt_result", "content": {"prompt_request_id": "p1", "prompt_name": "s"}},
+                {"content_type": "image", "content": {"type": "url", "data": "http://img"}},
+                {"content_type": "video", "content": {"type": "url", "data": "http://vid"}},
+                {"content_type": "audio", "content": {"type": "url", "data": "http://aud"}},
+                {"content_type": "document", "content": {"type": "url", "data": "http://doc"}},
+            ],
+        })
+        assert len(msg.content) == 12
+        expected_types = [
+            TextContent, ThinkingContent, ToolCallContentPart, ToolResultContentPart,
+            ResourceContentPart, ResourceRefContentPart, PromptRequestContentPart, PromptResultContentPart,
+            ImageContentPart, VideoContentPart, AudioContentPart, DocumentContentPart,
+        ]
+        for part, expected in zip(msg.content, expected_types):
+            assert isinstance(part, expected), f"Expected {expected.__name__}, got {type(part).__name__}"
+
+    def test_serialization_roundtrip(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[
+                TextContent(text="hello"),
+                ToolCallContentPart(
+                    content=ToolCall(tool_call_id="tc1", name="test", arguments={"a": 1}),
+                ),
+            ],
+        )
+        data = msg.model_dump()
+        restored = Message.model_validate(data)
+        assert restored.role == msg.role
+        assert len(restored.content) == 2
+        assert restored.content[0].text == "hello"
+        assert restored.content[1].content.name == "test"
+
+    def test_iter_views(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[
+                TextContent(text="hello"),
+                ToolCallContentPart(
+                    content=ToolCall(tool_call_id="tc1", name="test", arguments={}),
+                ),
+            ],
+        )
+        views = list(msg.iter_views())
+        assert len(views) == 2

--- a/tests/unit/cpex/framework/cmf/test_message.py
+++ b/tests/unit/cpex/framework/cmf/test_message.py
@@ -601,3 +601,125 @@ class TestMessage:
         )
         views = list(msg.iter_views())
         assert len(views) == 2
+
+
+# ---------------------------------------------------------------------------
+# Validation Tests
+# ---------------------------------------------------------------------------
+
+
+class TestResourceValidation:
+    """Tests for Resource model validators."""
+
+    def test_content_only(self):
+        res = Resource(
+            resource_request_id="r1", uri="file:///a.txt",
+            resource_type=ResourceType.FILE, content="hello",
+        )
+        assert res.content == "hello"
+        assert res.blob is None
+
+    def test_blob_only(self):
+        res = Resource(
+            resource_request_id="r1", uri="file:///a.bin",
+            resource_type=ResourceType.FILE, blob=b"\x00\x01",
+        )
+        assert res.blob == b"\x00\x01"
+        assert res.content is None
+
+    def test_neither_content_nor_blob(self):
+        res = Resource(
+            resource_request_id="r1", uri="file:///a.txt",
+            resource_type=ResourceType.FILE,
+        )
+        assert res.content is None
+        assert res.blob is None
+
+    def test_content_and_blob_raises(self):
+        with pytest.raises(ValueError, match="cannot have both"):
+            Resource(
+                resource_request_id="r1", uri="file:///a.txt",
+                resource_type=ResourceType.FILE,
+                content="hello", blob=b"\x00",
+            )
+
+
+class TestResourceReferenceValidation:
+    """Tests for ResourceReference range validators."""
+
+    def test_valid_range(self):
+        ref = ResourceReference(
+            resource_request_id="r1", uri="file:///a.txt",
+            resource_type=ResourceType.FILE,
+            range_start=10, range_end=20,
+        )
+        assert ref.range_start == 10
+        assert ref.range_end == 20
+
+    def test_equal_range(self):
+        ref = ResourceReference(
+            resource_request_id="r1", uri="file:///a.txt",
+            resource_type=ResourceType.FILE,
+            range_start=5, range_end=5,
+        )
+        assert ref.range_start == ref.range_end
+
+    def test_invalid_range_raises(self):
+        with pytest.raises(ValueError, match="range_end.*must be >= range_start"):
+            ResourceReference(
+                resource_request_id="r1", uri="file:///a.txt",
+                resource_type=ResourceType.FILE,
+                range_start=20, range_end=10,
+            )
+
+    def test_start_only(self):
+        ref = ResourceReference(
+            resource_request_id="r1", uri="file:///a.txt",
+            resource_type=ResourceType.FILE, range_start=5,
+        )
+        assert ref.range_start == 5
+        assert ref.range_end is None
+
+    def test_end_only(self):
+        ref = ResourceReference(
+            resource_request_id="r1", uri="file:///a.txt",
+            resource_type=ResourceType.FILE, range_end=10,
+        )
+        assert ref.range_start is None
+        assert ref.range_end == 10
+
+
+class TestDiscriminator:
+    """Tests for content_type discriminator function."""
+
+    def test_missing_content_type_in_dict_raises(self):
+        with pytest.raises(Exception):
+            Message(role=Role.USER, content=[{"text": "hello"}])
+
+    def test_invalid_content_type_in_dict_raises(self):
+        with pytest.raises(Exception):
+            Message(role=Role.USER, content=[{"content_type": "bogus", "text": "hello"}])
+
+
+class TestMediaSourceLiteral:
+    """Tests that media source type fields enforce Literal['url', 'base64']."""
+
+    def test_image_source_valid_types(self):
+        assert ImageSource(type="url", data="https://x.com/a.jpg").type == "url"
+        assert ImageSource(type="base64", data="abc").type == "base64"
+
+    def test_image_source_invalid_type(self):
+        with pytest.raises(Exception):
+            ImageSource(type="ftp", data="abc")
+
+    def test_video_source_invalid_type(self):
+        with pytest.raises(Exception):
+            VideoSource(type="file", data="abc")
+
+    def test_audio_source_invalid_type(self):
+        with pytest.raises(Exception):
+            AudioSource(type="stream", data="abc")
+
+    def test_document_source_invalid_type(self):
+        with pytest.raises(Exception):
+            DocumentSource(type="unknown", data="abc")

--- a/tests/unit/cpex/framework/cmf/test_message.py
+++ b/tests/unit/cpex/framework/cmf/test_message.py
@@ -489,7 +489,6 @@ class TestMessage:
         assert msg.role == Role.USER
         assert msg.schema_version == "2.0"
         assert msg.channel is None
-        assert msg.extensions is None
         assert len(msg.content) == 1
 
     def test_empty_content(self):

--- a/tests/unit/cpex/framework/cmf/test_view.py
+++ b/tests/unit/cpex/framework/cmf/test_view.py
@@ -87,8 +87,8 @@ def simple_assistant_msg():
 
 @pytest.fixture
 def full_msg():
-    """A message with full extensions populated."""
-    return Message(
+    """A message and extensions (separated per CMF design)."""
+    msg = Message(
         role=Role.ASSISTANT,
         content=[
             ToolCallContentPart(
@@ -100,58 +100,59 @@ def full_msg():
                 ),
             ),
         ],
-        extensions=Extensions(
-            request=RequestExtension(
-                environment="production",
-                request_id="req-001",
+    )
+    ext = Extensions(
+        request=RequestExtension(
+            environment="production",
+            request_id="req-001",
+        ),
+        agent=AgentExtension(
+            input="Show me Alice's compensation",
+            session_id="sess-001",
+            conversation_id="conv-001",
+            turn=2,
+            agent_id="main-agent",
+            parent_agent_id="orchestrator",
+        ),
+        http=HttpExtension(
+            headers={
+                "Authorization": "Bearer secret-token",
+                "Cookie": "session=abc",
+                "X-Request-ID": "req-001",
+                "Content-Type": "application/json",
+            },
+        ),
+        security=SecurityExtension(
+            labels=frozenset({"CONFIDENTIAL"}),
+            classification="confidential",
+            subject=SubjectExtension(
+                id="user-alice",
+                type=SubjectType.USER,
+                roles=frozenset({"admin", "hr-manager"}),
+                permissions=frozenset({"read:compensation", "tools.execute"}),
+                teams=frozenset({"hr-team"}),
             ),
-            agent=AgentExtension(
-                input="Show me Alice's compensation",
-                session_id="sess-001",
-                conversation_id="conv-001",
-                turn=2,
-                agent_id="main-agent",
-                parent_agent_id="orchestrator",
-            ),
-            http=HttpExtension(
-                headers={
-                    "Authorization": "Bearer secret-token",
-                    "Cookie": "session=abc",
-                    "X-Request-ID": "req-001",
-                    "Content-Type": "application/json",
-                },
-            ),
-            security=SecurityExtension(
-                labels=frozenset({"CONFIDENTIAL"}),
-                classification="confidential",
-                subject=SubjectExtension(
-                    id="user-alice",
-                    type=SubjectType.USER,
-                    roles=frozenset({"admin", "hr-manager"}),
-                    permissions=frozenset({"read:compensation", "tools.execute"}),
-                    teams=frozenset({"hr-team"}),
+            objects={
+                "get_compensation": ObjectSecurityProfile(
+                    managed_by="tool",
+                    permissions=["read:compensation"],
+                    trust_domain="internal",
+                    data_scope=["salary", "bonus"],
                 ),
-                objects={
-                    "get_compensation": ObjectSecurityProfile(
-                        managed_by="tool",
-                        permissions=["read:compensation"],
-                        trust_domain="internal",
-                        data_scope=["salary", "bonus"],
+            },
+            data={
+                "get_compensation": DataPolicy(
+                    apply_labels=["PII", "financial"],
+                    denied_actions=["export", "forward", "log_raw"],
+                    retention=RetentionPolicy(
+                        policy="session",
+                        max_age_seconds=3600,
                     ),
-                },
-                data={
-                    "get_compensation": DataPolicy(
-                        apply_labels=["PII", "financial"],
-                        denied_actions=["export", "forward", "log_raw"],
-                        retention=RetentionPolicy(
-                            policy="session",
-                            max_age_seconds=3600,
-                        ),
-                    ),
-                },
-            ),
+                ),
+            },
         ),
     )
+    return msg, ext
 
 
 # ---------------------------------------------------------------------------
@@ -603,38 +604,38 @@ class TestFlatAccessors:
     """Tests for capability-gated flat accessors."""
 
     def test_base_tier(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert view.environment == "production"
         assert view.request_id == "req-001"
 
     def test_subject(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert view.subject.id == "user-alice"
         assert view.subject.type == SubjectType.USER
 
     def test_roles(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert "admin" in view.roles
         assert "hr-manager" in view.roles
 
     def test_permissions(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert "read:compensation" in view.permissions
 
     def test_teams(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert "hr-team" in view.teams
 
     def test_headers(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert view.headers["Content-Type"] == "application/json"
 
     def test_labels(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert "CONFIDENTIAL" in view.labels
 
     def test_agent_accessors(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert view.agent_input == "Show me Alice's compensation"
         assert view.session_id == "sess-001"
         assert view.conversation_id == "conv-001"
@@ -643,7 +644,7 @@ class TestFlatAccessors:
         assert view.parent_agent_id == "orchestrator"
 
     def test_object_profile(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert view.object is not None
         assert view.object.managed_by == "tool"
         assert view.object.permissions == ["read:compensation"]
@@ -651,7 +652,7 @@ class TestFlatAccessors:
         assert view.object.data_scope == ["salary", "bonus"]
 
     def test_data_policy(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert view.data_policy is not None
         assert "PII" in view.data_policy.apply_labels
         assert "export" in view.data_policy.denied_actions
@@ -684,13 +685,13 @@ class TestFlatAccessors:
                 ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="tool_a", arguments={})),
                 ToolCallContentPart(content=ToolCall(tool_call_id="tc2", name="tool_b", arguments={})),
             ],
-            extensions=Extensions(
-                security=SecurityExtension(
-                    objects={"tool_a": ObjectSecurityProfile(managed_by="host")},
-                ),
+        )
+        ext = Extensions(
+            security=SecurityExtension(
+                objects={"tool_a": ObjectSecurityProfile(managed_by="host")},
             ),
         )
-        views = list(iter_views(msg))
+        views = list(iter_views(msg, extensions=ext))
         assert views[0].object is not None
         assert views[0].object.managed_by == "host"
         assert views[1].object is None
@@ -705,44 +706,44 @@ class TestHelperMethods:
     """Tests for helper methods on MessageView."""
 
     def test_has_role(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert view.has_role("admin") is True
         assert view.has_role("viewer") is False
 
     def test_has_permission(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert view.has_permission("read:compensation") is True
         assert view.has_permission("write:users") is False
 
     def test_has_label(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert view.has_label("CONFIDENTIAL") is True
         assert view.has_label("SECRET") is False
 
     def test_has_header(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert view.has_header("Content-Type") is True
         assert view.has_header("content-type") is True
         assert view.has_header("X-Missing") is False
 
     def test_get_header_case_insensitive(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert view.get_header("content-type") == "application/json"
         assert view.get_header("CONTENT-TYPE") == "application/json"
 
     def test_get_header_default(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert view.get_header("X-Missing") is None
         assert view.get_header("X-Missing", "fallback") == "fallback"
 
     def test_get_arg(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert view.get_arg("employee_id") == "emp-42"
         assert view.get_arg("missing") is None
         assert view.get_arg("missing", "default") == "default"
 
     def test_has_arg(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert view.has_arg("employee_id") is True
         assert view.has_arg("missing") is False
 
@@ -752,7 +753,7 @@ class TestHelperMethods:
         assert view.has_arg("anything") is False
 
     def test_matches_uri_pattern(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         assert view.matches_uri_pattern("tool://hr-server/*") is True
         assert view.matches_uri_pattern("tool://hr-server/get_*") is True
         assert view.matches_uri_pattern("tool://other/*") is False
@@ -917,7 +918,7 @@ class TestSerialization:
         assert d["uri"] == "tool://_/execute_sql"
 
     def test_to_dict_strips_sensitive_headers(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         d = view.to_dict()
         headers = d["extensions"].get("headers", {})
         assert "Authorization" not in headers
@@ -925,7 +926,7 @@ class TestSerialization:
         assert "Content-Type" in headers
 
     def test_to_dict_includes_extensions(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         d = view.to_dict()
         ext = d["extensions"]
         assert ext["environment"] == "production"
@@ -942,7 +943,7 @@ class TestSerialization:
         assert "size_bytes" not in d
 
     def test_to_dict_exclude_context(self, full_msg):
-        view = list(iter_views(full_msg))[0]
+        view = list(iter_views(full_msg[0], extensions=full_msg[1]))[0]
         d = view.to_dict(include_context=False)
         assert "extensions" not in d
 

--- a/tests/unit/cpex/framework/cmf/test_view.py
+++ b/tests/unit/cpex/framework/cmf/test_view.py
@@ -463,7 +463,7 @@ class TestAction:
             (ResourceContentPart(content=Resource(resource_request_id="r", uri="f:///a", resource_type=ResourceType.FILE)), Role.TOOL, ViewAction.READ),
             (ResourceRefContentPart(content=ResourceReference(resource_request_id="r", uri="f:///a", resource_type=ResourceType.FILE)), Role.ASSISTANT, ViewAction.READ),
             (PromptRequestContentPart(content=PromptRequest(prompt_request_id="p", name="s")), Role.ASSISTANT, ViewAction.INVOKE),
-            (PromptResultContentPart(content=PromptResult(prompt_request_id="p", prompt_name="s")), Role.TOOL, ViewAction.GENERATE),
+            (PromptResultContentPart(content=PromptResult(prompt_request_id="p", prompt_name="s")), Role.TOOL, ViewAction.RECEIVE),
             (ImageContentPart(content=ImageSource(type="url", data="http://img")), Role.USER, ViewAction.SEND),
         ]
         for part, role, expected_action in pairs:
@@ -538,10 +538,11 @@ class TestDirection:
         view = list(iter_views(msg))[0]
         assert view.is_pre is True
 
-    def test_tool_text_is_pre(self):
+    def test_tool_text_is_post(self):
         msg = Message(role=Role.TOOL, content=[TextContent(text="result text")])
         view = list(iter_views(msg))[0]
-        assert view.is_pre is True
+        assert view.is_pre is False
+        assert view.is_post is True
 
 
 # ---------------------------------------------------------------------------
@@ -817,7 +818,11 @@ class TestProperties:
             role=Role.TOOL,
             content=[PromptResultContentPart(content=PromptResult(
                 prompt_request_id="p1", prompt_name="s",
-                messages=["m1", "m2"], is_error=False,
+                messages=[
+                    Message(role=Role.USER, content=[TextContent(text="m1")]),
+                    Message(role=Role.ASSISTANT, content=[TextContent(text="m2")]),
+                ],
+                is_error=False,
             ))],
         )
         view = list(iter_views(msg))[0]
@@ -979,3 +984,191 @@ class TestRepr:
         r = repr(view)
         assert "tool_call" in r
         assert "tool://_/test" in r
+
+
+# ---------------------------------------------------------------------------
+# Hook property
+# ---------------------------------------------------------------------------
+
+
+class TestHookProperty:
+    """Tests for the hook property on MessageView."""
+
+    def test_hook_none_by_default(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.hook is None
+
+    def test_hook_passed_through(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg, hook="llm_input"))[0]
+        assert view.hook == "llm_input"
+
+    def test_hook_in_to_dict(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg, hook="tool_pre_invoke"))[0]
+        d = view.to_dict()
+        assert d["hook"] == "tool_pre_invoke"
+
+    def test_hook_absent_from_to_dict_when_none(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        d = view.to_dict()
+        assert "hook" not in d
+
+
+# ---------------------------------------------------------------------------
+# Content edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestContentEdgeCases:
+    """Tests for content property edge cases (json fallbacks)."""
+
+    def test_tool_call_non_serializable_args(self):
+        """Tool call with non-JSON-serializable arguments falls back to str()."""
+        tc = ToolCall(tool_call_id="tc1", name="test", arguments={"key": "val"})
+        msg = Message(role=Role.ASSISTANT, content=[ToolCallContentPart(content=tc)])
+        view = list(iter_views(msg))[0]
+        assert view.content is not None
+
+    def test_prompt_request_content(self):
+        pr = PromptRequest(
+            prompt_request_id="pr1", name="test",
+            arguments={"key": "val"},
+        )
+        msg = Message(role=Role.USER, content=[PromptRequestContentPart(content=pr)])
+        view = list(iter_views(msg))[0]
+        assert '"key"' in view.content
+
+    def test_prompt_result_content(self):
+        pr = PromptResult(
+            prompt_request_id="pr1", prompt_name="test",
+            content="rendered text",
+        )
+        msg = Message(role=Role.TOOL, content=[PromptResultContentPart(content=pr)])
+        view = list(iter_views(msg))[0]
+        assert view.content == "rendered text"
+
+    def test_resource_blob_size(self):
+        """Resource with blob but no content still reports size_bytes."""
+        res = Resource(
+            resource_request_id="r1", uri="file:///a.bin",
+            resource_type=ResourceType.FILE, blob=b"\x00\x01\x02",
+        )
+        msg = Message(role=Role.TOOL, content=[ResourceContentPart(content=res)])
+        view = list(iter_views(msg))[0]
+        assert view.content is None
+        assert view.size_bytes == 3
+
+    def test_resource_explicit_size(self):
+        """Resource with explicit size_bytes uses that value."""
+        res = Resource(
+            resource_request_id="r1", uri="file:///a.txt",
+            resource_type=ResourceType.FILE, content="hello",
+            size_bytes=999,
+        )
+        msg = Message(role=Role.TOOL, content=[ResourceContentPart(content=res)])
+        view = list(iter_views(msg))[0]
+        assert view.size_bytes == 999
+
+    def test_to_dict_no_content_with_blob_size(self):
+        """to_dict includes size_bytes even when content is None (blob path)."""
+        res = Resource(
+            resource_request_id="r1", uri="file:///a.bin",
+            resource_type=ResourceType.FILE, blob=b"\x00\x01",
+        )
+        msg = Message(role=Role.TOOL, content=[ResourceContentPart(content=res)])
+        view = list(iter_views(msg))[0]
+        d = view.to_dict()
+        assert "content" not in d
+        assert d["size_bytes"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Properties edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestPropertiesEdgeCases:
+    """Tests for properties on various view kinds."""
+
+    def test_resource_properties(self):
+        res = Resource(
+            resource_request_id="r1", uri="file:///a.txt",
+            resource_type=ResourceType.FILE, content="hi",
+            version="v1", annotations={"label": "pii"},
+        )
+        msg = Message(role=Role.TOOL, content=[ResourceContentPart(content=res)])
+        view = list(iter_views(msg))[0]
+        props = view.properties
+        assert props["resource_type"] == "file"
+        assert props["version"] == "v1"
+        assert props["annotations"] == {"label": "pii"}
+
+    def test_tool_call_properties(self):
+        tc = ToolCall(
+            tool_call_id="tc1", name="test",
+            namespace="ns", arguments={},
+        )
+        msg = Message(role=Role.ASSISTANT, content=[ToolCallContentPart(content=tc)])
+        view = list(iter_views(msg))[0]
+        props = view.properties
+        assert props["namespace"] == "ns"
+        assert props["tool_id"] == "tc1"
+
+    def test_tool_result_properties(self):
+        tr = ToolResult(
+            tool_call_id="tc1", tool_name="test",
+            content="result", is_error=True,
+        )
+        msg = Message(role=Role.TOOL, content=[ToolResultContentPart(content=tr)])
+        view = list(iter_views(msg))[0]
+        props = view.properties
+        assert props["is_error"] is True
+        assert props["tool_name"] == "test"
+
+    def test_prompt_request_properties(self):
+        pr = PromptRequest(
+            prompt_request_id="pr1", name="test",
+            server_id="srv1",
+        )
+        msg = Message(role=Role.USER, content=[PromptRequestContentPart(content=pr)])
+        view = list(iter_views(msg))[0]
+        props = view.properties
+        assert props["server_id"] == "srv1"
+
+
+# ---------------------------------------------------------------------------
+# Headers immutability
+# ---------------------------------------------------------------------------
+
+
+class TestHeadersImmutability:
+    """Tests that headers returns a read-only mapping."""
+
+    def test_headers_not_mutable(self):
+        ext = Extensions(http=HttpExtension(headers={"Authorization": "Bearer tok"}))
+        msg = Message(
+            role=Role.USER,
+            content=[TextContent(text="hi")],
+            extensions=ext,
+        )
+        view = list(iter_views(msg))[0]
+        with pytest.raises(TypeError):
+            view.headers["new_key"] = "val"
+
+
+# ---------------------------------------------------------------------------
+# get_arg / has_arg
+# ---------------------------------------------------------------------------
+
+
+class TestArgHelpers:
+    """Tests for get_arg and has_arg."""
+
+    def test_get_arg_on_non_tool(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.get_arg("anything") is None
+        assert view.get_arg("anything", "fallback") == "fallback"

--- a/tests/unit/cpex/framework/cmf/test_view.py
+++ b/tests/unit/cpex/framework/cmf/test_view.py
@@ -1153,9 +1153,8 @@ class TestHeadersImmutability:
         msg = Message(
             role=Role.USER,
             content=[TextContent(text="hi")],
-            extensions=ext,
         )
-        view = list(iter_views(msg))[0]
+        view = list(iter_views(msg, extensions=ext))[0]
         with pytest.raises(TypeError):
             view.headers["new_key"] = "val"
 

--- a/tests/unit/cpex/framework/cmf/test_view.py
+++ b/tests/unit/cpex/framework/cmf/test_view.py
@@ -1,0 +1,981 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/cpex/framework/cmf/test_view.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Unit tests for MessageView.
+"""
+
+# Standard
+from typing import Any
+
+# Third-Party
+import pytest
+
+# First-Party
+from cpex.framework.cmf.message import (
+    AudioContentPart,
+    AudioSource,
+    DocumentContentPart,
+    DocumentSource,
+    ImageContentPart,
+    ImageSource,
+    Message,
+    PromptRequest,
+    PromptRequestContentPart,
+    PromptResult,
+    PromptResultContentPart,
+    Resource,
+    ResourceContentPart,
+    ResourceReference,
+    ResourceRefContentPart,
+    ResourceType,
+    Role,
+    TextContent,
+    ThinkingContent,
+    ToolCall,
+    ToolCallContentPart,
+    ToolResult,
+    ToolResultContentPart,
+    VideoContentPart,
+    VideoSource,
+)
+from cpex.framework.cmf.view import (
+    MessageView,
+    ViewAction,
+    ViewKind,
+    iter_views,
+)
+from cpex.framework.extensions.agent import AgentExtension
+from cpex.framework.extensions.extensions import Extensions
+from cpex.framework.extensions.http import HttpExtension
+from cpex.framework.extensions.request import RequestExtension
+from cpex.framework.extensions.security import (
+    DataPolicy,
+    ObjectSecurityProfile,
+    RetentionPolicy,
+    SecurityExtension,
+    SubjectExtension,
+    SubjectType,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def simple_assistant_msg():
+    """An assistant message with text, thinking, and a tool call."""
+    return Message(
+        role=Role.ASSISTANT,
+        content=[
+            ThinkingContent(text="User wants admin users."),
+            TextContent(text="Let me look that up."),
+            ToolCallContentPart(
+                content=ToolCall(
+                    tool_call_id="tc_001",
+                    name="execute_sql",
+                    arguments={"query": "SELECT * FROM users WHERE role='admin'"},
+                ),
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def full_msg():
+    """A message with full extensions populated."""
+    return Message(
+        role=Role.ASSISTANT,
+        content=[
+            ToolCallContentPart(
+                content=ToolCall(
+                    tool_call_id="tc_001",
+                    name="get_compensation",
+                    namespace="hr-server",
+                    arguments={"employee_id": "emp-42"},
+                ),
+            ),
+        ],
+        extensions=Extensions(
+            request=RequestExtension(
+                environment="production",
+                request_id="req-001",
+            ),
+            agent=AgentExtension(
+                input="Show me Alice's compensation",
+                session_id="sess-001",
+                conversation_id="conv-001",
+                turn=2,
+                agent_id="main-agent",
+                parent_agent_id="orchestrator",
+            ),
+            http=HttpExtension(
+                headers={
+                    "Authorization": "Bearer secret-token",
+                    "Cookie": "session=abc",
+                    "X-Request-ID": "req-001",
+                    "Content-Type": "application/json",
+                },
+            ),
+            security=SecurityExtension(
+                labels=frozenset({"CONFIDENTIAL"}),
+                classification="confidential",
+                subject=SubjectExtension(
+                    id="user-alice",
+                    type=SubjectType.USER,
+                    roles=frozenset({"admin", "hr-manager"}),
+                    permissions=frozenset({"read:compensation", "tools.execute"}),
+                    teams=frozenset({"hr-team"}),
+                ),
+                objects={
+                    "get_compensation": ObjectSecurityProfile(
+                        managed_by="tool",
+                        permissions=["read:compensation"],
+                        trust_domain="internal",
+                        data_scope=["salary", "bonus"],
+                    ),
+                },
+                data={
+                    "get_compensation": DataPolicy(
+                        apply_labels=["PII", "financial"],
+                        denied_actions=["export", "forward", "log_raw"],
+                        retention=RetentionPolicy(
+                            policy="session",
+                            max_age_seconds=3600,
+                        ),
+                    ),
+                },
+            ),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Enum Tests
+# ---------------------------------------------------------------------------
+
+
+class TestViewKind:
+    """Tests for ViewKind enum."""
+
+    def test_member_count(self):
+        assert len(ViewKind) == 12
+
+    def test_values_match_content_type(self):
+        from cpex.framework.cmf.message import ContentType
+
+        for ct in ContentType:
+            assert ct.value in [vk.value for vk in ViewKind]
+
+
+class TestViewAction:
+    """Tests for ViewAction enum."""
+
+    def test_member_count(self):
+        assert len(ViewAction) == 7
+
+    def test_values(self):
+        expected = {"read", "write", "execute", "invoke", "send", "receive", "generate"}
+        assert {va.value for va in ViewAction} == expected
+
+
+# ---------------------------------------------------------------------------
+# View Iteration
+# ---------------------------------------------------------------------------
+
+
+class TestIterViews:
+    """Tests for iter_views() and Message.iter_views()."""
+
+    def test_standalone_and_method_match(self, simple_assistant_msg):
+        standalone = list(iter_views(simple_assistant_msg))
+        method = list(simple_assistant_msg.iter_views())
+        assert len(standalone) == len(method) == 3
+
+    def test_view_count(self, simple_assistant_msg):
+        views = list(iter_views(simple_assistant_msg))
+        assert len(views) == 3
+
+    def test_view_kinds(self, simple_assistant_msg):
+        views = list(iter_views(simple_assistant_msg))
+        assert views[0].kind == ViewKind.THINKING
+        assert views[1].kind == ViewKind.TEXT
+        assert views[2].kind == ViewKind.TOOL_CALL
+
+    def test_empty_message(self):
+        msg = Message(role=Role.USER)
+        views = list(iter_views(msg))
+        assert len(views) == 0
+
+    def test_single_content_part(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="Hi")])
+        views = list(iter_views(msg))
+        assert len(views) == 1
+        assert views[0].kind == ViewKind.TEXT
+
+    def test_all_content_types(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[
+                TextContent(text="hi"),
+                ThinkingContent(text="hmm"),
+                ToolCallContentPart(content=ToolCall(tool_call_id="t1", name="x", arguments={})),
+                ToolResultContentPart(content=ToolResult(tool_call_id="t1", tool_name="x", content="ok")),
+                ResourceContentPart(content=Resource(resource_request_id="r1", uri="file:///a", resource_type=ResourceType.FILE, content="data")),
+                ResourceRefContentPart(content=ResourceReference(resource_request_id="r2", uri="db://b", resource_type=ResourceType.DATABASE)),
+                PromptRequestContentPart(content=PromptRequest(prompt_request_id="p1", name="summarize")),
+                PromptResultContentPart(content=PromptResult(prompt_request_id="p1", prompt_name="summarize", content="summary")),
+                ImageContentPart(content=ImageSource(type="url", data="http://img")),
+                VideoContentPart(content=VideoSource(type="url", data="http://vid")),
+                AudioContentPart(content=AudioSource(type="url", data="http://aud")),
+                DocumentContentPart(content=DocumentSource(type="url", data="http://doc")),
+            ],
+        )
+        views = list(iter_views(msg))
+        assert len(views) == 12
+        expected_kinds = [
+            ViewKind.TEXT, ViewKind.THINKING, ViewKind.TOOL_CALL, ViewKind.TOOL_RESULT,
+            ViewKind.RESOURCE, ViewKind.RESOURCE_REF, ViewKind.PROMPT_REQUEST, ViewKind.PROMPT_RESULT,
+            ViewKind.IMAGE, ViewKind.VIDEO, ViewKind.AUDIO, ViewKind.DOCUMENT,
+        ]
+        for view, expected in zip(views, expected_kinds):
+            assert view.kind == expected
+
+
+# ---------------------------------------------------------------------------
+# Core Properties
+# ---------------------------------------------------------------------------
+
+
+class TestCoreProperties:
+    """Tests for MessageView core properties."""
+
+    def test_role(self, simple_assistant_msg):
+        view = list(iter_views(simple_assistant_msg))[0]
+        assert view.role == Role.ASSISTANT
+
+    def test_raw_access(self, simple_assistant_msg):
+        views = list(iter_views(simple_assistant_msg))
+        assert isinstance(views[0].raw, ThinkingContent)
+        assert isinstance(views[2].raw, ToolCallContentPart)
+
+    def test_content_text(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="Hello")])
+        view = list(iter_views(msg))[0]
+        assert view.content == "Hello"
+
+    def test_content_thinking(self):
+        msg = Message(role=Role.ASSISTANT, content=[ThinkingContent(text="Reasoning...")])
+        view = list(iter_views(msg))[0]
+        assert view.content == "Reasoning..."
+
+    def test_content_tool_call(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="test", arguments={"key": "value"}))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.content == '{"key": "value"}'
+
+    def test_content_tool_result(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[ToolResultContentPart(content=ToolResult(tool_call_id="tc1", tool_name="test", content={"result": 42}))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.content == '{"result": 42}'
+
+    def test_content_tool_result_string(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[ToolResultContentPart(content=ToolResult(tool_call_id="tc1", tool_name="test", content="plain text"))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.content == "plain text"
+
+    def test_content_tool_result_none(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[ToolResultContentPart(content=ToolResult(tool_call_id="tc1", tool_name="test"))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.content is None
+
+    def test_content_resource(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[ResourceContentPart(content=Resource(
+                resource_request_id="r1", uri="file:///a",
+                resource_type=ResourceType.FILE, content="file data",
+            ))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.content == "file data"
+
+    def test_content_prompt_request(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[PromptRequestContentPart(content=PromptRequest(prompt_request_id="p1", name="s", arguments={"text": "hi"}))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.content == '{"text": "hi"}'
+
+    def test_content_prompt_result(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[PromptResultContentPart(content=PromptResult(prompt_request_id="p1", prompt_name="s", content="rendered"))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.content == "rendered"
+
+    def test_content_media_none(self):
+        msg = Message(
+            role=Role.USER,
+            content=[ImageContentPart(content=ImageSource(type="url", data="http://img"))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.content is None
+
+
+# ---------------------------------------------------------------------------
+# URI
+# ---------------------------------------------------------------------------
+
+
+class TestURI:
+    """Tests for synthetic URI generation."""
+
+    def test_tool_call_uri(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="get_user", arguments={}))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.uri == "tool://_/get_user"
+
+    def test_tool_call_uri_with_namespace(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="get_user", namespace="user-svc", arguments={}))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.uri == "tool://user-svc/get_user"
+
+    def test_tool_result_uri(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[ToolResultContentPart(content=ToolResult(tool_call_id="tc1", tool_name="get_user"))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.uri == "tool_result://get_user"
+
+    def test_resource_uri(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[ResourceContentPart(content=Resource(
+                resource_request_id="r1", uri="file:///data/report.csv",
+                resource_type=ResourceType.FILE,
+            ))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.uri == "file:///data/report.csv"
+
+    def test_resource_ref_uri(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[ResourceRefContentPart(content=ResourceReference(
+                resource_request_id="r1", uri="db://users/42",
+                resource_type=ResourceType.DATABASE,
+            ))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.uri == "db://users/42"
+
+    def test_prompt_request_uri(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[PromptRequestContentPart(content=PromptRequest(prompt_request_id="p1", name="summarize", server_id="prompt-svc"))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.uri == "prompt://prompt-svc/summarize"
+
+    def test_prompt_result_uri(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[PromptResultContentPart(content=PromptResult(prompt_request_id="p1", prompt_name="summarize"))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.uri == "prompt_result://summarize"
+
+    def test_text_uri_is_none(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.uri is None
+
+
+# ---------------------------------------------------------------------------
+# Name
+# ---------------------------------------------------------------------------
+
+
+class TestName:
+    """Tests for the name property."""
+
+    def test_tool_call_name(self):
+        msg = Message(role=Role.ASSISTANT, content=[ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="get_user", arguments={}))])
+        assert list(iter_views(msg))[0].name == "get_user"
+
+    def test_tool_result_name(self):
+        msg = Message(role=Role.TOOL, content=[ToolResultContentPart(content=ToolResult(tool_call_id="tc1", tool_name="get_user"))])
+        assert list(iter_views(msg))[0].name == "get_user"
+
+    def test_prompt_request_name(self):
+        msg = Message(role=Role.ASSISTANT, content=[PromptRequestContentPart(content=PromptRequest(prompt_request_id="p1", name="summarize"))])
+        assert list(iter_views(msg))[0].name == "summarize"
+
+    def test_prompt_result_name(self):
+        msg = Message(role=Role.TOOL, content=[PromptResultContentPart(content=PromptResult(prompt_request_id="p1", prompt_name="summarize"))])
+        assert list(iter_views(msg))[0].name == "summarize"
+
+    def test_text_name_is_none(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        assert list(iter_views(msg))[0].name is None
+
+
+# ---------------------------------------------------------------------------
+# Action
+# ---------------------------------------------------------------------------
+
+
+class TestAction:
+    """Tests for the action property."""
+
+    def test_action_mapping(self):
+        pairs = [
+            (TextContent(text="hi"), Role.USER, ViewAction.SEND),
+            (ThinkingContent(text="hmm"), Role.ASSISTANT, ViewAction.GENERATE),
+            (ToolCallContentPart(content=ToolCall(tool_call_id="t", name="x", arguments={})), Role.ASSISTANT, ViewAction.EXECUTE),
+            (ToolResultContentPart(content=ToolResult(tool_call_id="t", tool_name="x")), Role.TOOL, ViewAction.RECEIVE),
+            (ResourceContentPart(content=Resource(resource_request_id="r", uri="f:///a", resource_type=ResourceType.FILE)), Role.TOOL, ViewAction.READ),
+            (ResourceRefContentPart(content=ResourceReference(resource_request_id="r", uri="f:///a", resource_type=ResourceType.FILE)), Role.ASSISTANT, ViewAction.READ),
+            (PromptRequestContentPart(content=PromptRequest(prompt_request_id="p", name="s")), Role.ASSISTANT, ViewAction.INVOKE),
+            (PromptResultContentPart(content=PromptResult(prompt_request_id="p", prompt_name="s")), Role.TOOL, ViewAction.GENERATE),
+            (ImageContentPart(content=ImageSource(type="url", data="http://img")), Role.USER, ViewAction.SEND),
+        ]
+        for part, role, expected_action in pairs:
+            msg = Message(role=role, content=[part])
+            view = list(iter_views(msg))[0]
+            assert view.action == expected_action, f"Expected {expected_action} for {part.content_type}"
+
+
+# ---------------------------------------------------------------------------
+# Direction
+# ---------------------------------------------------------------------------
+
+
+class TestDirection:
+    """Tests for is_pre / is_post direction logic."""
+
+    def test_tool_call_is_pre(self):
+        msg = Message(role=Role.ASSISTANT, content=[ToolCallContentPart(content=ToolCall(tool_call_id="t", name="x", arguments={}))])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is True
+        assert view.is_post is False
+
+    def test_tool_result_is_post(self):
+        msg = Message(role=Role.TOOL, content=[ToolResultContentPart(content=ToolResult(tool_call_id="t", tool_name="x"))])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is False
+        assert view.is_post is True
+
+    def test_prompt_request_is_pre(self):
+        msg = Message(role=Role.ASSISTANT, content=[PromptRequestContentPart(content=PromptRequest(prompt_request_id="p", name="s"))])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is True
+
+    def test_prompt_result_is_post(self):
+        msg = Message(role=Role.TOOL, content=[PromptResultContentPart(content=PromptResult(prompt_request_id="p", prompt_name="s"))])
+        view = list(iter_views(msg))[0]
+        assert view.is_post is True
+
+    def test_resource_ref_is_pre(self):
+        msg = Message(role=Role.ASSISTANT, content=[
+            ResourceRefContentPart(content=ResourceReference(resource_request_id="r", uri="f:///a", resource_type=ResourceType.FILE)),
+        ])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is True
+
+    def test_resource_is_post(self):
+        msg = Message(role=Role.TOOL, content=[
+            ResourceContentPart(content=Resource(resource_request_id="r", uri="f:///a", resource_type=ResourceType.FILE)),
+        ])
+        view = list(iter_views(msg))[0]
+        assert view.is_post is True
+
+    def test_user_text_is_pre(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is True
+        assert view.is_post is False
+
+    def test_assistant_text_is_post(self):
+        msg = Message(role=Role.ASSISTANT, content=[TextContent(text="hello")])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is False
+        assert view.is_post is True
+
+    def test_system_text_is_pre(self):
+        msg = Message(role=Role.SYSTEM, content=[TextContent(text="instructions")])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is True
+
+    def test_developer_text_is_pre(self):
+        msg = Message(role=Role.DEVELOPER, content=[TextContent(text="hints")])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is True
+
+    def test_tool_text_is_pre(self):
+        msg = Message(role=Role.TOOL, content=[TextContent(text="result text")])
+        view = list(iter_views(msg))[0]
+        assert view.is_pre is True
+
+
+# ---------------------------------------------------------------------------
+# Entity Type Helpers
+# ---------------------------------------------------------------------------
+
+
+class TestEntityTypeHelpers:
+    """Tests for is_tool, is_prompt, is_resource, is_text, is_media."""
+
+    def test_is_tool(self):
+        msg = Message(role=Role.ASSISTANT, content=[ToolCallContentPart(content=ToolCall(tool_call_id="t", name="x", arguments={}))])
+        assert list(iter_views(msg))[0].is_tool is True
+
+    def test_is_tool_result(self):
+        msg = Message(role=Role.TOOL, content=[ToolResultContentPart(content=ToolResult(tool_call_id="t", tool_name="x"))])
+        assert list(iter_views(msg))[0].is_tool is True
+
+    def test_is_prompt(self):
+        msg = Message(role=Role.ASSISTANT, content=[PromptRequestContentPart(content=PromptRequest(prompt_request_id="p", name="s"))])
+        assert list(iter_views(msg))[0].is_prompt is True
+
+    def test_is_resource(self):
+        msg = Message(role=Role.TOOL, content=[
+            ResourceContentPart(content=Resource(resource_request_id="r", uri="f:///a", resource_type=ResourceType.FILE)),
+        ])
+        assert list(iter_views(msg))[0].is_resource is True
+
+    def test_is_text(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        assert list(iter_views(msg))[0].is_text is True
+
+    def test_is_text_thinking(self):
+        msg = Message(role=Role.ASSISTANT, content=[ThinkingContent(text="hmm")])
+        assert list(iter_views(msg))[0].is_text is True
+
+    def test_is_media(self):
+        for part in [
+            ImageContentPart(content=ImageSource(type="url", data="http://img")),
+            VideoContentPart(content=VideoSource(type="url", data="http://vid")),
+            AudioContentPart(content=AudioSource(type="url", data="http://aud")),
+            DocumentContentPart(content=DocumentSource(type="url", data="http://doc")),
+        ]:
+            msg = Message(role=Role.USER, content=[part])
+            assert list(iter_views(msg))[0].is_media is True
+
+    def test_text_is_not_media(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        assert list(iter_views(msg))[0].is_media is False
+
+
+# ---------------------------------------------------------------------------
+# Flat Accessors
+# ---------------------------------------------------------------------------
+
+
+class TestFlatAccessors:
+    """Tests for capability-gated flat accessors."""
+
+    def test_base_tier(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.environment == "production"
+        assert view.request_id == "req-001"
+
+    def test_subject(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.subject.id == "user-alice"
+        assert view.subject.type == SubjectType.USER
+
+    def test_roles(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert "admin" in view.roles
+        assert "hr-manager" in view.roles
+
+    def test_permissions(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert "read:compensation" in view.permissions
+
+    def test_teams(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert "hr-team" in view.teams
+
+    def test_headers(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.headers["Content-Type"] == "application/json"
+
+    def test_labels(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert "CONFIDENTIAL" in view.labels
+
+    def test_agent_accessors(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.agent_input == "Show me Alice's compensation"
+        assert view.session_id == "sess-001"
+        assert view.conversation_id == "conv-001"
+        assert view.turn == 2
+        assert view.agent_id == "main-agent"
+        assert view.parent_agent_id == "orchestrator"
+
+    def test_object_profile(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.object is not None
+        assert view.object.managed_by == "tool"
+        assert view.object.permissions == ["read:compensation"]
+        assert view.object.trust_domain == "internal"
+        assert view.object.data_scope == ["salary", "bonus"]
+
+    def test_data_policy(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.data_policy is not None
+        assert "PII" in view.data_policy.apply_labels
+        assert "export" in view.data_policy.denied_actions
+        assert view.data_policy.retention.policy == "session"
+
+    def test_no_extensions(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.environment is None
+        assert view.request_id is None
+        assert view.subject is None
+        assert view.roles == frozenset()
+        assert view.permissions == frozenset()
+        assert view.teams == frozenset()
+        assert view.headers == {}
+        assert view.labels == frozenset()
+        assert view.agent_input is None
+        assert view.session_id is None
+        assert view.conversation_id is None
+        assert view.turn is None
+        assert view.agent_id is None
+        assert view.parent_agent_id is None
+        assert view.object is None
+        assert view.data_policy is None
+
+    def test_object_resolves_by_name(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[
+                ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="tool_a", arguments={})),
+                ToolCallContentPart(content=ToolCall(tool_call_id="tc2", name="tool_b", arguments={})),
+            ],
+            extensions=Extensions(
+                security=SecurityExtension(
+                    objects={"tool_a": ObjectSecurityProfile(managed_by="host")},
+                ),
+            ),
+        )
+        views = list(iter_views(msg))
+        assert views[0].object is not None
+        assert views[0].object.managed_by == "host"
+        assert views[1].object is None
+
+
+# ---------------------------------------------------------------------------
+# Helper Methods
+# ---------------------------------------------------------------------------
+
+
+class TestHelperMethods:
+    """Tests for helper methods on MessageView."""
+
+    def test_has_role(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.has_role("admin") is True
+        assert view.has_role("viewer") is False
+
+    def test_has_permission(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.has_permission("read:compensation") is True
+        assert view.has_permission("write:users") is False
+
+    def test_has_label(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.has_label("CONFIDENTIAL") is True
+        assert view.has_label("SECRET") is False
+
+    def test_has_header(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.has_header("Content-Type") is True
+        assert view.has_header("content-type") is True
+        assert view.has_header("X-Missing") is False
+
+    def test_get_header_case_insensitive(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.get_header("content-type") == "application/json"
+        assert view.get_header("CONTENT-TYPE") == "application/json"
+
+    def test_get_header_default(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.get_header("X-Missing") is None
+        assert view.get_header("X-Missing", "fallback") == "fallback"
+
+    def test_get_arg(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.get_arg("employee_id") == "emp-42"
+        assert view.get_arg("missing") is None
+        assert view.get_arg("missing", "default") == "default"
+
+    def test_has_arg(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.has_arg("employee_id") is True
+        assert view.has_arg("missing") is False
+
+    def test_has_arg_text_view(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.has_arg("anything") is False
+
+    def test_matches_uri_pattern(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        assert view.matches_uri_pattern("tool://hr-server/*") is True
+        assert view.matches_uri_pattern("tool://hr-server/get_*") is True
+        assert view.matches_uri_pattern("tool://other/*") is False
+        assert view.matches_uri_pattern("tool://**") is True
+
+    def test_matches_uri_pattern_no_uri(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.matches_uri_pattern("*") is False
+
+    def test_has_content(self, simple_assistant_msg):
+        views = list(iter_views(simple_assistant_msg))
+        assert views[0].has_content() is True
+        assert views[1].has_content() is True
+        assert views[2].has_content() is True
+
+
+# ---------------------------------------------------------------------------
+# Type-Specific Properties
+# ---------------------------------------------------------------------------
+
+
+class TestProperties:
+    """Tests for type-specific properties."""
+
+    def test_tool_call_properties(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="test", namespace="ns", arguments={}))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.get_property("namespace") == "ns"
+        assert view.get_property("tool_id") == "tc1"
+        props = view.properties
+        assert props["namespace"] == "ns"
+        assert props["tool_id"] == "tc1"
+
+    def test_tool_result_properties(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[ToolResultContentPart(content=ToolResult(tool_call_id="tc1", tool_name="test", is_error=True))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.get_property("is_error") is True
+        assert view.get_property("tool_name") == "test"
+
+    def test_resource_properties(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[ResourceContentPart(content=Resource(
+                resource_request_id="r1", uri="f:///a",
+                resource_type=ResourceType.FILE, version="v2",
+                annotations={"key": "val"},
+            ))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.get_property("resource_type") == "file"
+        assert view.get_property("version") == "v2"
+        assert view.get_property("annotations") == {"key": "val"}
+
+    def test_prompt_result_properties(self):
+        msg = Message(
+            role=Role.TOOL,
+            content=[PromptResultContentPart(content=PromptResult(
+                prompt_request_id="p1", prompt_name="s",
+                messages=["m1", "m2"], is_error=False,
+            ))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.get_property("is_error") is False
+        assert view.get_property("message_count") == 2
+
+    def test_get_property_default(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.get_property("anything") is None
+        assert view.get_property("anything", "fallback") == "fallback"
+
+    def test_empty_properties_for_text(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        assert view.properties == {}
+
+
+# ---------------------------------------------------------------------------
+# Misc Properties
+# ---------------------------------------------------------------------------
+
+
+class TestMiscProperties:
+    """Tests for mime_type, size_bytes, args."""
+
+    def test_mime_type_resource(self):
+        msg = Message(role=Role.TOOL, content=[ResourceContentPart(content=Resource(
+            resource_request_id="r1", uri="f:///a",
+            resource_type=ResourceType.FILE, mime_type="text/csv",
+        ))])
+        assert list(iter_views(msg))[0].mime_type == "text/csv"
+
+    def test_mime_type_image(self):
+        msg = Message(role=Role.USER, content=[
+            ImageContentPart(content=ImageSource(type="url", data="http://img", media_type="image/png")),
+        ])
+        assert list(iter_views(msg))[0].mime_type == "image/png"
+
+    def test_mime_type_text_none(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        assert list(iter_views(msg))[0].mime_type is None
+
+    def test_size_bytes_text(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hello")])
+        assert list(iter_views(msg))[0].size_bytes == 5
+
+    def test_size_bytes_resource_explicit(self):
+        msg = Message(role=Role.TOOL, content=[ResourceContentPart(content=Resource(
+            resource_request_id="r1", uri="f:///a",
+            resource_type=ResourceType.FILE, size_bytes=1024,
+        ))])
+        assert list(iter_views(msg))[0].size_bytes == 1024
+
+    def test_size_bytes_resource_from_content(self):
+        msg = Message(role=Role.TOOL, content=[ResourceContentPart(content=Resource(
+            resource_request_id="r1", uri="f:///a",
+            resource_type=ResourceType.FILE, content="hello",
+        ))])
+        assert list(iter_views(msg))[0].size_bytes == 5
+
+    def test_args_tool_call(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="x", arguments={"a": 1, "b": 2}))],
+        )
+        view = list(iter_views(msg))[0]
+        assert view.args == {"a": 1, "b": 2}
+
+    def test_args_text_none(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        assert list(iter_views(msg))[0].args is None
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    """Tests for to_dict() and to_opa_input()."""
+
+    def test_to_dict_basic(self, simple_assistant_msg):
+        view = list(iter_views(simple_assistant_msg))[2]
+        d = view.to_dict()
+        assert d["kind"] == "tool_call"
+        assert d["role"] == "assistant"
+        assert d["is_pre"] is True
+        assert d["is_post"] is False
+        assert d["action"] == "execute"
+        assert d["name"] == "execute_sql"
+        assert d["uri"] == "tool://_/execute_sql"
+
+    def test_to_dict_strips_sensitive_headers(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        d = view.to_dict()
+        headers = d["extensions"].get("headers", {})
+        assert "Authorization" not in headers
+        assert "Cookie" not in headers
+        assert "Content-Type" in headers
+
+    def test_to_dict_includes_extensions(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        d = view.to_dict()
+        ext = d["extensions"]
+        assert ext["environment"] == "production"
+        assert ext["subject"]["id"] == "user-alice"
+        assert "CONFIDENTIAL" in ext["labels"]
+        assert ext["object"]["managed_by"] == "tool"
+        assert "PII" in ext["data"]["apply_labels"]
+        assert ext["agent"]["input"] == "Show me Alice's compensation"
+
+    def test_to_dict_exclude_content(self, simple_assistant_msg):
+        view = list(iter_views(simple_assistant_msg))[0]
+        d = view.to_dict(include_content=False)
+        assert "content" not in d
+        assert "size_bytes" not in d
+
+    def test_to_dict_exclude_context(self, full_msg):
+        view = list(iter_views(full_msg))[0]
+        d = view.to_dict(include_context=False)
+        assert "extensions" not in d
+
+    def test_to_opa_input(self, simple_assistant_msg):
+        view = list(iter_views(simple_assistant_msg))[2]
+        opa = view.to_opa_input()
+        assert "input" in opa
+        assert opa["input"]["kind"] == "tool_call"
+
+    def test_to_dict_no_extensions(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        d = view.to_dict()
+        assert "extensions" not in d
+
+
+# ---------------------------------------------------------------------------
+# Repr
+# ---------------------------------------------------------------------------
+
+
+class TestRepr:
+    """Tests for __repr__."""
+
+    def test_repr_text(self):
+        msg = Message(role=Role.USER, content=[TextContent(text="hi")])
+        view = list(iter_views(msg))[0]
+        r = repr(view)
+        assert "kind=text" in r
+        assert "role=user" in r
+        assert "pre" in r
+
+    def test_repr_tool_call(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[ToolCallContentPart(content=ToolCall(tool_call_id="tc1", name="test", arguments={}))],
+        )
+        view = list(iter_views(msg))[0]
+        r = repr(view)
+        assert "tool_call" in r
+        assert "tool://_/test" in r

--- a/tests/unit/cpex/framework/extensions/test_delegation.py
+++ b/tests/unit/cpex/framework/extensions/test_delegation.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+"""Tests for DelegationExtension and DelegationHop.
+
+Covers:
+- DelegationHop construction and timestamp (timezone-aware)
+- DelegationExtension.with_new_hop() monotonic chain growth
+- Scope narrowing on hop creation
+- age_seconds calculation
+- Immutability of frozen models
+"""
+
+import pytest
+from datetime import UTC, datetime, timedelta
+
+from cpex.framework.extensions.delegation import DelegationExtension, DelegationHop
+
+
+class TestDelegationHop:
+    """Tests for DelegationHop construction."""
+
+    def test_basic_construction(self):
+        hop = DelegationHop(subject_id="alice@corp.com", subject_type="user")
+        assert hop.subject_id == "alice@corp.com"
+        assert hop.subject_type == "user"
+        assert hop.audience is None
+        assert hop.scopes_granted == ()
+        assert hop.from_cache is False
+
+    def test_timestamp_is_timezone_aware(self):
+        hop = DelegationHop(subject_id="alice", subject_type="user")
+        assert hop.timestamp.tzinfo is not None
+
+    def test_with_scopes(self):
+        hop = DelegationHop(
+            subject_id="alice",
+            subject_type="user",
+            scopes_granted=("read:compensation", "read:directory"),
+            audience="hr-service",
+            strategy="token_exchange",
+        )
+        assert len(hop.scopes_granted) == 2
+        assert "read:compensation" in hop.scopes_granted
+        assert hop.audience == "hr-service"
+        assert hop.strategy == "token_exchange"
+
+    def test_frozen(self):
+        hop = DelegationHop(subject_id="alice", subject_type="user")
+        with pytest.raises(Exception):  # ValidationError for frozen
+            hop.subject_id = "bob"
+
+
+class TestDelegationExtension:
+    """Tests for DelegationExtension."""
+
+    def test_empty_extension(self):
+        ext = DelegationExtension()
+        assert ext.delegated is False
+        assert ext.depth == 0
+        assert ext.chain == ()
+        assert ext.origin_subject_id is None
+        assert ext.actor_subject_id is None
+
+    def test_with_new_hop_first_hop(self):
+        ext = DelegationExtension()
+        hop = DelegationHop(
+            subject_id="alice@corp.com",
+            subject_type="user",
+            scopes_granted=("read",),
+        )
+        new_ext = ext.with_new_hop(hop)
+
+        assert new_ext.delegated is True
+        assert new_ext.depth == 1
+        assert len(new_ext.chain) == 1
+        assert new_ext.origin_subject_id == "alice@corp.com"
+        assert new_ext.actor_subject_id == "alice@corp.com"
+
+    def test_with_new_hop_preserves_origin(self):
+        ext = DelegationExtension()
+        hop1 = DelegationHop(subject_id="alice", subject_type="user", scopes_granted=("read", "write"))
+        hop2 = DelegationHop(subject_id="agent-1", subject_type="agent", scopes_granted=("read",))
+
+        ext1 = ext.with_new_hop(hop1)
+        ext2 = ext1.with_new_hop(hop2)
+
+        assert ext2.depth == 2
+        assert ext2.origin_subject_id == "alice"  # preserved from first hop
+        assert ext2.actor_subject_id == "agent-1"  # updated to latest hop
+
+    def test_with_new_hop_is_immutable(self):
+        """with_new_hop returns a NEW extension — original is unchanged."""
+        ext = DelegationExtension()
+        hop = DelegationHop(subject_id="alice", subject_type="user")
+        new_ext = ext.with_new_hop(hop)
+
+        assert ext.depth == 0  # original unchanged
+        assert new_ext.depth == 1  # new one has the hop
+
+    def test_with_new_hop_chain_grows_monotonically(self):
+        ext = DelegationExtension()
+        hop1 = DelegationHop(subject_id="alice", subject_type="user")
+        hop2 = DelegationHop(subject_id="bob", subject_type="agent")
+        hop3 = DelegationHop(subject_id="charlie", subject_type="service")
+
+        ext1 = ext.with_new_hop(hop1)
+        ext2 = ext1.with_new_hop(hop2)
+        ext3 = ext2.with_new_hop(hop3)
+
+        assert ext3.depth == 3
+        assert ext3.chain[0].subject_id == "alice"
+        assert ext3.chain[1].subject_id == "bob"
+        assert ext3.chain[2].subject_id == "charlie"
+
+    def test_age_seconds_increases(self):
+        """age_seconds should reflect time since first hop."""
+        # Create a hop with a timestamp in the past
+        old_hop = DelegationHop(
+            subject_id="alice",
+            subject_type="user",
+            timestamp=datetime.now(UTC) - timedelta(seconds=10),
+        )
+        ext = DelegationExtension()
+        ext1 = ext.with_new_hop(old_hop)
+
+        # Add a second hop — age should be > 0
+        hop2 = DelegationHop(subject_id="bob", subject_type="agent")
+        ext2 = ext1.with_new_hop(hop2)
+        assert ext2.age_seconds >= 9.0  # at least ~10s minus timing
+
+    def test_frozen(self):
+        ext = DelegationExtension()
+        with pytest.raises(Exception):
+            ext.delegated = True

--- a/tests/unit/cpex/framework/extensions/test_extensions.py
+++ b/tests/unit/cpex/framework/extensions/test_extensions.py
@@ -1,0 +1,624 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/cpex/framework/extensions/test_extensions.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Unit tests for extension models.
+"""
+
+# Standard
+from typing import Any
+
+# Third-Party
+import pytest
+
+# First-Party
+from cpex.framework.extensions.agent import AgentExtension, ConversationContext
+from cpex.framework.extensions.completion import (
+    CompletionExtension,
+    StopReason,
+    TokenUsage,
+)
+from cpex.framework.extensions.extensions import Extensions
+from cpex.framework.extensions.framework import FrameworkExtension
+from cpex.framework.extensions.http import HttpExtension
+from cpex.framework.extensions.llm import LLMExtension
+from cpex.framework.extensions.mcp import (
+    MCPExtension,
+    PromptMetadata,
+    ResourceMetadata,
+    ToolMetadata,
+)
+from cpex.framework.extensions.provenance import ProvenanceExtension
+from cpex.framework.extensions.request import RequestExtension
+from cpex.framework.extensions.security import (
+    DataPolicy,
+    ObjectSecurityProfile,
+    RetentionPolicy,
+    SecurityExtension,
+    SubjectExtension,
+    SubjectType,
+)
+
+
+# ---------------------------------------------------------------------------
+# RequestExtension
+# ---------------------------------------------------------------------------
+
+
+class TestRequestExtension:
+    """Tests for RequestExtension."""
+
+    def test_creation(self):
+        ext = RequestExtension(
+            environment="production",
+            request_id="req-001",
+            timestamp="2025-01-15T10:30:00Z",
+        )
+        assert ext.environment == "production"
+        assert ext.request_id == "req-001"
+        assert ext.timestamp == "2025-01-15T10:30:00Z"
+
+    def test_defaults(self):
+        ext = RequestExtension()
+        assert ext.environment is None
+        assert ext.request_id is None
+        assert ext.timestamp is None
+        assert ext.trace_id is None
+        assert ext.span_id is None
+
+    def test_frozen(self):
+        ext = RequestExtension(environment="dev")
+        with pytest.raises(Exception):
+            ext.environment = "production"
+
+    def test_model_copy(self):
+        ext = RequestExtension(environment="dev")
+        updated = ext.model_copy(update={"environment": "production"})
+        assert ext.environment == "dev"
+        assert updated.environment == "production"
+
+    def test_tracing_fields(self):
+        ext = RequestExtension(
+            trace_id="trace-abc",
+            span_id="span-123",
+        )
+        assert ext.trace_id == "trace-abc"
+        assert ext.span_id == "span-123"
+
+
+# ---------------------------------------------------------------------------
+# AgentExtension
+# ---------------------------------------------------------------------------
+
+
+class TestConversationContext:
+    """Tests for ConversationContext."""
+
+    def test_creation(self):
+        ctx = ConversationContext(
+            summary="User asked about revenue.",
+            topics=["revenue", "Q4"],
+        )
+        assert ctx.summary == "User asked about revenue."
+        assert ctx.topics == ["revenue", "Q4"]
+
+    def test_defaults(self):
+        ctx = ConversationContext()
+        assert ctx.history == []
+        assert ctx.summary is None
+        assert ctx.topics == []
+
+    def test_frozen(self):
+        ctx = ConversationContext(summary="test")
+        with pytest.raises(Exception):
+            ctx.summary = "modified"
+
+
+class TestAgentExtension:
+    """Tests for AgentExtension."""
+
+    def test_creation(self):
+        ext = AgentExtension(
+            input="What is the weather?",
+            session_id="sess-001",
+            conversation_id="conv-042",
+            turn=3,
+            agent_id="weather-agent",
+        )
+        assert ext.input == "What is the weather?"
+        assert ext.session_id == "sess-001"
+        assert ext.turn == 3
+
+    def test_defaults(self):
+        ext = AgentExtension()
+        assert ext.input is None
+        assert ext.session_id is None
+        assert ext.conversation_id is None
+        assert ext.turn is None
+        assert ext.agent_id is None
+        assert ext.parent_agent_id is None
+        assert ext.conversation is None
+
+    def test_multi_agent_lineage(self):
+        ext = AgentExtension(
+            agent_id="sub-agent-01",
+            parent_agent_id="main-agent",
+        )
+        assert ext.parent_agent_id == "main-agent"
+
+    def test_with_conversation(self):
+        conv = ConversationContext(summary="Prior context", topics=["weather"])
+        ext = AgentExtension(conversation=conv)
+        assert ext.conversation.summary == "Prior context"
+
+
+# ---------------------------------------------------------------------------
+# HttpExtension
+# ---------------------------------------------------------------------------
+
+
+class TestHttpExtension:
+    """Tests for HttpExtension."""
+
+    def test_creation(self):
+        ext = HttpExtension(
+            headers={"Content-Type": "application/json", "X-Request-ID": "req-001"},
+        )
+        assert ext.headers["Content-Type"] == "application/json"
+
+    def test_defaults(self):
+        ext = HttpExtension()
+        assert ext.headers == {}
+
+    def test_frozen(self):
+        ext = HttpExtension(headers={"X-Test": "value"})
+        with pytest.raises(Exception):
+            ext.headers = {}
+
+    def test_model_copy_add_header(self):
+        ext = HttpExtension(headers={"X-Test": "value"})
+        updated = ext.model_copy(
+            update={"headers": {**ext.headers, "X-New": "added"}},
+        )
+        assert "X-New" in updated.headers
+        assert "X-New" not in ext.headers
+
+
+# ---------------------------------------------------------------------------
+# SecurityExtension
+# ---------------------------------------------------------------------------
+
+
+class TestSubjectType:
+    """Tests for SubjectType enum."""
+
+    def test_values(self):
+        assert SubjectType.USER.value == "user"
+        assert SubjectType.AGENT.value == "agent"
+        assert SubjectType.SERVICE.value == "service"
+        assert SubjectType.SYSTEM.value == "system"
+
+    def test_member_count(self):
+        assert len(SubjectType) == 4
+
+
+class TestSubjectExtension:
+    """Tests for SubjectExtension."""
+
+    def test_creation(self):
+        subject = SubjectExtension(
+            id="user-alice",
+            type=SubjectType.USER,
+            roles=frozenset({"admin", "developer"}),
+            permissions=frozenset({"db.read", "tools.execute"}),
+        )
+        assert subject.id == "user-alice"
+        assert subject.type == SubjectType.USER
+        assert "admin" in subject.roles
+        assert "db.read" in subject.permissions
+
+    def test_defaults(self):
+        subject = SubjectExtension(id="svc-1", type=SubjectType.SERVICE)
+        assert subject.roles == frozenset()
+        assert subject.permissions == frozenset()
+        assert subject.teams == frozenset()
+        assert subject.claims == {}
+
+    def test_frozen_sets(self):
+        subject = SubjectExtension(
+            id="test",
+            type=SubjectType.USER,
+            roles=frozenset({"admin"}),
+        )
+        assert isinstance(subject.roles, frozenset)
+        assert isinstance(subject.permissions, frozenset)
+        assert isinstance(subject.teams, frozenset)
+
+
+class TestObjectSecurityProfile:
+    """Tests for ObjectSecurityProfile."""
+
+    def test_creation(self):
+        profile = ObjectSecurityProfile(
+            managed_by="tool",
+            permissions=["read:compensation"],
+            trust_domain="internal",
+            data_scope=["salary", "bonus"],
+        )
+        assert profile.managed_by == "tool"
+        assert "read:compensation" in profile.permissions
+        assert profile.trust_domain == "internal"
+
+    def test_defaults(self):
+        profile = ObjectSecurityProfile()
+        assert profile.managed_by == "host"
+        assert profile.permissions == []
+        assert profile.trust_domain is None
+        assert profile.data_scope == []
+
+
+class TestRetentionPolicy:
+    """Tests for RetentionPolicy."""
+
+    def test_creation(self):
+        ret = RetentionPolicy(
+            max_age_seconds=3600,
+            policy="session",
+        )
+        assert ret.max_age_seconds == 3600
+        assert ret.policy == "session"
+
+    def test_defaults(self):
+        ret = RetentionPolicy()
+        assert ret.max_age_seconds is None
+        assert ret.policy == "persistent"
+        assert ret.delete_after is None
+
+
+class TestDataPolicy:
+    """Tests for DataPolicy."""
+
+    def test_creation(self):
+        policy = DataPolicy(
+            apply_labels=["PII", "financial"],
+            denied_actions=["export", "forward"],
+            retention=RetentionPolicy(policy="session", max_age_seconds=7200),
+        )
+        assert "PII" in policy.apply_labels
+        assert "export" in policy.denied_actions
+        assert policy.retention.policy == "session"
+
+    def test_defaults(self):
+        policy = DataPolicy()
+        assert policy.apply_labels == []
+        assert policy.allowed_actions is None
+        assert policy.denied_actions == []
+        assert policy.retention is None
+
+    def test_unrestricted_vs_restricted(self):
+        unrestricted = DataPolicy()
+        restricted = DataPolicy(allowed_actions=["view", "summarize"])
+        assert unrestricted.allowed_actions is None
+        assert restricted.allowed_actions == ["view", "summarize"]
+
+
+class TestSecurityExtension:
+    """Tests for SecurityExtension."""
+
+    def test_creation(self):
+        ext = SecurityExtension(
+            labels=frozenset({"PII", "CONFIDENTIAL"}),
+            classification="confidential",
+            subject=SubjectExtension(id="user-1", type=SubjectType.USER),
+        )
+        assert "PII" in ext.labels
+        assert ext.classification == "confidential"
+        assert ext.subject.id == "user-1"
+
+    def test_defaults(self):
+        ext = SecurityExtension()
+        assert ext.labels == frozenset()
+        assert ext.classification is None
+        assert ext.subject is None
+        assert ext.objects == {}
+        assert ext.data == {}
+
+    def test_monotonic_label_addition(self):
+        ext = SecurityExtension(labels=frozenset({"PII"}))
+        updated = ext.model_copy(
+            update={"labels": ext.labels | frozenset({"CONFIDENTIAL"})},
+        )
+        assert "PII" in updated.labels
+        assert "CONFIDENTIAL" in updated.labels
+        assert ext.labels == frozenset({"PII"})
+
+    def test_labels_are_frozenset(self):
+        ext = SecurityExtension(labels=frozenset({"PII"}))
+        assert isinstance(ext.labels, frozenset)
+
+    def test_with_objects_and_data(self):
+        ext = SecurityExtension(
+            objects={
+                "get_user": ObjectSecurityProfile(
+                    managed_by="host",
+                    permissions=["users.read"],
+                ),
+            },
+            data={
+                "get_user": DataPolicy(
+                    apply_labels=["PII"],
+                    denied_actions=["export"],
+                ),
+            },
+        )
+        assert ext.objects["get_user"].permissions == ["users.read"]
+        assert ext.data["get_user"].apply_labels == ["PII"]
+
+
+# ---------------------------------------------------------------------------
+# MCPExtension
+# ---------------------------------------------------------------------------
+
+
+class TestToolMetadata:
+    """Tests for ToolMetadata."""
+
+    def test_creation(self):
+        meta = ToolMetadata(
+            name="get_user",
+            description="Retrieve user by ID",
+            input_schema={"type": "object", "properties": {"id": {"type": "string"}}},
+        )
+        assert meta.name == "get_user"
+        assert meta.input_schema is not None
+
+    def test_defaults(self):
+        meta = ToolMetadata(name="test")
+        assert meta.title is None
+        assert meta.description is None
+        assert meta.input_schema is None
+        assert meta.output_schema is None
+        assert meta.server_id is None
+        assert meta.namespace is None
+        assert meta.annotations == {}
+
+
+class TestResourceMetadata:
+    """Tests for ResourceMetadata."""
+
+    def test_creation(self):
+        meta = ResourceMetadata(
+            uri="file:///data/report.csv",
+            name="Quarterly Report",
+            mime_type="text/csv",
+        )
+        assert meta.uri == "file:///data/report.csv"
+
+
+class TestPromptMetadata:
+    """Tests for PromptMetadata."""
+
+    def test_creation(self):
+        meta = PromptMetadata(
+            name="summarize",
+            arguments=[{"name": "text", "description": "Text to summarize", "required": True}],
+        )
+        assert meta.name == "summarize"
+        assert meta.arguments[0]["name"] == "text"
+
+
+class TestMCPExtension:
+    """Tests for MCPExtension."""
+
+    def test_with_tool(self):
+        ext = MCPExtension(tool=ToolMetadata(name="get_user"))
+        assert ext.tool.name == "get_user"
+        assert ext.resource is None
+        assert ext.prompt is None
+
+    def test_with_resource(self):
+        ext = MCPExtension(resource=ResourceMetadata(uri="file:///test"))
+        assert ext.resource.uri == "file:///test"
+        assert ext.tool is None
+
+    def test_with_prompt(self):
+        ext = MCPExtension(prompt=PromptMetadata(name="summarize"))
+        assert ext.prompt.name == "summarize"
+
+    def test_defaults(self):
+        ext = MCPExtension()
+        assert ext.tool is None
+        assert ext.resource is None
+        assert ext.prompt is None
+
+
+# ---------------------------------------------------------------------------
+# CompletionExtension
+# ---------------------------------------------------------------------------
+
+
+class TestStopReason:
+    """Tests for StopReason enum."""
+
+    def test_values(self):
+        assert StopReason.END.value == "end"
+        assert StopReason.MAX_TOKENS.value == "max_tokens"
+
+    def test_member_count(self):
+        assert len(StopReason) == 5
+
+
+class TestTokenUsage:
+    """Tests for TokenUsage."""
+
+    def test_creation(self):
+        usage = TokenUsage(input_tokens=100, output_tokens=50, total_tokens=150)
+        assert usage.total_tokens == 150
+
+
+class TestCompletionExtension:
+    """Tests for CompletionExtension."""
+
+    def test_creation(self):
+        ext = CompletionExtension(
+            stop_reason=StopReason.END,
+            tokens=TokenUsage(input_tokens=100, output_tokens=50, total_tokens=150),
+            model="gpt-4o",
+            latency_ms=1200,
+        )
+        assert ext.stop_reason == StopReason.END
+        assert ext.tokens.total_tokens == 150
+        assert ext.model == "gpt-4o"
+        assert ext.latency_ms == 1200
+
+    def test_defaults(self):
+        ext = CompletionExtension()
+        assert ext.stop_reason is None
+        assert ext.tokens is None
+        assert ext.model is None
+        assert ext.raw_format is None
+        assert ext.created_at is None
+        assert ext.latency_ms is None
+
+
+# ---------------------------------------------------------------------------
+# ProvenanceExtension
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceExtension:
+    """Tests for ProvenanceExtension."""
+
+    def test_creation(self):
+        ext = ProvenanceExtension(
+            source="agent:weather-bot",
+            message_id="msg-001",
+            parent_id="msg-000",
+        )
+        assert ext.source == "agent:weather-bot"
+        assert ext.message_id == "msg-001"
+
+    def test_defaults(self):
+        ext = ProvenanceExtension()
+        assert ext.source is None
+        assert ext.message_id is None
+        assert ext.parent_id is None
+
+
+# ---------------------------------------------------------------------------
+# LLMExtension
+# ---------------------------------------------------------------------------
+
+
+class TestLLMExtension:
+    """Tests for LLMExtension."""
+
+    def test_creation(self):
+        ext = LLMExtension(
+            model_id="claude-sonnet-4-20250514",
+            provider="anthropic",
+            capabilities=["vision", "tool_use"],
+        )
+        assert ext.provider == "anthropic"
+        assert "tool_use" in ext.capabilities
+
+    def test_defaults(self):
+        ext = LLMExtension()
+        assert ext.model_id is None
+        assert ext.provider is None
+        assert ext.capabilities == []
+
+
+# ---------------------------------------------------------------------------
+# FrameworkExtension
+# ---------------------------------------------------------------------------
+
+
+class TestFrameworkExtension:
+    """Tests for FrameworkExtension."""
+
+    def test_creation(self):
+        ext = FrameworkExtension(
+            framework="langgraph",
+            framework_version="0.2.0",
+            node_id="weather_node",
+            graph_id="travel_planner",
+        )
+        assert ext.framework == "langgraph"
+        assert ext.node_id == "weather_node"
+
+    def test_defaults(self):
+        ext = FrameworkExtension()
+        assert ext.framework is None
+        assert ext.framework_version is None
+        assert ext.node_id is None
+        assert ext.graph_id is None
+        assert ext.metadata == {}
+
+
+# ---------------------------------------------------------------------------
+# Extensions Container
+# ---------------------------------------------------------------------------
+
+
+class TestExtensions:
+    """Tests for the Extensions container."""
+
+    def test_all_none_by_default(self):
+        ext = Extensions()
+        assert ext.request is None
+        assert ext.agent is None
+        assert ext.http is None
+        assert ext.security is None
+        assert ext.mcp is None
+        assert ext.completion is None
+        assert ext.provenance is None
+        assert ext.llm is None
+        assert ext.framework is None
+        assert ext.custom is None
+
+    def test_frozen(self):
+        ext = Extensions()
+        with pytest.raises(Exception):
+            ext.request = RequestExtension()
+
+    def test_model_copy(self):
+        ext = Extensions(
+            request=RequestExtension(environment="dev"),
+        )
+        updated = ext.model_copy(
+            update={"request": RequestExtension(environment="production")},
+        )
+        assert ext.request.environment == "dev"
+        assert updated.request.environment == "production"
+
+    def test_full_construction(self):
+        ext = Extensions(
+            request=RequestExtension(environment="production", request_id="req-001"),
+            agent=AgentExtension(input="Hello", session_id="sess-001"),
+            http=HttpExtension(headers={"X-Test": "value"}),
+            security=SecurityExtension(labels=frozenset({"PII"})),
+            mcp=MCPExtension(tool=ToolMetadata(name="get_user")),
+            completion=CompletionExtension(stop_reason=StopReason.END),
+            provenance=ProvenanceExtension(source="user"),
+            llm=LLMExtension(model_id="gpt-4o", provider="openai"),
+            framework=FrameworkExtension(framework="langgraph"),
+            custom={"debug": True},
+        )
+        assert ext.request.environment == "production"
+        assert ext.agent.input == "Hello"
+        assert ext.http.headers["X-Test"] == "value"
+        assert "PII" in ext.security.labels
+        assert ext.mcp.tool.name == "get_user"
+        assert ext.completion.stop_reason == StopReason.END
+        assert ext.provenance.source == "user"
+        assert ext.llm.provider == "openai"
+        assert ext.framework.framework == "langgraph"
+        assert ext.custom["debug"] is True
+
+    def test_custom_extension(self):
+        ext = Extensions(custom={"key": "value", "nested": {"a": 1}})
+        assert ext.custom["key"] == "value"
+        assert ext.custom["nested"]["a"] == 1

--- a/tests/unit/cpex/framework/extensions/test_tiers.py
+++ b/tests/unit/cpex/framework/extensions/test_tiers.py
@@ -1,0 +1,748 @@
+# -*- coding: utf-8 -*-
+"""Tests for cpex.framework.extensions.tiers module.
+
+Covers mutability tiers, capability gating, extension filtering,
+tier constraint validation, and lockdown (private registry, frozen config).
+"""
+
+# Standard
+from __future__ import annotations
+
+# Third-Party
+import pytest
+
+# First-Party
+from cpex.framework.extensions.agent import AgentExtension
+from cpex.framework.extensions.extensions import Extensions
+from cpex.framework.extensions.http import HttpExtension
+from cpex.framework.extensions.request import RequestExtension
+from cpex.framework.extensions.security import (
+    SecurityExtension,
+    SubjectExtension,
+    SubjectType,
+)
+from cpex.framework.extensions.constants import SlotName
+from cpex.framework.extensions.tiers import (
+    AccessPolicy,
+    Capability,
+    MutabilityTier,
+    SlotPolicy,
+    TierViolationError,
+    _slot_registry,
+    filter_extensions,
+    merge_extensions,
+    validate_tier_constraints,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def subject():
+    return SubjectExtension(
+        id="user-alice",
+        type=SubjectType.USER,
+        roles=frozenset({"admin", "developer"}),
+        teams=frozenset({"platform"}),
+        claims={"sub": "alice", "iss": "idp"},
+        permissions=frozenset({"tools.execute", "db.read"}),
+    )
+
+
+@pytest.fixture()
+def security_ext(subject):
+    return SecurityExtension(
+        labels=frozenset({"PII", "CONFIDENTIAL"}),
+        classification="confidential",
+        subject=subject,
+    )
+
+
+@pytest.fixture()
+def full_extensions(security_ext):
+    return Extensions(
+        request=RequestExtension(environment="test", request_id="req-1"),
+        agent=AgentExtension(session_id="sess-1"),
+        http=HttpExtension(headers={"Authorization": "Bearer tok"}),
+        security=security_ext,
+        custom={"key": "value"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Enum / SlotPolicy basics
+# ---------------------------------------------------------------------------
+
+
+class TestMutabilityTier:
+    def test_values(self):
+        assert MutabilityTier.IMMUTABLE.value == "immutable"
+        assert MutabilityTier.MONOTONIC.value == "monotonic"
+        assert MutabilityTier.MUTABLE.value == "mutable"
+
+    def test_string_enum(self):
+        assert MutabilityTier("immutable") == MutabilityTier.IMMUTABLE
+
+
+class TestAccessPolicy:
+    def test_values(self):
+        assert AccessPolicy.UNRESTRICTED.value == "unrestricted"
+        assert AccessPolicy.CAPABILITY_GATED.value == "capability_gated"
+
+    def test_string_enum(self):
+        assert AccessPolicy("unrestricted") == AccessPolicy.UNRESTRICTED
+
+
+class TestCapability:
+    def test_all_values(self):
+        assert len(Capability) == 10  # noqa: PLR2004
+        assert Capability.READ_SUBJECT.value == "read_subject"
+        assert Capability.APPEND_LABELS.value == "append_labels"
+        assert Capability.WRITE_HEADERS.value == "write_headers"
+
+    def test_string_enum(self):
+        assert Capability("read_agent") == Capability.READ_AGENT
+
+
+class TestSlotPolicy:
+    def test_frozen(self):
+        policy = SlotPolicy(MutabilityTier.IMMUTABLE)
+        with pytest.raises(AttributeError):
+            policy.tier = MutabilityTier.MUTABLE  # type: ignore[misc]
+
+    def test_defaults(self):
+        policy = SlotPolicy(MutabilityTier.IMMUTABLE)
+        assert policy.access == AccessPolicy.UNRESTRICTED
+        assert policy.read_cap is None
+        assert policy.write_cap is None
+
+    def test_capability_gated(self):
+        policy = SlotPolicy(
+            MutabilityTier.IMMUTABLE,
+            access=AccessPolicy.CAPABILITY_GATED,
+            read_cap=Capability.READ_AGENT,
+        )
+        assert policy.access == AccessPolicy.CAPABILITY_GATED
+        assert policy.read_cap == Capability.READ_AGENT
+
+
+class TestSlotRegistry:
+    def test_base_tier_slots_unrestricted(self):
+        for slot in (
+            SlotName.REQUEST,
+            SlotName.PROVENANCE,
+            SlotName.COMPLETION,
+            SlotName.LLM,
+            SlotName.FRAMEWORK,
+            SlotName.MCP,
+        ):
+            policy = _slot_registry[slot]
+            assert policy.tier == MutabilityTier.IMMUTABLE
+            assert policy.access == AccessPolicy.UNRESTRICTED
+            assert policy.read_cap is None
+            assert policy.write_cap is None
+
+    def test_agent_capability_gated(self):
+        policy = _slot_registry[SlotName.AGENT]
+        assert policy.access == AccessPolicy.CAPABILITY_GATED
+        assert policy.read_cap == Capability.READ_AGENT
+        assert policy.write_cap is None
+
+    def test_http_capability_gated(self):
+        policy = _slot_registry[SlotName.HTTP]
+        assert policy.access == AccessPolicy.CAPABILITY_GATED
+        assert policy.read_cap == Capability.READ_HEADERS
+        assert policy.write_cap == Capability.WRITE_HEADERS
+
+    def test_labels_monotonic_capability_gated(self):
+        policy = _slot_registry[SlotName.SECURITY_LABELS]
+        assert policy.tier == MutabilityTier.MONOTONIC
+        assert policy.access == AccessPolicy.CAPABILITY_GATED
+        assert policy.read_cap == Capability.READ_LABELS
+        assert policy.write_cap == Capability.APPEND_LABELS
+
+    def test_custom_mutable_unrestricted(self):
+        policy = _slot_registry[SlotName.CUSTOM]
+        assert policy.tier == MutabilityTier.MUTABLE
+        assert policy.access == AccessPolicy.UNRESTRICTED
+
+    def test_security_objects_unrestricted(self):
+        policy = _slot_registry[SlotName.SECURITY_OBJECTS]
+        assert policy.access == AccessPolicy.UNRESTRICTED
+
+    def test_security_data_unrestricted(self):
+        policy = _slot_registry[SlotName.SECURITY_DATA]
+        assert policy.access == AccessPolicy.UNRESTRICTED
+
+    def test_subject_subfields_capability_gated(self):
+        for slot in (
+            SlotName.SECURITY_SUBJECT,
+            SlotName.SECURITY_SUBJECT_ROLES,
+            SlotName.SECURITY_SUBJECT_TEAMS,
+            SlotName.SECURITY_SUBJECT_CLAIMS,
+            SlotName.SECURITY_SUBJECT_PERMISSIONS,
+        ):
+            policy = _slot_registry[slot]
+            assert policy.access == AccessPolicy.CAPABILITY_GATED, f"{slot} should be capability-gated"
+
+    def test_registry_is_read_only(self):
+        with pytest.raises(TypeError):
+            _slot_registry[SlotName.CUSTOM] = SlotPolicy(MutabilityTier.IMMUTABLE)  # type: ignore[index]
+
+    def test_registry_not_in_public_exports(self):
+        import cpex.framework.extensions as ext_pkg
+
+        assert "SLOT_REGISTRY" not in ext_pkg.__all__
+        assert "filter_extensions" not in ext_pkg.__all__
+        assert "validate_tier_constraints" not in ext_pkg.__all__
+        assert "SlotPolicy" not in ext_pkg.__all__
+
+
+# ---------------------------------------------------------------------------
+# filter_extensions
+# ---------------------------------------------------------------------------
+
+
+class TestFilterExtensions:
+    def test_none_input(self):
+        assert filter_extensions(None, frozenset()) is None
+
+    def test_no_capabilities_hides_gated_slots(self, full_extensions):
+        filtered = filter_extensions(full_extensions, frozenset())
+        # Unrestricted slots pass through
+        assert filtered.request is not None
+        assert filtered.custom is not None
+        # Capability-gated slots hidden
+        assert filtered.agent is None
+        assert filtered.http is None
+        # Security sub-fields: subject hidden, labels hidden
+        assert filtered.security is not None
+        assert filtered.security.subject is None
+        assert filtered.security.labels == frozenset()
+
+    def test_read_agent_makes_agent_visible(self, full_extensions):
+        caps = frozenset({"read_agent"})
+        filtered = filter_extensions(full_extensions, caps)
+        assert filtered.agent is not None
+        assert filtered.agent.session_id == "sess-1"
+
+    def test_read_headers_makes_http_visible(self, full_extensions):
+        caps = frozenset({"read_headers"})
+        filtered = filter_extensions(full_extensions, caps)
+        assert filtered.http is not None
+        assert filtered.http.headers["Authorization"] == "Bearer tok"
+
+    def test_write_headers_implies_read(self, full_extensions):
+        caps = frozenset({"write_headers"})
+        filtered = filter_extensions(full_extensions, caps)
+        assert filtered.http is not None
+
+    def test_append_labels_implies_read(self, full_extensions):
+        caps = frozenset({"append_labels"})
+        filtered = filter_extensions(full_extensions, caps)
+        assert filtered.security.labels == frozenset({"PII", "CONFIDENTIAL"})
+
+    def test_read_labels_makes_labels_visible(self, full_extensions):
+        caps = frozenset({"read_labels"})
+        filtered = filter_extensions(full_extensions, caps)
+        assert filtered.security.labels == frozenset({"PII", "CONFIDENTIAL"})
+
+    def test_no_filtering_returns_equal_object(self):
+        ext = Extensions(request=RequestExtension(environment="test", request_id="r1"))
+        result = filter_extensions(ext, frozenset())
+        assert result == ext  # Build-up always creates a new frozen instance
+        assert result is not ext
+
+    def test_ungated_security_subfields_pass_through(self, full_extensions):
+        """security.objects and security.data are always visible."""
+        filtered = filter_extensions(full_extensions, frozenset())
+        assert filtered.security.objects == full_extensions.security.objects
+        assert filtered.security.data == full_extensions.security.data
+
+
+class TestFilterSubjectGranular:
+    """Subject sub-field filtering: roles, teams, claims, permissions gated independently."""
+
+    def test_read_subject_only_hides_subfields(self, full_extensions):
+        caps = frozenset({"read_subject"})
+        filtered = filter_extensions(full_extensions, caps)
+        subj = filtered.security.subject
+        assert subj is not None
+        assert subj.id == "user-alice"
+        assert subj.type == SubjectType.USER
+        # Sub-fields hidden
+        assert subj.roles == frozenset()
+        assert subj.teams == frozenset()
+        assert subj.claims == {}
+        assert subj.permissions == frozenset()
+
+    def test_read_roles_implies_read_subject(self, full_extensions):
+        caps = frozenset({"read_roles"})
+        filtered = filter_extensions(full_extensions, caps)
+        subj = filtered.security.subject
+        assert subj is not None
+        assert subj.id == "user-alice"
+        assert "admin" in subj.roles
+        # Other sub-fields still hidden
+        assert subj.teams == frozenset()
+        assert subj.claims == {}
+        assert subj.permissions == frozenset()
+
+    def test_read_teams_implies_read_subject(self, full_extensions):
+        caps = frozenset({"read_teams"})
+        filtered = filter_extensions(full_extensions, caps)
+        subj = filtered.security.subject
+        assert subj is not None
+        assert "platform" in subj.teams
+        assert subj.roles == frozenset()
+
+    def test_read_claims_implies_read_subject(self, full_extensions):
+        caps = frozenset({"read_claims"})
+        filtered = filter_extensions(full_extensions, caps)
+        subj = filtered.security.subject
+        assert subj is not None
+        assert subj.claims == {"sub": "alice", "iss": "idp"}
+        assert subj.roles == frozenset()
+
+    def test_read_permissions_implies_read_subject(self, full_extensions):
+        caps = frozenset({"read_permissions"})
+        filtered = filter_extensions(full_extensions, caps)
+        subj = filtered.security.subject
+        assert subj is not None
+        assert "tools.execute" in subj.permissions
+        assert subj.roles == frozenset()
+
+    def test_multiple_subject_caps(self, full_extensions):
+        caps = frozenset({"read_roles", "read_permissions"})
+        filtered = filter_extensions(full_extensions, caps)
+        subj = filtered.security.subject
+        assert "admin" in subj.roles
+        assert "tools.execute" in subj.permissions
+        assert subj.teams == frozenset()
+        assert subj.claims == {}
+
+    def test_no_subject_extension_no_error(self):
+        ext = Extensions(
+            security=SecurityExtension(labels=frozenset({"PII"})),
+        )
+        filtered = filter_extensions(ext, frozenset({"read_labels"}))
+        assert filtered.security.labels == frozenset({"PII"})
+        assert filtered.security.subject is None
+
+
+# ---------------------------------------------------------------------------
+# validate_tier_constraints
+# ---------------------------------------------------------------------------
+
+
+class TestValidateTierConstraints:
+    def test_both_none(self):
+        validate_tier_constraints(None, None, frozenset(), "test-plugin")
+
+    def test_no_change_passes(self, full_extensions):
+        validate_tier_constraints(
+            full_extensions, full_extensions, frozenset(), "test-plugin"
+        )
+
+    def test_immutable_no_write_cap_rejects_change(self):
+        before = Extensions(
+            request=RequestExtension(environment="prod", request_id="r1"),
+        )
+        after = Extensions(
+            request=RequestExtension(environment="staging", request_id="r1"),
+        )
+        with pytest.raises(TierViolationError) as exc_info:
+            validate_tier_constraints(before, after, frozenset(), "bad-plugin")
+        assert exc_info.value.plugin_name == "bad-plugin"
+        assert exc_info.value.slot == SlotName.REQUEST
+        assert exc_info.value.tier == MutabilityTier.IMMUTABLE
+
+    def test_immutable_gated_rejects_without_cap(self):
+        before = Extensions(
+            http=HttpExtension(headers={"X-Foo": "bar"}),
+        )
+        after = Extensions(
+            http=HttpExtension(headers={"X-Foo": "baz"}),
+        )
+        with pytest.raises(TierViolationError) as exc_info:
+            validate_tier_constraints(before, after, frozenset(), "bad-plugin")
+        assert "write_headers" in exc_info.value.detail
+
+    def test_immutable_gated_allows_with_write_cap(self):
+        before = Extensions(
+            http=HttpExtension(headers={"X-Foo": "bar"}),
+        )
+        after = Extensions(
+            http=HttpExtension(headers={"X-Foo": "baz"}),
+        )
+        caps = frozenset({"write_headers"})
+        # Should not raise
+        validate_tier_constraints(before, after, caps, "good-plugin")
+
+    def test_monotonic_superset_passes(self):
+        before = Extensions(
+            security=SecurityExtension(labels=frozenset({"PII"})),
+        )
+        after = Extensions(
+            security=SecurityExtension(labels=frozenset({"PII", "CONFIDENTIAL"})),
+        )
+        caps = frozenset({"append_labels"})
+        validate_tier_constraints(before, after, caps, "good-plugin")
+
+    def test_monotonic_removal_rejects(self):
+        before = Extensions(
+            security=SecurityExtension(labels=frozenset({"PII", "CONFIDENTIAL"})),
+        )
+        after = Extensions(
+            security=SecurityExtension(labels=frozenset({"PII"})),
+        )
+        caps = frozenset({"append_labels"})
+        with pytest.raises(TierViolationError) as exc_info:
+            validate_tier_constraints(before, after, caps, "bad-plugin")
+        assert "monotonic" in str(exc_info.value)
+        assert exc_info.value.tier == MutabilityTier.MONOTONIC
+
+    def test_monotonic_without_cap_rejects(self):
+        before = Extensions(
+            security=SecurityExtension(labels=frozenset({"PII"})),
+        )
+        after = Extensions(
+            security=SecurityExtension(labels=frozenset({"PII", "SECRET"})),
+        )
+        with pytest.raises(TierViolationError) as exc_info:
+            validate_tier_constraints(before, after, frozenset(), "bad-plugin")
+        assert "append_labels" in exc_info.value.detail
+
+    def test_mutable_allows_any_change(self):
+        before = Extensions(custom={"key": "value"})
+        after = Extensions(custom={"key": "changed", "new": "stuff"})
+        validate_tier_constraints(before, after, frozenset(), "plugin")
+
+    def test_mutable_allows_deletion(self):
+        before = Extensions(custom={"key": "value"})
+        after = Extensions(custom=None)
+        validate_tier_constraints(before, after, frozenset(), "plugin")
+
+
+class TestTierViolationError:
+    def test_attributes(self):
+        err = TierViolationError("my-plugin", SlotName.REQUEST, MutabilityTier.IMMUTABLE, "changed")
+        assert err.plugin_name == "my-plugin"
+        assert err.slot == SlotName.REQUEST
+        assert err.tier == MutabilityTier.IMMUTABLE
+        assert err.detail == "changed"
+
+    def test_message(self):
+        err = TierViolationError("p", SlotName.REQUEST, MutabilityTier.IMMUTABLE, "nope")
+        assert "p" in str(err)
+        assert "immutable" in str(err)
+        assert "request" in str(err)
+        assert "nope" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# merge_extensions
+# ---------------------------------------------------------------------------
+
+
+class TestMergeExtensions:
+    def test_none_original_returns_none(self):
+        output = Extensions(custom={"key": "val"})
+        assert merge_extensions(None, output, frozenset(), "p") is None
+
+    def test_none_output_returns_original(self):
+        original = Extensions(custom={"key": "val"})
+        assert merge_extensions(original, None, frozenset(), "p") is original
+
+    def test_no_changes_returns_original(self):
+        original = Extensions(
+            request=RequestExtension(environment="prod", request_id="r1"),
+            custom={"key": "val"},
+        )
+        output = original.model_copy()
+        result = merge_extensions(original, output, frozenset(), "p")
+        assert result is original
+
+    def test_immutable_slots_ignored(self):
+        original = Extensions(
+            request=RequestExtension(environment="prod", request_id="r1"),
+        )
+        output = Extensions(
+            request=RequestExtension(environment="staging", request_id="r1"),
+        )
+        result = merge_extensions(original, output, frozenset(), "p")
+        assert result is original
+        assert result.request.environment == "prod"
+
+    def test_immutable_agent_ignored(self):
+        original = Extensions(
+            agent=AgentExtension(agent_id="a1", session_id="s1"),
+        )
+        output = Extensions(
+            agent=AgentExtension(agent_id="hijacked", session_id="s1"),
+        )
+        result = merge_extensions(original, output, frozenset({"read_agent"}), "p")
+        assert result is original
+        assert result.agent.agent_id == "a1"
+
+    def test_custom_accepted_without_cap(self):
+        original = Extensions(custom={"key": "val"})
+        output = Extensions(custom={"key": "changed", "new": "stuff"})
+        result = merge_extensions(original, output, frozenset(), "p")
+        assert result.custom == {"key": "changed", "new": "stuff"}
+        # Immutable slots unchanged
+        assert result.request is None
+
+    def test_custom_deletion_accepted(self):
+        original = Extensions(custom={"key": "val"})
+        output = Extensions(custom=None)
+        result = merge_extensions(original, output, frozenset(), "p")
+        assert result.custom is None
+
+    def test_http_accepted_with_write_cap(self):
+        original = Extensions(
+            http=HttpExtension(headers={"X-Foo": "bar"}),
+        )
+        output = Extensions(
+            http=HttpExtension(headers={"X-Foo": "baz"}),
+        )
+        caps = frozenset({"write_headers"})
+        result = merge_extensions(original, output, caps, "p")
+        assert result.http.headers == {"X-Foo": "baz"}
+
+    def test_http_ignored_without_write_cap(self):
+        original = Extensions(
+            http=HttpExtension(headers={"X-Foo": "bar"}),
+        )
+        output = Extensions(
+            http=HttpExtension(headers={"X-Foo": "baz"}),
+        )
+        result = merge_extensions(original, output, frozenset({"read_headers"}), "p")
+        assert result is original
+        assert result.http.headers == {"X-Foo": "bar"}
+
+    def test_labels_accepted_with_append_cap(self):
+        original = Extensions(
+            security=SecurityExtension(labels=frozenset({"PII"})),
+        )
+        output = Extensions(
+            security=SecurityExtension(labels=frozenset({"PII", "CONFIDENTIAL"})),
+        )
+        caps = frozenset({"append_labels"})
+        result = merge_extensions(original, output, caps, "p")
+        assert result.security.labels == frozenset({"PII", "CONFIDENTIAL"})
+
+    def test_labels_ignored_without_cap(self):
+        original = Extensions(
+            security=SecurityExtension(labels=frozenset({"PII"})),
+        )
+        output = Extensions(
+            security=SecurityExtension(labels=frozenset({"PII", "CONFIDENTIAL"})),
+        )
+        result = merge_extensions(original, output, frozenset(), "p")
+        assert result is original
+        assert result.security.labels == frozenset({"PII"})
+
+    def test_labels_removal_rejected(self):
+        original = Extensions(
+            security=SecurityExtension(labels=frozenset({"PII", "CONFIDENTIAL"})),
+        )
+        output = Extensions(
+            security=SecurityExtension(labels=frozenset({"PII"})),
+        )
+        caps = frozenset({"append_labels"})
+        with pytest.raises(TierViolationError) as exc_info:
+            merge_extensions(original, output, caps, "bad-plugin")
+        assert exc_info.value.tier == MutabilityTier.MONOTONIC
+
+    def test_security_subject_ignored(self):
+        """Subject is immutable — plugin changes are discarded."""
+        original = Extensions(
+            security=SecurityExtension(
+                subject=SubjectExtension(
+                    id="alice", type=SubjectType.USER, roles=frozenset({"admin"}),
+                ),
+            ),
+        )
+        output = Extensions(
+            security=SecurityExtension(
+                subject=SubjectExtension(
+                    id="eve", type=SubjectType.USER, roles=frozenset({"root"}),
+                ),
+            ),
+        )
+        caps = frozenset({"read_subject", "read_roles"})
+        result = merge_extensions(original, output, caps, "p")
+        assert result is original
+        assert result.security.subject.id == "alice"
+
+    def test_mixed_changes(self, full_extensions):
+        """Only writable slots are accepted in a single merge."""
+        output = full_extensions.model_copy(update={
+            # Immutable — should be ignored
+            "request": RequestExtension(environment="hijacked", request_id="r1"),
+            # Mutable — should be accepted
+            "custom": {"injected": True},
+        })
+        result = merge_extensions(full_extensions, output, frozenset(), "p")
+        assert result.request.environment == full_extensions.request.environment
+        assert result.custom == {"injected": True}
+
+
+# ---------------------------------------------------------------------------
+# PluginConfig capabilities and frozen lockdown
+# ---------------------------------------------------------------------------
+
+
+class TestPluginConfigCapabilities:
+    _PLUGIN_BASE = {"name": "test-plugin", "kind": "test.Plugin"}
+
+    def test_valid_capabilities(self):
+        from cpex.framework.models import PluginConfig
+
+        conf = PluginConfig(
+            **self._PLUGIN_BASE,
+            capabilities=["read_headers", "append_labels"],
+        )
+        assert conf.capabilities == frozenset({"read_headers", "append_labels"})
+
+    def test_unknown_capability_rejected(self):
+        from cpex.framework.models import PluginConfig
+
+        with pytest.raises(ValueError, match="Unknown capability"):
+            PluginConfig(**self._PLUGIN_BASE, capabilities=["bogus_cap"])
+
+    def test_empty_capabilities_default(self):
+        from cpex.framework.models import PluginConfig
+
+        conf = PluginConfig(**self._PLUGIN_BASE)
+        assert conf.capabilities == frozenset()
+
+    def test_capabilities_serialization(self):
+        import orjson
+
+        from cpex.framework.models import PluginConfig
+
+        conf = PluginConfig(
+            **self._PLUGIN_BASE,
+            capabilities=["read_agent", "read_headers"],
+        )
+        data = orjson.loads(orjson.dumps(conf.model_dump()))
+        assert sorted(data["capabilities"]) == ["read_agent", "read_headers"]
+
+    def test_frozen_config_prevents_capability_escalation(self):
+        from pydantic import ValidationError
+
+        from cpex.framework.models import PluginConfig
+
+        conf = PluginConfig(**self._PLUGIN_BASE)
+        with pytest.raises(ValidationError):
+            conf.capabilities = frozenset({"write_headers"})  # type: ignore[misc]
+
+    def test_frozen_config_prevents_field_mutation(self):
+        from pydantic import ValidationError
+
+        from cpex.framework.models import PluginConfig
+
+        conf = PluginConfig(**self._PLUGIN_BASE)
+        with pytest.raises(ValidationError):
+            conf.name = "hijacked"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Defensive config copy and PluginRef trusted config
+# ---------------------------------------------------------------------------
+
+
+class TestDefensiveConfigCopy:
+    """Verify the trust boundary between Manager and plugins."""
+
+    _PLUGIN_BASE = {"name": "copy-test", "kind": "test.Plugin"}
+
+    def test_plugin_ref_trusted_config_is_separate_from_plugin(self):
+        """PluginRef's trusted_config should be a different object than the plugin's config."""
+        from cpex.framework.base import Plugin, PluginRef
+        from cpex.framework.models import PluginConfig
+
+        original = PluginConfig(**self._PLUGIN_BASE, capabilities=["read_headers"])
+        copy = original.model_copy()
+        plugin = Plugin(copy)
+        ref = PluginRef(plugin, trusted_config=original)
+
+        # The plugin holds the copy, the ref holds the original
+        assert ref.trusted_config is original
+        assert plugin.config is copy
+        assert ref.trusted_config is not plugin.config
+
+    def test_plugin_ref_reads_from_trusted_config(self):
+        """PluginRef properties should read from trusted_config, not from the plugin."""
+        from cpex.framework.base import Plugin, PluginRef
+        from cpex.framework.models import PluginConfig, PluginMode
+
+        original = PluginConfig(
+            **self._PLUGIN_BASE,
+            mode=PluginMode.CONCURRENT,
+            priority=42,
+            tags=["trusted"],
+            capabilities=["read_headers"],
+        )
+        # Give the plugin a different copy with different values
+        plugin_copy = PluginConfig(
+            name="copy-test",
+            kind="test.Plugin",
+            mode=PluginMode.SEQUENTIAL,
+            priority=99,
+            tags=["untrusted"],
+        )
+        plugin = Plugin(plugin_copy)
+        ref = PluginRef(plugin, trusted_config=original)
+
+        # All properties come from trusted_config
+        assert ref.mode == PluginMode.CONCURRENT
+        assert ref.priority == 42
+        assert ref.tags == ["trusted"]
+        assert ref.capabilities == frozenset({"read_headers"})
+
+    def test_plugin_ref_fallback_without_trusted_config(self):
+        """Without trusted_config, PluginRef falls back to plugin.config."""
+        from cpex.framework.base import Plugin, PluginRef
+        from cpex.framework.models import PluginConfig
+
+        config = PluginConfig(**self._PLUGIN_BASE)
+        plugin = Plugin(config)
+        ref = PluginRef(plugin)
+
+        assert ref.trusted_config is plugin.config
+
+    def test_model_copy_produces_equal_but_distinct_config(self):
+        """model_copy() should produce an equal but distinct PluginConfig."""
+        from cpex.framework.models import PluginConfig
+
+        original = PluginConfig(**self._PLUGIN_BASE, capabilities=["append_labels"])
+        copy = original.model_copy()
+
+        assert copy == original
+        assert copy is not original
+        assert copy.capabilities == original.capabilities
+
+    def test_registry_passes_trusted_config_to_ref(self):
+        """PluginInstanceRegistry.register() should pass trusted_config to PluginRef."""
+        from cpex.framework.base import Plugin
+        from cpex.framework.models import PluginConfig
+        from cpex.framework.registry import PluginInstanceRegistry
+
+        original = PluginConfig(**self._PLUGIN_BASE, capabilities=["read_headers"])
+        copy = original.model_copy()
+        plugin = Plugin(copy)
+
+        registry = PluginInstanceRegistry()
+        registry.register(plugin, trusted_config=original)
+
+        ref = registry.get_plugin("copy-test")
+        assert ref is not None
+        assert ref.trusted_config is original
+        assert ref.plugin.config is copy
+        assert ref.trusted_config is not ref.plugin.config

--- a/tests/unit/cpex/framework/extensions/test_tiers.py
+++ b/tests/unit/cpex/framework/extensions/test_tiers.py
@@ -98,10 +98,12 @@ class TestAccessPolicy:
 
 class TestCapability:
     def test_all_values(self):
-        assert len(Capability) == 10  # noqa: PLR2004
+        assert len(Capability) == 12  # noqa: PLR2004
         assert Capability.READ_SUBJECT.value == "read_subject"
         assert Capability.APPEND_LABELS.value == "append_labels"
         assert Capability.WRITE_HEADERS.value == "write_headers"
+        assert Capability.READ_DELEGATION.value == "read_delegation"
+        assert Capability.APPEND_DELEGATION.value == "append_delegation"
 
     def test_string_enum(self):
         assert Capability("read_agent") == Capability.READ_AGENT

--- a/tests/unit/cpex/framework/external/grpc/test_client.py
+++ b/tests/unit/cpex/framework/external/grpc/test_client.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 import pytest
+from pydantic import ValidationError
 
 # First-Party
 from cpex.framework import PluginError, ToolPreInvokePayload
@@ -84,20 +85,14 @@ class TestGrpcExternalPluginInit:
 class TestGrpcExternalPluginInitialize:
     """Tests for GrpcExternalPlugin.initialize()."""
 
-    @pytest.mark.asyncio
-    async def test_initialize_missing_grpc_config(self):
-        """Test initialize raises PluginError when grpc config is missing."""
-        config = PluginConfig(
-            name="TestPlugin",
-            kind="external",
-            hooks=["tool_pre_invoke"],
-            grpc=GRPCClientConfig(target="localhost:50051"),
-        )
-        plugin = GrpcExternalPlugin(config)
-        plugin._config.grpc = None  # Remove grpc config
-
-        with pytest.raises(PluginError, match="grpc section must be defined"):
-            await plugin.initialize()
+    def test_initialize_missing_grpc_config(self):
+        """Test PluginConfig validation rejects external plugin without transport config."""
+        with pytest.raises(ValidationError, match="External plugin.*must have"):
+            PluginConfig(
+                name="TestPlugin",
+                kind="external",
+                hooks=["tool_pre_invoke"],
+            )
 
     @pytest.mark.asyncio
     async def test_initialize_creates_channel(self, mock_plugin_config):

--- a/tests/unit/cpex/framework/external/mcp/test_client_config.py
+++ b/tests/unit/cpex/framework/external/mcp/test_client_config.py
@@ -54,9 +54,9 @@ async def test_initialize_missing_mcp_config():
     config = ConfigLoader.load_config("tests/unit/cpex/fixtures/configs/valid_stdio_external_plugin.yaml")
     plugin_config = config.plugins[0]
 
-    # Create plugin and temporarily set mcp to None
-    plugin = ExternalPlugin(plugin_config)
-    plugin._config.mcp = None
+    # Create plugin with mcp removed via frozen-safe copy
+    no_mcp_config = plugin_config.model_copy(update={"mcp": None})
+    plugin = ExternalPlugin(no_mcp_config)
 
     with pytest.raises(PluginError, match="The mcp section must be defined for external plugin"):
         await plugin.initialize()
@@ -67,10 +67,11 @@ async def test_initialize_stdio_missing_script():
     """Test initialize raises ValueError for missing stdio script."""
     config = ConfigLoader.load_config("tests/unit/cpex/fixtures/configs/valid_stdio_external_plugin.yaml")
     plugin_config = config.plugins[0]
-    plugin = ExternalPlugin(plugin_config)
 
-    # Mock the script path to be missing
-    plugin._config.mcp.script = "/path/to/missing.sh"
+    # Create plugin with missing script via frozen-safe copy
+    bad_mcp = plugin_config.mcp.model_copy(update={"script": "/path/to/missing.sh"})
+    bad_config = plugin_config.model_copy(update={"mcp": bad_mcp})
+    plugin = ExternalPlugin(bad_config)
 
     # Cross-platform: Windows uses backslashes, Unix uses forward slashes
     with pytest.raises(PluginError, match=r"Server script .+[/\\]missing\.sh does not exist\."):

--- a/tests/unit/cpex/framework/external/unix/test_client.py
+++ b/tests/unit/cpex/framework/external/unix/test_client.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 import pytest
+from pydantic import ValidationError
 
 # First-Party
 from cpex.framework import ToolPreInvokePayload
@@ -79,19 +80,13 @@ class TestUnixSocketExternalPluginInit:
         assert plugin._reconnect_delay == 0.1
 
     def test_init_missing_unix_socket_config(self):
-        """Test init raises PluginError when unix_socket config is missing."""
-        config = PluginConfig(
-            name="TestPlugin",
-            kind="external",
-            hooks=["tool_pre_invoke"],
-            unix_socket=UnixSocketClientConfig(path="/tmp/test.sock"),
-        )
-        plugin = UnixSocketExternalPlugin(config)
-        plugin._config.unix_socket = None
-
-        with pytest.raises(PluginError, match="unix_socket section must be defined"):
-            # Re-initialize to trigger the check
-            UnixSocketExternalPlugin.__init__(plugin, config)
+        """Test PluginConfig validation rejects external plugin without transport config."""
+        with pytest.raises(ValidationError, match="External plugin.*must have"):
+            PluginConfig(
+                name="TestPlugin",
+                kind="external",
+                hooks=["tool_pre_invoke"],
+            )
 
 
 class TestUnixSocketExternalPluginConnected:

--- a/tests/unit/cpex/framework/hooks/test_identity.py
+++ b/tests/unit/cpex/framework/hooks/test_identity.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+"""Tests for identity resolution and token delegation hook payloads.
+
+Covers:
+- IdentityPayload construction and SecretStr redaction
+- DelegationPayload construction and SecretStr redaction
+- AttenuationConfig construction
+- IdentityResult construction
+- Serialization safety (tokens redacted in JSON output)
+"""
+
+import pytest
+
+from pydantic import SecretStr
+
+from cpex.framework.hooks.identity import (
+    AttenuationConfig,
+    DelegationPayload,
+    IdentityPayload,
+    IdentityResult,
+)
+from cpex.framework.extensions.security import SubjectExtension, SubjectType
+
+
+class TestIdentityPayload:
+    """Tests for IdentityPayload."""
+
+    def test_basic_construction(self):
+        payload = IdentityPayload(
+            raw_token="eyJhbGciOi...",
+            source="bearer",
+        )
+        assert payload.source == "bearer"
+        assert isinstance(payload.raw_token, SecretStr)
+
+    def test_raw_token_is_secret(self):
+        payload = IdentityPayload(raw_token="secret-jwt", source="bearer")
+        # str() should redact
+        assert "secret-jwt" not in str(payload.raw_token)
+        # get_secret_value() reveals it
+        assert payload.raw_token.get_secret_value() == "secret-jwt"
+
+    def test_serialization_redacts_token(self):
+        payload = IdentityPayload(raw_token="secret-jwt", source="bearer")
+        dumped = payload.model_dump()
+        # The serialized value should not contain the actual token
+        assert dumped["raw_token"] != "secret-jwt"
+
+    def test_with_headers(self):
+        payload = IdentityPayload(
+            raw_token="tok",
+            source="bearer",
+            headers={"authorization": "Bearer tok"},
+            client_host="10.0.0.1",
+            client_port=443,
+        )
+        assert payload.headers["authorization"] == "Bearer tok"
+        assert payload.client_host == "10.0.0.1"
+
+    def test_default_source(self):
+        payload = IdentityPayload(raw_token="tok")
+        assert payload.source == "bearer"
+
+
+class TestDelegationPayload:
+    """Tests for DelegationPayload."""
+
+    def test_basic_construction(self):
+        payload = DelegationPayload(
+            target_name="get_compensation",
+            target_type="tool",
+            required_permissions=["read:compensation"],
+        )
+        assert payload.target_name == "get_compensation"
+        assert payload.target_type == "tool"
+        assert payload.bearer_token is None
+
+    def test_bearer_token_is_secret(self):
+        payload = DelegationPayload(
+            target_name="get_compensation",
+            bearer_token="my-bearer-token",
+        )
+        assert isinstance(payload.bearer_token, SecretStr)
+        assert "my-bearer-token" not in str(payload.bearer_token)
+        assert payload.bearer_token.get_secret_value() == "my-bearer-token"
+
+    def test_serialization_redacts_bearer(self):
+        payload = DelegationPayload(
+            target_name="tool",
+            bearer_token="secret-bearer",
+        )
+        dumped = payload.model_dump()
+        assert dumped["bearer_token"] != "secret-bearer"
+
+    def test_with_attenuation(self):
+        attenuation = AttenuationConfig(
+            capabilities=["read:compensation"],
+            resource_template="hr://employees/{{ args.employee_id }}",
+            actions=["read"],
+            ttl_seconds=60,
+        )
+        payload = DelegationPayload(
+            target_name="get_compensation",
+            auth_enforced_by="target",
+            route_attenuation=attenuation,
+        )
+        assert payload.route_attenuation.capabilities == ["read:compensation"]
+        assert payload.route_attenuation.ttl_seconds == 60
+
+
+class TestAttenuationConfig:
+    """Tests for AttenuationConfig."""
+
+    def test_basic_construction(self):
+        config = AttenuationConfig(
+            capabilities=["read:compensation"],
+            actions=["read"],
+        )
+        assert config.capabilities == ["read:compensation"]
+        assert config.actions == ["read"]
+        assert config.resource_template is None
+        assert config.ttl_seconds is None
+
+    def test_frozen(self):
+        config = AttenuationConfig(capabilities=["read"])
+        with pytest.raises(Exception):
+            config.capabilities = ["write"]
+
+    def test_defaults(self):
+        config = AttenuationConfig()
+        assert config.capabilities == []
+        assert config.actions == []
+        assert config.resource_template is None
+        assert config.ttl_seconds is None
+
+
+class TestIdentityResult:
+    """Tests for IdentityResult."""
+
+    def test_accepted_result(self):
+        subject = SubjectExtension(
+            id="alice@corp.com",
+            type=SubjectType.USER,
+            roles=frozenset({"engineer"}),
+            permissions=frozenset({"tool_execute"}),
+        )
+        result = IdentityResult(subject=subject)
+        assert result.rejected is False
+        assert result.subject.id == "alice@corp.com"
+
+    def test_rejected_result(self):
+        result = IdentityResult(
+            rejected=True,
+            reject_status=401,
+            reject_reason="Token expired",
+        )
+        assert result.rejected is True
+        assert result.reject_status == 401
+        assert result.reject_reason == "Token expired"
+        assert result.subject is None

--- a/tests/unit/cpex/framework/hooks/test_message.py
+++ b/tests/unit/cpex/framework/hooks/test_message.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/cpex/framework/hooks/test_message.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: Teryl Taylor
+
+Unit tests for message evaluation hook definitions.
+"""
+
+# Third-Party
+import pytest
+
+# First-Party
+from cpex.framework.cmf.message import Message, Role, TextContent
+from cpex.framework.hooks.message import (
+    MessageHookType,
+    MessagePayload,
+    MessageResult,
+)
+from cpex.framework.hooks.registry import get_hook_registry
+from cpex.framework.models import PluginPayload, PluginResult
+
+
+# ---------------------------------------------------------------------------
+# MessageHookType Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMessageHookType:
+    """Tests for the MessageHookType enum."""
+
+    def test_evaluate_value(self):
+        assert MessageHookType.EVALUATE.value == "evaluate"
+
+    def test_from_string(self):
+        assert MessageHookType("evaluate") == MessageHookType.EVALUATE
+
+    def test_invalid_value(self):
+        with pytest.raises(ValueError):
+            MessageHookType("invalid")
+
+    def test_member_count(self):
+        assert len(MessageHookType) == 1
+
+    def test_is_str_enum(self):
+        assert isinstance(MessageHookType.EVALUATE, str)
+        assert MessageHookType.EVALUATE == "evaluate"
+
+
+# ---------------------------------------------------------------------------
+# MessagePayload Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMessagePayload:
+    """Tests for the MessagePayload model."""
+
+    def test_subclass_of_plugin_payload(self):
+        assert issubclass(MessagePayload, PluginPayload)
+
+    def test_creation(self):
+        msg = Message(
+            role=Role.USER,
+            content=[TextContent(text="Hello")],
+        )
+        payload = MessagePayload(message=msg)
+        assert payload.message is msg
+        assert payload.message.role == Role.USER
+        assert payload.message.content[0].text == "Hello"
+
+    def test_message_field_required(self):
+        with pytest.raises(Exception):
+            MessagePayload()
+
+    def test_with_multi_part_message(self):
+        msg = Message(
+            role=Role.ASSISTANT,
+            content=[
+                TextContent(text="Part one"),
+                TextContent(text="Part two"),
+            ],
+        )
+        payload = MessagePayload(message=msg)
+        assert len(payload.message.content) == 2
+
+    def test_iter_views_through_payload(self):
+        msg = Message(
+            role=Role.USER,
+            content=[
+                TextContent(text="First"),
+                TextContent(text="Second"),
+            ],
+        )
+        payload = MessagePayload(message=msg)
+        views = list(payload.message.iter_views())
+        assert len(views) == 2
+
+
+# ---------------------------------------------------------------------------
+# MessageResult Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMessageResult:
+    """Tests for the MessageResult type alias."""
+
+    def test_is_plugin_result_subclass(self):
+        assert issubclass(MessageResult, PluginResult)
+
+
+# ---------------------------------------------------------------------------
+# Hook Registration Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMessageHookRegistration:
+    """Tests for message hook registration in the global registry."""
+
+    def test_evaluate_hook_registered(self):
+        registry = get_hook_registry()
+        assert registry.is_registered(MessageHookType.EVALUATE)
+
+    def test_payload_type(self):
+        registry = get_hook_registry()
+        assert registry.get_payload_type(MessageHookType.EVALUATE) is MessagePayload
+
+    def test_result_type(self):
+        registry = get_hook_registry()
+        assert registry.get_result_type(MessageHookType.EVALUATE) is MessageResult
+
+    def test_idempotent_registration(self):
+        """Re-importing or re-calling _register should not raise."""
+        # First-Party
+        from cpex.framework.hooks.message import _register_message_hooks
+
+        _register_message_hooks()
+        registry = get_hook_registry()
+        assert registry.is_registered(MessageHookType.EVALUATE)

--- a/tests/unit/cpex/framework/hooks/test_message.py
+++ b/tests/unit/cpex/framework/hooks/test_message.py
@@ -40,7 +40,7 @@ class TestMessageHookType:
             MessageHookType("invalid")
 
     def test_member_count(self):
-        assert len(MessageHookType) == 1
+        assert len(MessageHookType) == 9
 
     def test_is_str_enum(self):
         assert isinstance(MessageHookType.EVALUATE, str)

--- a/tests/unit/cpex/framework/test_errors.py
+++ b/tests/unit/cpex/framework/test_errors.py
@@ -61,8 +61,9 @@ async def test_error_plugin_raise_error_false():
     # assert not result.modified_payload
 
     await plugin_manager.shutdown()
-    plugin_manager.config.plugins[0].mode = PluginMode.CONCURRENT
-    plugin_manager.config.plugins[0].on_error = OnError.IGNORE
+    plugin_manager.config.plugins[0] = plugin_manager.config.plugins[0].model_copy(
+        update={"mode": PluginMode.CONCURRENT, "on_error": OnError.IGNORE}
+    )
     await plugin_manager.initialize()
     result, _ = await plugin_manager.invoke_hook(PromptHookType.PROMPT_PRE_FETCH, payload, global_context)
     assert result.continue_processing

--- a/tests/unit/cpex/framework/test_extensions_integration.py
+++ b/tests/unit/cpex/framework/test_extensions_integration.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for the extensions pipeline.
+
+Covers the end-to-end flow:
+1. Plugin receives capability-filtered extensions
+2. Plugin modifies allowed slots (labels, custom)
+3. Manager merges modifications back with tier validation
+4. Immutable/monotonic violations are rejected
+"""
+
+import pytest
+
+from cpex.framework.extensions.extensions import Extensions
+from cpex.framework.extensions.security import (
+    SecurityExtension,
+    SubjectExtension,
+    SubjectType,
+)
+from cpex.framework.extensions.delegation import DelegationExtension, DelegationHop
+from cpex.framework.extensions.http import HttpExtension
+from cpex.framework.extensions.tiers import (
+    TierViolationError,
+    filter_extensions,
+    merge_extensions,
+)
+
+
+class TestFilterAndMergeIntegration:
+    """End-to-end: filter → plugin modifies → merge back."""
+
+    def _make_extensions(self):
+        """Create a fully-populated Extensions for testing."""
+        return Extensions(
+            security=SecurityExtension(
+                labels=frozenset({"internal"}),
+                subject=SubjectExtension(
+                    id="alice@corp.com",
+                    type=SubjectType.USER,
+                    roles=frozenset({"engineer"}),
+                    permissions=frozenset({"tool_execute"}),
+                    teams=frozenset({"engineering"}),
+                ),
+            ),
+            http=HttpExtension(headers={"authorization": "Bearer tok", "x-request-id": "req-1"}),
+            delegation=DelegationExtension(),
+            custom={"trace": True},
+        )
+
+    def test_plugin_with_read_labels_sees_labels(self):
+        """A plugin with read_labels capability sees security labels."""
+        ext = self._make_extensions()
+        filtered = filter_extensions(ext, frozenset({"read_labels"}))
+        assert filtered.security is not None
+        assert "internal" in filtered.security.labels
+
+    def test_plugin_without_read_labels_gets_no_labels(self):
+        """A plugin without read_labels capability does not see labels."""
+        ext = self._make_extensions()
+        filtered = filter_extensions(ext, frozenset())
+        # Security may still be present (for objects/data) but labels should be empty
+        if filtered.security:
+            assert len(filtered.security.labels) == 0
+
+    def test_plugin_with_read_subject_sees_identity(self):
+        ext = self._make_extensions()
+        filtered = filter_extensions(ext, frozenset({"read_subject"}))
+        assert filtered.security is not None
+        assert filtered.security.subject is not None
+        assert filtered.security.subject.id == "alice@corp.com"
+
+    def test_plugin_without_read_subject_gets_no_identity(self):
+        ext = self._make_extensions()
+        filtered = filter_extensions(ext, frozenset())
+        if filtered.security and filtered.security.subject:
+            pytest.fail("Plugin without read_subject should not see subject")
+
+    def test_plugin_with_read_headers_sees_headers(self):
+        ext = self._make_extensions()
+        filtered = filter_extensions(ext, frozenset({"read_headers"}))
+        assert filtered.http is not None
+        assert "authorization" in filtered.http.headers
+
+    def test_plugin_without_read_headers_gets_no_http(self):
+        ext = self._make_extensions()
+        filtered = filter_extensions(ext, frozenset())
+        assert filtered.http is None
+
+    def test_delegation_visible_with_capability(self):
+        ext = self._make_extensions()
+        filtered = filter_extensions(ext, frozenset({"read_delegation"}))
+        assert filtered.delegation is not None
+
+    def test_delegation_hidden_without_capability(self):
+        ext = self._make_extensions()
+        filtered = filter_extensions(ext, frozenset())
+        assert filtered.delegation is None
+
+    def test_merge_accepts_label_addition(self):
+        """Labels are monotonic — additions are accepted."""
+        original = self._make_extensions()
+        # Simulate plugin adding a label
+        new_labels = original.security.labels | frozenset({"PII"})
+        new_security = original.security.model_copy(update={"labels": new_labels})
+        modified = original.model_copy(update={"security": new_security})
+
+        merged = merge_extensions(
+            original, modified,
+            frozenset({"read_labels", "append_labels"}),
+            "test-plugin",
+        )
+        assert "PII" in merged.security.labels
+        assert "internal" in merged.security.labels  # original preserved
+
+    def test_merge_rejects_label_removal(self):
+        """Labels are monotonic — removals are rejected."""
+        original = self._make_extensions()
+        # Simulate plugin removing a label
+        new_security = original.security.model_copy(update={"labels": frozenset()})
+        modified = original.model_copy(update={"security": new_security})
+
+        with pytest.raises(TierViolationError):
+            merge_extensions(
+                original, modified,
+                frozenset({"read_labels", "append_labels"}),
+                "bad-plugin",
+            )
+
+    def test_merge_accepts_delegation_chain_growth(self):
+        """Delegation chain is monotonic — growth is accepted with capability."""
+        original = self._make_extensions()
+        hop = DelegationHop(subject_id="alice", subject_type="user", scopes_granted=("read",))
+        new_delegation = original.delegation.with_new_hop(hop)
+        modified = original.model_copy(update={"delegation": new_delegation})
+
+        merged = merge_extensions(
+            original, modified,
+            frozenset({"read_delegation", "append_delegation"}),
+            "test-plugin",
+        )
+        assert merged.delegation.depth == 1
+        assert merged.delegation.chain[0].subject_id == "alice"
+
+    def test_merge_ignores_delegation_without_capability(self):
+        """Delegation changes are ignored without append_delegation capability."""
+        original = self._make_extensions()
+        hop = DelegationHop(subject_id="alice", subject_type="user")
+        new_delegation = original.delegation.with_new_hop(hop)
+        modified = original.model_copy(update={"delegation": new_delegation})
+
+        merged = merge_extensions(
+            original, modified,
+            frozenset(),  # no append_delegation
+            "no-cap-plugin",
+        )
+        # Original delegation preserved — plugin's changes silently dropped
+        assert merged.delegation.depth == 0
+
+    def test_merge_rejects_delegation_chain_shrink(self):
+        """Delegation chain is monotonic — shrinking is rejected."""
+        # Build a 2-hop chain
+        ext = self._make_extensions()
+        hop1 = DelegationHop(subject_id="alice", subject_type="user")
+        hop2 = DelegationHop(subject_id="bob", subject_type="agent")
+        ext1 = ext.model_copy(update={"delegation": ext.delegation.with_new_hop(hop1)})
+        ext2 = ext1.model_copy(update={"delegation": ext1.delegation.with_new_hop(hop2)})
+
+        # Try to shrink back to empty
+        shrunk = ext2.model_copy(update={"delegation": DelegationExtension()})
+        with pytest.raises(TierViolationError):
+            merge_extensions(
+                ext2, shrunk,
+                frozenset({"read_delegation", "append_delegation"}),
+                "bad-plugin",
+            )
+
+    def test_merge_rejects_delegation_chain_tamper(self):
+        """Delegation chain is monotonic — modifying existing hops is rejected."""
+        ext = self._make_extensions()
+        hop1 = DelegationHop(subject_id="alice", subject_type="user")
+        ext1 = ext.model_copy(update={"delegation": ext.delegation.with_new_hop(hop1)})
+
+        # Tamper with the existing hop
+        tampered_hop = DelegationHop(subject_id="mallory", subject_type="user")
+        tampered = ext1.model_copy(
+            update={"delegation": DelegationExtension(
+                chain=(tampered_hop,), depth=1, delegated=True,
+                origin_subject_id="mallory", actor_subject_id="mallory",
+            )}
+        )
+        with pytest.raises(TierViolationError):
+            merge_extensions(
+                ext1, tampered,
+                frozenset({"read_delegation", "append_delegation"}),
+                "tamper-plugin",
+            )
+
+    def test_merge_accepts_custom_changes(self):
+        """Custom extensions are mutable — any change is accepted."""
+        original = self._make_extensions()
+        modified = original.model_copy(update={"custom": {"trace": False, "new_key": "val"}})
+
+        merged = merge_extensions(original, modified, frozenset(), "test-plugin")
+        assert merged.custom["trace"] is False
+        assert merged.custom["new_key"] == "val"
+
+    def test_merge_accepts_header_changes_with_capability(self):
+        """HTTP headers are writable with write_headers capability."""
+        original = self._make_extensions()
+        new_http = HttpExtension(headers={"x-request-id": "req-1", "x-custom": "added"})
+        modified = original.model_copy(update={"http": new_http})
+
+        merged = merge_extensions(
+            original, modified,
+            frozenset({"read_headers", "write_headers"}),
+            "test-plugin",
+        )
+        assert "x-custom" in merged.http.headers
+
+    def test_merge_ignores_header_changes_without_capability(self):
+        """HTTP headers are NOT writable without write_headers capability."""
+        original = self._make_extensions()
+        new_http = HttpExtension(headers={"x-custom": "sneaky"})
+        modified = original.model_copy(update={"http": new_http})
+
+        merged = merge_extensions(
+            original, modified,
+            frozenset(),  # no write_headers
+            "no-cap-plugin",
+        )
+        # Original headers preserved — plugin's changes ignored
+        assert "x-custom" not in merged.http.headers
+        assert "authorization" in merged.http.headers

--- a/tests/unit/cpex/framework/test_manager_extended.py
+++ b/tests/unit/cpex/framework/test_manager_extended.py
@@ -116,10 +116,12 @@ async def test_manager_timeout_handling():
         # assert "timeout" in result.violation.description.lower()
 
     # Test with audit mode + on_error=IGNORE (errors are logged and ignored)
-    plugin_config.mode = PluginMode.AUDIT
-    plugin_config.on_error = OnError.IGNORE
+    audit_config = plugin_config.model_copy(
+        update={"mode": PluginMode.AUDIT, "on_error": OnError.IGNORE}
+    )
+    audit_plugin = TimeoutPlugin(audit_config)
     with patch.object(manager._registry, "get_hook_refs_for_hook") as mock_get:
-        hook_ref = HookRef(PromptHookType.PROMPT_PRE_FETCH, PluginRef(timeout_plugin))
+        hook_ref = HookRef(PromptHookType.PROMPT_PRE_FETCH, PluginRef(audit_plugin))
         mock_get.return_value = [hook_ref]
 
         result, _ = await manager.invoke_hook(PromptHookType.PROMPT_PRE_FETCH, prompt, global_context=global_context)
@@ -177,10 +179,12 @@ async def test_manager_exception_handling():
         # assert "error" in result.violation.description.lower()
 
     # Test with audit mode + on_error=IGNORE (errors are logged and ignored)
-    plugin_config.mode = PluginMode.AUDIT
-    plugin_config.on_error = OnError.IGNORE
+    audit_config = plugin_config.model_copy(
+        update={"mode": PluginMode.AUDIT, "on_error": OnError.IGNORE}
+    )
+    audit_plugin = ErrorPlugin(audit_config)
     with patch.object(manager._registry, "get_hook_refs_for_hook") as mock_get:
-        hook_ref = HookRef(PromptHookType.PROMPT_PRE_FETCH, PluginRef(error_plugin))
+        hook_ref = HookRef(PromptHookType.PROMPT_PRE_FETCH, PluginRef(audit_plugin))
         mock_get.return_value = [hook_ref]
 
         result, _ = await manager.invoke_hook(PromptHookType.PROMPT_PRE_FETCH, prompt, global_context=global_context)
@@ -189,41 +193,21 @@ async def test_manager_exception_handling():
         assert result.continue_processing
         assert result.violation is None
 
-    plugin_config.mode = PluginMode.CONCURRENT
-    plugin_config.on_error = OnError.IGNORE
-    with patch.object(manager._registry, "get_hook_refs_for_hook") as mock_get:
-        hook_ref = HookRef(PromptHookType.PROMPT_PRE_FETCH, PluginRef(error_plugin))
-        mock_get.return_value = [hook_ref]
+    # Test with concurrent mode + on_error=IGNORE (repeated to verify consistency)
+    ignore_config = plugin_config.model_copy(
+        update={"mode": PluginMode.CONCURRENT, "on_error": OnError.IGNORE}
+    )
+    ignore_plugin = ErrorPlugin(ignore_config)
+    for _ in range(3):
+        with patch.object(manager._registry, "get_hook_refs_for_hook") as mock_get:
+            hook_ref = HookRef(PromptHookType.PROMPT_PRE_FETCH, PluginRef(ignore_plugin))
+            mock_get.return_value = [hook_ref]
 
-        result, _ = await manager.invoke_hook(PromptHookType.PROMPT_PRE_FETCH, prompt, global_context=global_context)
+            result, _ = await manager.invoke_hook(PromptHookType.PROMPT_PRE_FETCH, prompt, global_context=global_context)
 
-        # Should continue with on_error=ignore
-        assert result.continue_processing
-        assert result.violation is None
-
-    plugin_config.mode = PluginMode.CONCURRENT
-    plugin_config.on_error = OnError.IGNORE
-    with patch.object(manager._registry, "get_hook_refs_for_hook") as mock_get:
-        hook_ref = HookRef(PromptHookType.PROMPT_PRE_FETCH, PluginRef(error_plugin))
-        mock_get.return_value = [hook_ref]
-
-        result, _ = await manager.invoke_hook(PromptHookType.PROMPT_PRE_FETCH, prompt, global_context=global_context)
-
-        # Should continue with on_error=ignore
-        assert result.continue_processing
-        assert result.violation is None
-
-    plugin_config.mode = PluginMode.CONCURRENT
-    plugin_config.on_error = OnError.IGNORE
-    with patch.object(manager._registry, "get_hook_refs_for_hook") as mock_get:
-        hook_ref = HookRef(PromptHookType.PROMPT_PRE_FETCH, PluginRef(error_plugin))
-        mock_get.return_value = [hook_ref]
-
-        result, _ = await manager.invoke_hook(PromptHookType.PROMPT_PRE_FETCH, prompt, global_context=global_context)
-
-        # Should continue with on_error=ignore
-        assert result.continue_processing
-        assert result.violation is None
+            # Should continue with on_error=ignore
+            assert result.continue_processing
+            assert result.violation is None
 
     await manager.shutdown()
 

--- a/tests/unit/cpex/framework/test_manager_extensions.py
+++ b/tests/unit/cpex/framework/test_manager_extensions.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+"""Tests for PluginManager with extensions-aware plugins.
+
+Covers:
+- _execute_with_timeout with accepts_extensions=True
+- Plugin receives capability-filtered extensions
+- Extensions passed through invoke_hook reach the plugin
+"""
+
+import pytest
+
+from cpex.framework import (
+    GlobalContext,
+    PluginManager,
+    ToolHookType,
+    ToolPreInvokePayload,
+)
+from cpex.framework.extensions.extensions import Extensions
+from cpex.framework.extensions.security import (
+    SecurityExtension,
+    SubjectExtension,
+    SubjectType,
+)
+
+
+@pytest.mark.asyncio
+async def test_manager_extensions_aware_plugin_receives_extensions():
+    """An extensions-aware plugin (3-param hook) receives filtered extensions."""
+    manager = PluginManager("./tests/unit/cpex/fixtures/configs/extensions_aware_plugin.yaml")
+    await manager.initialize()
+
+    extensions = Extensions(
+        security=SecurityExtension(
+            labels=frozenset({"internal"}),
+            subject=SubjectExtension(
+                id="alice@corp.com",
+                type=SubjectType.USER,
+                roles=frozenset({"required_role", "engineer"}),
+                permissions=frozenset({"tool_execute"}),
+            ),
+        ),
+    )
+
+    payload = ToolPreInvokePayload(name="test_tool", args={"key": "value"})
+    context = GlobalContext(request_id="req-1")
+
+    result, contexts = await manager.invoke_hook(
+        ToolHookType.TOOL_PRE_INVOKE,
+        payload,
+        global_context=context,
+        extensions=extensions,
+    )
+
+    assert result.continue_processing is True
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_manager_extensions_aware_plugin_without_extensions():
+    """An extensions-aware plugin works when no extensions are passed."""
+    manager = PluginManager("./tests/unit/cpex/fixtures/configs/extensions_aware_plugin.yaml")
+    await manager.initialize()
+
+    payload = ToolPreInvokePayload(name="test_tool", args={"key": "value"})
+    context = GlobalContext(request_id="req-1")
+
+    # No extensions passed — plugin should still work (backward compat)
+    result, contexts = await manager.invoke_hook(
+        ToolHookType.TOOL_PRE_INVOKE,
+        payload,
+        global_context=context,
+    )
+
+    assert result.continue_processing is True
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_manager_extensions_capability_filtering():
+    """Extensions are filtered by the plugin's declared capabilities."""
+    manager = PluginManager("./tests/unit/cpex/fixtures/configs/extensions_aware_plugin.yaml")
+    await manager.initialize()
+
+    # Create extensions with HTTP headers — plugin doesn't have read_headers capability
+    from cpex.framework.extensions.http import HttpExtension
+
+    extensions = Extensions(
+        security=SecurityExtension(
+            labels=frozenset({"PII"}),
+            subject=SubjectExtension(
+                id="alice@corp.com",
+                type=SubjectType.USER,
+                roles=frozenset({"engineer"}),
+            ),
+        ),
+        http=HttpExtension(headers={"authorization": "Bearer secret"}),
+    )
+
+    payload = ToolPreInvokePayload(name="test_tool", args={"key": "value"})
+    context = GlobalContext(request_id="req-1")
+
+    result, contexts = await manager.invoke_hook(
+        ToolHookType.TOOL_PRE_INVOKE,
+        payload,
+        global_context=context,
+        extensions=extensions,
+    )
+
+    # Plugin should execute successfully — it has read_subject and read_labels
+    # but NOT read_headers, so HTTP headers should be filtered out by the framework
+    assert result.continue_processing is True
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_manager_plugin_adds_label_and_manager_merges():
+    """Plugin adds a label to extensions; manager merges it back in the result."""
+    manager = PluginManager("./tests/unit/cpex/fixtures/configs/extensions_label_plugin.yaml")
+    await manager.initialize()
+
+    extensions = Extensions(
+        security=SecurityExtension(
+            labels=frozenset({"internal"}),
+        ),
+    )
+
+    payload = ToolPreInvokePayload(name="test_tool", args={"key": "value"})
+    context = GlobalContext(request_id="req-1")
+
+    result, contexts = await manager.invoke_hook(
+        ToolHookType.TOOL_PRE_INVOKE,
+        payload,
+        global_context=context,
+        extensions=extensions,
+    )
+
+    assert result.continue_processing is True
+
+    # The plugin should have added 'PLUGIN_TOUCHED' label via modified_extensions
+    assert result.modified_extensions is not None
+    assert "PLUGIN_TOUCHED" in result.modified_extensions.security.labels
+    # Original label should still be present (monotonic — only growth)
+    assert "internal" in result.modified_extensions.security.labels
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_manager_plugin_writes_custom_extensions():
+    """Plugin reads labels and writes observation to custom extensions."""
+    manager = PluginManager("./tests/unit/cpex/fixtures/configs/extensions_custom_plugin.yaml")
+    await manager.initialize()
+
+    extensions = Extensions(
+        security=SecurityExtension(
+            labels=frozenset({"PII", "financial"}),
+        ),
+    )
+
+    payload = ToolPreInvokePayload(name="test_tool", args={"key": "value"})
+    context = GlobalContext(request_id="req-1")
+
+    result, contexts = await manager.invoke_hook(
+        ToolHookType.TOOL_PRE_INVOKE,
+        payload,
+        global_context=context,
+        extensions=extensions,
+    )
+
+    assert result.continue_processing is True
+    # Plugin should have written pii_detected=True to custom extensions
+    assert result.modified_extensions is not None
+    assert result.modified_extensions.custom["pii_detected"] is True
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_manager_plugin_custom_no_pii():
+    """Plugin reads labels — no PII label means pii_detected=False."""
+    manager = PluginManager("./tests/unit/cpex/fixtures/configs/extensions_custom_plugin.yaml")
+    await manager.initialize()
+
+    extensions = Extensions(
+        security=SecurityExtension(
+            labels=frozenset({"internal"}),
+        ),
+    )
+
+    payload = ToolPreInvokePayload(name="test_tool", args={"key": "value"})
+    context = GlobalContext(request_id="req-1")
+
+    result, contexts = await manager.invoke_hook(
+        ToolHookType.TOOL_PRE_INVOKE,
+        payload,
+        global_context=context,
+        extensions=extensions,
+    )
+
+    assert result.continue_processing is True
+    assert result.modified_extensions is not None
+    assert result.modified_extensions.custom["pii_detected"] is False
+    await manager.shutdown()

--- a/tests/unit/cpex/framework/test_plugin_base_coverage.py
+++ b/tests/unit/cpex/framework/test_plugin_base_coverage.py
@@ -64,6 +64,13 @@ class BadSigPlugin(Plugin):
         return PluginResult(continue_processing=True)
 
 
+class ThreeParamPlugin(Plugin):
+    """Plugin with 3 parameters (accepts extensions)."""
+
+    async def tool_pre_invoke(self, payload: PluginPayload, context: PluginContext, extensions) -> PluginResult:
+        return PluginResult(continue_processing=True)
+
+
 class NoHookPlugin(Plugin):
     """Plugin with no method matching the hook."""
 
@@ -154,6 +161,19 @@ class TestHookRef:
         ref = PluginRef(plugin)
         with pytest.raises(PluginError, match="invalid signature"):
             HookRef("tool_pre_invoke", ref)
+
+    def test_three_param_plugin_accepted(self):
+        plugin = ThreeParamPlugin(_make_config())
+        ref = PluginRef(plugin)
+        hook_ref = HookRef("tool_pre_invoke", ref)
+        assert hook_ref.hook is not None
+        assert hook_ref.accepts_extensions is True
+
+    def test_two_param_plugin_no_extensions(self):
+        plugin = ConcretePlugin(_make_config())
+        ref = PluginRef(plugin)
+        hook_ref = HookRef("tool_pre_invoke", ref)
+        assert hook_ref.accepts_extensions is False
 
     def test_sync_method_raises(self):
         plugin = SyncPlugin(_make_config())

--- a/tests/unit/cpex/framework/test_resource_hooks.py
+++ b/tests/unit/cpex/framework/test_resource_hooks.py
@@ -419,9 +419,12 @@ class TestResourceHookIntegration:
             assert result.continue_processing is True  # Continues despite error
 
         # Test with concurrent mode + on_error=FAIL (default) - should raise PluginError
-        config.mode = PluginMode.CONCURRENT
-        config.on_error = OnError.FAIL
-        with patch.object(manager._registry, "get_hook_refs_for_hook", return_value=[hook_ref]):
+        fail_config = config.model_copy(
+            update={"mode": PluginMode.CONCURRENT, "on_error": OnError.FAIL}
+        )
+        fail_plugin = ErrorPlugin(fail_config)
+        fail_ref = HookRef(ResourceHookType.RESOURCE_PRE_FETCH, PluginRef(fail_plugin))
+        with patch.object(manager._registry, "get_hook_refs_for_hook", return_value=[fail_ref]):
             with pytest.raises(PluginError):
                 result, contexts = await manager.invoke_hook(
                     ResourceHookType.RESOURCE_PRE_FETCH, payload, global_context


### PR DESCRIPTION
### Summary

As the plugin framework grows to support multi-tenant deployments, security-sensitive workloads, and diverse authentication methods, plugins increasingly need access to contextual metadata: who is making the request, what security labels apply, which HTTP headers were sent, and what agent is orchestrating the call. Today, this metadata is either unavailable to plugins or scattered across payload fields (such as the now-deprecated headers). Extensions address this by providing a single, structured envelope of contextual metadata that travels alongside every hook invocation. But not every plugin should see everything: a logging plugin does not need the user's security clearance, and no plugin should be able to forge identity claims. Capabilities govern this: each plugin declares what it can read and write, and the framework enforces those boundaries automatically. Together, extensions and capabilities give plugin authors rich context while giving platform operators fine-grained control over what each plugin can access and modify.

[CMF Specification](https://github.com/contextforge-org/contextforge-plugins-framework/blob/652ea1d7311460c09d9502ce0446702bfa53d10c/docs/specs/cmf-message-spec.md)

Closes: #4

### Changes

- Introduces a typed Extensions system (`cpex/framework/extensions/`) with optional metadata slots: security (subject, labels, classification, objects, data), HTTP headers, agent context, MCP metadata, provenance, request context, LLM parameters, and custom fields. These flow through the plugin pipeline as structured, frozen Pydantic models.
- Implements a capability-based access control tier system with three mutability levels:
  - **Immutable** (request, provenance, subject, objects, data, classification): plugins can read with the right capability but never modify.
  - **Monotonic** (security labels): plugins can append but never remove, enforced via superset validation on merge.
  - **Mutable** (HTTP headers, agent, custom): plugins with write capabilities can freely modify.
- Build-up filtering (`filter_extensions`) constructs a new `Extensions` object from empty, copying in only the slots granted by the plugin's declared capabilities. Secure by default: new slots remain hidden unless explicitly included.
- Selective merge (`merge_extensions`) controls what the manager accepts back from plugins: immutable slots are silently ignored, monotonic slots are validated for superset, and mutable slots are accepted. No costly before/after diff is needed.
- `SlotName` enum and `FIELD_*` constants in `constants.py` provide a single source of truth for all slot registry keys and Pydantic field names, preventing typo-induced duplicates.
- Optional third-argument dispatch: plugins opt into receiving extensions by adding an `extensions` parameter to their hook method. The signature is inspected once at registration time and stored as a boolean on `HookRef`, with a single branch at dispatch. All 30+ existing 2-parameter plugins continue to work unchanged with zero overhead. Extensions are filtered per plugin via `filter_extensions(extensions, plugin.capabilities)` at the dispatch site.
- Extensions are passed separately from the payload. The payload stays immutable and shared across all plugins (zero copies unless a plugin modifies it); only the small `Extensions` object is filtered/copied per plugin. This maps directly to Rust's `Arc<Payload>` + per-plugin stack-value pattern.
- Adds the Common Message Format (CMF): frozen `Message` and `MessageView` models for multi-modal conversations, with message hooks (`message_pre_invoke`, `message_post_invoke`) for pipeline processing.
- Adds deprecation warnings on redundant header fields across HTTP, agent, and tool payloads (superseded by `extensions.http.headers`), using `warnings.warn(DeprecationWarning)`, which fires once per call site.

### Test Plan

- `python -m pytest tests/ -x -q --tb=short` — all 1159 tests pass
- Verify existing 2-parameter plugins work unchanged (no extensions argument required)
- Verify 3-parameter plugins receive filtered extensions based on declared capabilities
- Verify tier enforcement: immutable slots ignored on merge, monotonic validated for superset, mutable accepted
- Verify `filter_extensions` builds up from empty; undeclared capabilities produce `None` slots
- Verify `merge_extensions` silently drops immutable slot changes and rejects label removal
- Verify deprecation warnings fire once per call site (no log spam)