### PR TITLE
fix: respect PLUGINS_LOG_LEVEL environment variable in all runtime.py files

### DIFF
--- a/cpex/framework/external/grpc/server/runtime.py
+++ b/cpex/framework/external/grpc/server/runtime.py
@@ -289,10 +289,13 @@ Examples:
 
     args = parser.parse_args()
 
-    # Configure logging
+    # Configure logging - respect PLUGINS_LOG_LEVEL environment variable
+    log_level_str = os.getenv("PLUGINS_LOG_LEVEL", args.log_level).upper()
+    log_level = getattr(logging, log_level_str, logging.INFO)
     logging.basicConfig(
-        level=getattr(logging, args.log_level),
+        level=log_level,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        stream=sys.stderr,
     )
 
     # Run the server

--- a/cpex/framework/external/grpc/server/runtime.py
+++ b/cpex/framework/external/grpc/server/runtime.py
@@ -290,8 +290,9 @@ Examples:
     args = parser.parse_args()
 
     # Configure logging - respect PLUGINS_LOG_LEVEL environment variable
-    log_level_str = os.getenv("PLUGINS_LOG_LEVEL", args.log_level).upper()
-    log_level = getattr(logging, log_level_str, logging.INFO)
+    settings = get_settings()
+    log_level_str = settings.log_level or args.log_level
+    log_level = getattr(logging, log_level_str.upper(), logging.INFO)
     logging.basicConfig(
         level=log_level,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",

--- a/cpex/framework/external/mcp/server/runtime.py
+++ b/cpex/framework/external/mcp/server/runtime.py
@@ -81,6 +81,15 @@ from cpex.framework.constants import (
 )
 from cpex.framework.settings import get_transport_settings
 
+# Configure logging - respect PLUGINS_LOG_LEVEL environment variable
+log_level_str = os.getenv("PLUGINS_LOG_LEVEL", "INFO").upper()
+log_level = getattr(logging, log_level_str, logging.INFO)
+logging.basicConfig(
+    level=log_level,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    stream=sys.stderr,
+)
+
 logger = logging.getLogger(__name__)
 
 SERVER: ExternalPluginServer | None = None

--- a/cpex/framework/external/mcp/server/runtime.py
+++ b/cpex/framework/external/mcp/server/runtime.py
@@ -79,11 +79,13 @@ from cpex.framework.constants import (
     MCP_SERVER_INSTRUCTIONS,
     MCP_SERVER_NAME,
 )
-from cpex.framework.settings import get_transport_settings
 
 # Configure logging - respect PLUGINS_LOG_LEVEL environment variable
-log_level_str = os.getenv("PLUGINS_LOG_LEVEL", "INFO").upper()
-log_level = getattr(logging, log_level_str, logging.INFO)
+from cpex.framework.settings import get_settings, get_transport_settings
+
+settings = get_settings()
+log_level_str = settings.log_level
+log_level = getattr(logging, log_level_str.upper(), logging.INFO)
 logging.basicConfig(
     level=log_level,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",

--- a/cpex/framework/external/unix/server/runtime.py
+++ b/cpex/framework/external/unix/server/runtime.py
@@ -33,9 +33,11 @@ import sys
 from cpex.framework.external.unix.server.server import run_server
 from cpex.framework.settings import get_settings
 
-# Configure logging
+# Configure logging - respect PLUGINS_LOG_LEVEL environment variable
+log_level_str = os.getenv("PLUGINS_LOG_LEVEL", "INFO").upper()
+log_level = getattr(logging, log_level_str, logging.INFO)
 logging.basicConfig(
-    level=logging.INFO,
+    level=log_level,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     stream=sys.stderr,  # Log to stderr to keep stdout clean for coordination
 )

--- a/cpex/framework/external/unix/server/runtime.py
+++ b/cpex/framework/external/unix/server/runtime.py
@@ -34,8 +34,9 @@ from cpex.framework.external.unix.server.server import run_server
 from cpex.framework.settings import get_settings
 
 # Configure logging - respect PLUGINS_LOG_LEVEL environment variable
-log_level_str = os.getenv("PLUGINS_LOG_LEVEL", "INFO").upper()
-log_level = getattr(logging, log_level_str, logging.INFO)
+settings = get_settings()
+log_level_str = settings.log_level
+log_level = getattr(logging, log_level_str.upper(), logging.INFO)
 logging.basicConfig(
     level=log_level,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",


### PR DESCRIPTION
### Summary
This PR fixes a bug where the `PLUGINS_LOG_LEVEL` environment variable was not being respected in the external plugin server runtime files. This ensures consistent logging behavior across all plugin server implementations (gRPC, MCP, and Unix socket).

This is a bug fix ported from the original Context Forge repository where plugins were initially developed before being split into this separate repository.

**Related Context Forge Issues:**
- Original PR: https://github.com/IBM/mcp-context-forge/pull/4363
- Original Issue: https://github.com/IBM/mcp-context-forge/issues/4359

### Changes
- Updated `cpex/framework/external/grpc/server/runtime.py` to check `PLUGINS_LOG_LEVEL` environment variable before falling back to command-line argument
- Updated `cpex/framework/external/mcp/server/runtime.py` to add logging configuration that respects `PLUGINS_LOG_LEVEL` environment variable
- Updated `cpex/framework/external/unix/server/runtime.py` to respect `PLUGINS_LOG_LEVEL` environment variable instead of hardcoded `INFO` level
- All implementations now consistently log to `stderr` and follow the same pattern:
  ```python
  log_level_str = os.getenv("PLUGINS_LOG_LEVEL", "INFO").upper()
  log_level = getattr(logging, log_level_str, logging.INFO)
  logging.basicConfig(
      level=log_level,
      format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
      stream=sys.stderr,
  )
  ```

### Checks

- [x] `make lint` passes
- [x] `make test` passes
- [ ] CHANGELOG updated (if user-facing)

### Notes (optional)
The `PLUGINS_LOG_LEVEL` environment variable is already documented in `.env.example` (line 13). This fix ensures that all three external plugin server runtimes honor this configuration consistently.
