### PR TITLE
fix: handle exception types when isolating payloads

### DIFF
--- a/cpex/framework/memory.py
+++ b/cpex/framework/memory.py
@@ -558,6 +558,8 @@ def _wrap_value(value: Any) -> Any:
         return value
     if isinstance(value, _PRIMITIVE_TYPES):
         return value
+    if isinstance(value, BaseException):
+        return value
     if isinstance(value, RootModel):
         root = value.root
         if isinstance(root, dict):

--- a/tests/unit/cpex/framework/test_memory.py
+++ b/tests/unit/cpex/framework/test_memory.py
@@ -1396,3 +1396,99 @@ class TestSafeDeepCopy:
 
         assert result is lock
         assert "Cannot deep-copy" in caplog.text or "sharing reference" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Tests: BaseException isolation (no deepcopy)
+# ---------------------------------------------------------------------------
+
+
+class _NonCopyableError(Exception):
+    """Exception whose __init__ uses keyword-only args, breaking deepcopy."""
+
+    def __init__(self, *, message: str = "error", request: object = None):
+        super().__init__(message)
+        self.request = request
+
+
+class _PayloadWithException(BaseModel):
+    """Payload carrying an exception field (like GenerationErrorPayload)."""
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    name: str = "test"
+    exception: BaseException
+
+
+class _PayloadWithExceptionAndDict(BaseModel):
+    """Payload with both an exception and a mutable dict field."""
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    name: str = "test"
+    exception: BaseException
+    args: dict = Field(default_factory=dict)
+
+
+class TestExceptionIsolation:
+    """Tests for BaseException handling in payload isolation."""
+
+    def test_wrap_value_returns_exception_as_is(self):
+        """_wrap_value returns a BaseException instance without copying."""
+        exc = ValueError("something went wrong")
+        result = _wrap_value(exc)
+        assert result is exc
+
+    def test_wrap_value_returns_non_copyable_exception_as_is(self):
+        """_wrap_value returns exceptions with keyword-only __init__ as-is."""
+        exc = _NonCopyableError(message="conn error", request=None)
+        result = _wrap_value(exc)
+        assert result is exc
+
+    def test_wrap_payload_exception_field_shared(self):
+        """Exception field in a payload is shared by reference after isolation."""
+        exc = _NonCopyableError(message="conn error", request=None)
+        p = _PayloadWithException(name="x", exception=exc)
+
+        wrapped = wrap_payload_for_isolation(p)
+
+        assert wrapped.exception is exc
+
+    def test_wrap_payload_exception_no_warning(self, caplog):
+        """Isolating a payload with an exception field produces no deepcopy warning."""
+        import logging
+
+        exc = _NonCopyableError(message="conn error", request=None)
+        p = _PayloadWithException(name="x", exception=exc)
+
+        with caplog.at_level(logging.WARNING):
+            wrap_payload_for_isolation(p)
+
+        assert "Cannot deep-copy" not in caplog.text
+
+    def test_wrap_payload_exception_alongside_dict(self):
+        """Exception is shared while dict field is CoW-wrapped."""
+        exc = _NonCopyableError(message="conn error", request=None)
+        original_args = {"key": "val"}
+        p = _PayloadWithExceptionAndDict(
+            name="x", exception=exc, args=original_args
+        )
+
+        wrapped = wrap_payload_for_isolation(p)
+
+        assert wrapped.exception is exc
+        assert isinstance(wrapped.args, CopyOnWriteDict)
+        wrapped.args["key"] = "changed"
+        assert original_args["key"] == "val"
+
+    def test_wrap_value_base_exception_subclass(self):
+        """_wrap_value handles BaseException subclasses (not just Exception)."""
+        exc = KeyboardInterrupt()
+        result = _wrap_value(exc)
+        assert result is exc
+
+    def test_wrap_value_standard_exception(self):
+        """_wrap_value handles standard copyable exceptions as-is too."""
+        exc = RuntimeError("boom")
+        result = _wrap_value(exc)
+        assert result is exc


### PR DESCRIPTION
### Summary
CPEX should not try to deep copy exception objects in payload fields.

Closes: #41 

### Changes
One line added to `_wrap_value()` in `cpex/framework/memory.py`: `BaseException` isinstance check that returns the exception object as-is, placed right after the primitives check and before other checks. This prevents `_safe_deepcopy` from ever being called on exception objects.

Why it's safe: Exceptions are effectively immutable in practice. Plugins should not mutate the exception, so sharing by reference is acceptable.

Tests added: 7 new tests in TestExceptionIsolation covering `_wrap_value` with standard exceptions, non-copyable exceptions (keyword-only `__init__`), `BaseException` subclasses, full `wrap_payload_for_isolation` on exception-carrying payloads, no-warning verification, and exception + dict coexistence in the same payload.

### Checks

- [x] `make lint` passes
- [x] `make test` passes