### PR TITLE
feat: improve APL ergonomics

### DIFF
--- a/crates/apl-core/src/parser.rs
+++ b/crates/apl-core/src/parser.rs
@@ -474,6 +474,19 @@ pub fn parse_rule(line: &str, source: &str) -> Result<Rule, ParseError> {
                     source: source.to_string(),
                 });
             }
+            // Unconditional `deny('reason')` / `deny('reason', 'code')` —
+            // the call form of a bare deny. Lets reaction lists
+            // (`on_deny: [...]` / `on_allow: [...]`) and standalone rule
+            // lines attach a reason/code without a guard predicate. A
+            // malformed `deny(...)` surfaces its own error here rather
+            // than being misread as a predicate downstream.
+            if let Some(deny) = try_parse_deny_call(trimmed, trimmed)? {
+                return Ok(Rule {
+                    condition: Expression::Always,
+                    effects: vec![deny],
+                    source: source.to_string(),
+                });
+            }
             // DSL §2 default: bare predicate denies.
             (trimmed, vec![Effect::Deny { reason: None, code: None }])
         }
@@ -2460,6 +2473,40 @@ mod tests {
         let r = parse_rule("allow", "test").unwrap();
         assert_eq!(r.condition, Expression::Always);
         assert!(matches!(r.effects.as_slice(), [Effect::Allow]));
+    }
+
+    #[test]
+    fn rule_bare_deny_call_carries_reason_and_code() {
+        // Unconditional `deny('reason')` / `deny('reason', 'code')` parse
+        // to an Always-guarded Deny, so they're usable as bare rule lines
+        // and as `on_deny:` / `on_allow:` reactions.
+        let r = parse_rule("deny('nope')", "test").unwrap();
+        assert_eq!(r.condition, Expression::Always);
+        match r.effects.as_slice() {
+            [Effect::Deny { reason: Some(reason), code: None }] => assert_eq!(reason, "nope"),
+            other => panic!("expected [Deny{{reason: Some, code: None}}], got {:?}", other),
+        }
+
+        let r = parse_rule("deny('nope', 'cel.policy')", "test").unwrap();
+        assert_eq!(r.condition, Expression::Always);
+        match r.effects.as_slice() {
+            [Effect::Deny { reason: Some(reason), code: Some(code) }] => {
+                assert_eq!(reason, "nope");
+                assert_eq!(code, "cel.policy");
+            }
+            other => panic!("expected [Deny{{reason, code}}], got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn rule_malformed_bare_deny_call_errors() {
+        // A malformed `deny(...)` must surface its own error rather than
+        // falling through to the predicate parser.
+        let err = parse_rule("deny(unquoted)", "test").unwrap_err();
+        assert!(
+            matches!(err, ParseError::Rule { .. }),
+            "expected ParseError::Rule, got {:?}", err
+        );
     }
 
     #[test]

--- a/crates/apl-core/src/parser.rs
+++ b/crates/apl-core/src/parser.rs
@@ -1897,7 +1897,16 @@ fn parse_stage(src: &str) -> Result<Stage, ParseError> {
             )))
         }
         // `run` is an alias for `plugin` (mirrors the policy-step alias).
-        ("plugin" | "run", Some(a)) => Ok(Stage::Plugin { name: a.trim().to_string() }),
+        ("plugin" | "run", Some(a)) => {
+            let name = a.trim();
+            if name.is_empty() {
+                // Mirror the empty-name guard in `parse_step_string` so
+                // both the policy-step and field-stage paths reject a
+                // nameless `plugin()` / `run()` with the same diagnostic.
+                return Err(bad(&format!("`{head}(...)`: plugin name must not be empty")));
+            }
+            Ok(Stage::Plugin { name: name.to_string() })
+        }
         ("taint", Some(a)) => parse_taint(a, src),
 
         (other, _) => Err(bad(&format!("unknown stage `{}`", other))),
@@ -2836,6 +2845,22 @@ do: "args.card_number | run(luhn)"
                 }
             }
             other => panic!("expected single FieldOp, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn field_stage_plugin_empty_name_is_rejected() {
+        // `plugin()` / `run()` with no name in a field pipeline must be
+        // rejected, mirroring the policy-step path (`parse_step_string`).
+        // Previously the field-stage path accepted it as
+        // `Stage::Plugin { name: "" }`.
+        for verb in ["plugin", "run"] {
+            let err = parse_stage(&format!("{verb}()")).expect_err("empty name must error");
+            let msg = format!("{err}");
+            assert!(
+                msg.contains(verb) && msg.contains("must not be empty"),
+                "{verb}(): expected verb-named empty-name error, got: {msg}"
+            );
         }
     }
 

--- a/crates/apl-core/src/parser.rs
+++ b/crates/apl-core/src/parser.rs
@@ -579,10 +579,10 @@ fn parse_require_rule(line: &str) -> Result<Expression, ParseError> {
     })
 }
 
-/// Detect `taint(...)` / `plugin(...)` / `cedar:` / `cedarling:` / `opa(` / `authzen(` / `nemo(` / `cel:`.
+/// Detect `taint(...)` / `plugin(...)` / `run(...)` / `cedar:` / `cedarling:` / `opa(` / `authzen(` / `nemo(` / `cel:`.
 fn detect_step_kind(s: &str) -> Option<&'static str> {
     let s = s.trim_start();
-    for prefix in ["taint(", "plugin(", "cedar:", "cedarling:", "opa(", "authzen(", "nemo(", "cel:", "sequential:", "parallel:"] {
+    for prefix in ["taint(", "plugin(", "run(", "cedar:", "cedarling:", "opa(", "authzen(", "nemo(", "cel:", "sequential:", "parallel:"] {
         if s.starts_with(prefix) {
             return Some(prefix.trim_end_matches('(').trim_end_matches(':'));
         }
@@ -712,7 +712,7 @@ fn strip_string_literal(s: &str, rule: &str) -> Result<String, ParseError> {
 /// - **String entry** — a rule line, taint effect, or plugin call.
 ///   - `"require(authenticated)"` → `Step::Rule`
 ///   - `"delegation.depth > 2: deny"` → `Step::Rule`
-///   - `"plugin(rate_limiter)"` → `Step::Plugin`
+///   - `"plugin(rate_limiter)"` → `Step::Plugin` (`"run(rate_limiter)"` is an alias)
 ///   - `"taint(PII, session)"` → `Step::Taint`
 /// - **Map entry** (single-key map) — PDP call with optional reactions.
 ///   - `cedar: { action: read, resource: e, on_deny: [...] }` → `Step::Pdp`
@@ -747,18 +747,25 @@ fn parse_step_string(line: &str, source: &str) -> Result<Step, ParseError> {
         unreachable!("parse_taint always returns Stage::Taint");
     }
 
-    // plugin(name) — emit as Step::Plugin.
-    if trimmed.starts_with("plugin(") {
-        let inside = extract_call_args(trimmed, "plugin")
-            .ok_or_else(|| ParseError::Rule {
-                rule: trimmed.to_string(),
-                msg: "malformed `plugin(...)`".into(),
-            })?;
+    // plugin(name) / run(name) — invoke a named plugin. `run` is an
+    // alias for `plugin`; both emit Step::Plugin.
+    let plugin_verb = if trimmed.starts_with("plugin(") {
+        Some("plugin")
+    } else if trimmed.starts_with("run(") {
+        Some("run")
+    } else {
+        None
+    };
+    if let Some(verb) = plugin_verb {
+        let inside = extract_call_args(trimmed, verb).ok_or_else(|| ParseError::Rule {
+            rule: trimmed.to_string(),
+            msg: format!("malformed `{verb}(...)`"),
+        })?;
         let name = inside.trim();
         if name.is_empty() {
             return Err(ParseError::Rule {
                 rule: trimmed.to_string(),
-                msg: "plugin name must not be empty".into(),
+                msg: format!("`{verb}(...)`: plugin name must not be empty"),
             });
         }
         return Ok(Step::Plugin { name: name.to_string() });
@@ -1889,7 +1896,8 @@ fn parse_stage(src: &str) -> Result<Stage, ParseError> {
                 a.trim(),
             )))
         }
-        ("plugin", Some(a)) => Ok(Stage::Plugin { name: a.trim().to_string() }),
+        // `run` is an alias for `plugin` (mirrors the policy-step alias).
+        ("plugin" | "run", Some(a)) => Ok(Stage::Plugin { name: a.trim().to_string() }),
         ("taint", Some(a)) => parse_taint(a, src),
 
         (other, _) => Err(bad(&format!("unknown stage `{}`", other))),
@@ -2808,6 +2816,30 @@ do: "args.card_number | str | mask(4)"
     }
 
     #[test]
+    fn field_stage_run_aliases_plugin() {
+        // In a field pipeline, `run(name)` is the same plugin-transform
+        // stage as `plugin(name)` — symmetry with the policy-step alias.
+        let yaml = r#"
+when: role.support
+do: "args.card_number | run(luhn)"
+"#;
+        let step = parse_step_yaml(yaml).unwrap();
+        let Step::Rule(rule) = step else {
+            panic!("expected Step::Rule");
+        };
+        match &rule.effects[..] {
+            [Effect::FieldOp { path, stages }] => {
+                assert_eq!(path, "args.card_number");
+                match &stages[..] {
+                    [Stage::Plugin { name }] => assert_eq!(name, "luhn"),
+                    other => panic!("expected [Stage::Plugin], got {:?}", other),
+                }
+            }
+            other => panic!("expected single FieldOp, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn field_op_invalid_path_falls_through() {
         // `role.hr | redact` looks like a pipe chain but the path
         // doesn't start with `args.` / `result.`. We refuse to treat
@@ -3116,6 +3148,39 @@ routes:
             Effect::Plugin { name } => assert_eq!(name, "rate_limiter"),
             other => panic!("expected Effect::Plugin, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn compile_run_step_string_form_aliases_plugin() {
+        // `run(name)` is an alias for `plugin(name)`: both invoke a named
+        // plugin and compile to Effect::Plugin.
+        let yaml = r#"
+routes:
+  rate_limited:
+    policy:
+      - "run(rate_limiter)"
+"#;
+        let routes = compile_config(yaml).unwrap().routes;
+        let route = routes.get("rate_limited").unwrap();
+        assert_eq!(route.policy.len(), 1);
+        match &route.policy[0] {
+            Effect::Plugin { name } => assert_eq!(name, "rate_limiter"),
+            other => panic!("expected Effect::Plugin, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_step_run_is_plugin_alias() {
+        for s in ["run(audit-log)", "plugin(audit-log)"] {
+            let step = parse_step(&serde_yaml::Value::String(s.to_string()), "test").unwrap();
+            match step {
+                crate::step::Step::Plugin { name } => assert_eq!(name, "audit-log", "{s}"),
+                other => panic!("expected Step::Plugin for `{s}`, got {other:?}"),
+            }
+        }
+        // Empty / malformed `run(...)` surfaces a clear, verb-named error.
+        let err = parse_step(&serde_yaml::Value::String("run()".to_string()), "test").unwrap_err();
+        assert!(format!("{err}").contains("run("), "error should name `run(...)`: {err}");
     }
 
     #[test]

--- a/crates/apl-cpex/src/visitor.rs
+++ b/crates/apl-cpex/src/visitor.rs
@@ -390,9 +390,6 @@ impl ConfigVisitor for AplConfigVisitor {
         // we need for annotate_route. A route without an APL block AND
         // without inherited layers contributes nothing — skip.
         let route_apl = apl_subblock(yaml);
-        if let Some(block) = &route_apl {
-            warn_if_pdp_at_nonglobal_scope("route", block);
-        }
         let (entity_type, entity_names) = match entity_identity(parsed) {
             Some(e) => e,
             None => {
@@ -402,6 +399,9 @@ impl ConfigVisitor for AplConfigVisitor {
                 return Ok(());
             }
         };
+        if let Some(block) = &route_apl {
+            warn_if_pdp_at_nonglobal_scope(&format!("routes.{entity_type}"), block);
+        }
         let scope = parsed.meta.as_ref().and_then(|m| m.scope.clone());
         let tags: Vec<String> = parsed
             .meta
@@ -425,7 +425,7 @@ impl ConfigVisitor for AplConfigVisitor {
             )
         };
 
-        for entity_name in &entity_names {
+        for (idx, entity_name) in entity_names.iter().enumerate() {
             // route_key is what `DispatchCache` keys on, so it must
             // disambiguate scoped vs unscoped routes for the same
             // entity — otherwise two same-named annotations share one
@@ -459,6 +459,17 @@ impl ConfigVisitor for AplConfigVisitor {
                 let route_layer = compile_policy_block_value(&source, block)
                     .map_err(|e| Box::new(e) as VisitorError)?;
                 effective.apply_layer(route_layer);
+            }
+
+            // Load-time lint, once per route: flag any APL `plugins:`
+            // override declared for a plugin that no policy / delegate step
+            // references. Checked on the fully-stacked `effective` route so
+            // an override consumed by an inherited (global / default / tag)
+            // policy is not falsely flagged. The overrides and referenced
+            // names are entity-independent, so the first entity is
+            // representative — guarding on `idx == 0` keeps it to one pass.
+            if idx == 0 {
+                warn_unreferenced_plugin_overrides(&effective);
             }
 
             // No layers contributed anything? Don't install a handler — the
@@ -661,6 +672,33 @@ fn warn_if_pdp_at_nonglobal_scope(scope: &str, apl_block: &serde_yaml::Value) {
     }
 }
 
+/// Load-time lint: warn when an APL `plugins:` override is declared for a
+/// plugin that no `plugin(...)` / `run(...)` policy step (or `delegate(...)`
+/// step) in the effective route references. The `plugins:` map only
+/// *configures* a plugin — policy steps do the *activating* — so an
+/// unreferenced override has no effect and is almost always a typo or a
+/// leftover. Inspects the fully-stacked route, so an override consumed by an
+/// inherited (global / default / tag) policy is not falsely flagged. Called
+/// once per route from `visit_route` at config-load time, never per request.
+fn warn_unreferenced_plugin_overrides(route: &CompiledRoute) {
+    if route.plugin_overrides.is_empty() {
+        return;
+    }
+    let mut referenced: std::collections::HashSet<String> =
+        crate::dispatch_plan::collect_plugin_names(route).into_iter().collect();
+    referenced.extend(crate::dispatch_plan::collect_delegate_plugin_names(route));
+    for name in route.plugin_overrides.keys() {
+        if !referenced.contains(name) {
+            tracing::warn!(
+                plugin = %name,
+                route = %route.route_key,
+                "APL `plugins:` override declared for a plugin no policy step references \
+                 — the override has no effect (the `plugins:` map configures; policy steps activate)",
+            );
+        }
+    }
+}
+
 /// Strip the `pdp` sub-key from an `apl:` mapping so the remainder can
 /// be handed to `compile_policy_block_value` (which doesn't model PDP
 /// declarations — those are CPEX wiring concerns). Returns a clone of
@@ -825,5 +863,30 @@ mod tests {
         let without_pdp = yaml("policy:\n  - \"deny\"\n");
         warn_if_pdp_at_nonglobal_scope("route", &with_pdp);
         warn_if_pdp_at_nonglobal_scope("global.defaults.tool.apl", &without_pdp);
+    }
+
+    #[test]
+    fn unreferenced_plugin_override_is_detectable_and_lint_is_safe() {
+        use super::{compile_policy_block_value, warn_unreferenced_plugin_overrides};
+        // A route configures two plugins but its policy only activates one:
+        // `used` is referenced by a `plugin(...)` step, `unused` is only
+        // configured. The lint relies on `collect_plugin_names` seeing the
+        // referenced set; verify that linkage, then that the helper runs.
+        let block = yaml(
+            "policy:\n  - \"plugin(used)\"\n\
+             plugins:\n  used:\n    on_error: ignore\n  unused:\n    on_error: ignore\n",
+        );
+        let route = compile_policy_block_value("test", &block).expect("compiles");
+
+        let referenced = crate::dispatch_plan::collect_plugin_names(&route);
+        assert!(referenced.contains(&"used".to_string()), "policy step is referenced");
+        assert!(
+            !referenced.contains(&"unused".to_string()),
+            "config-only override is not a reference",
+        );
+        assert!(route.plugin_overrides.contains_key("unused"), "override was compiled in");
+
+        // Must not panic; it warns on `unused` and stays silent on `used`.
+        warn_unreferenced_plugin_overrides(&route);
     }
 }

--- a/crates/apl-cpex/src/visitor.rs
+++ b/crates/apl-cpex/src/visitor.rs
@@ -348,6 +348,7 @@ impl ConfigVisitor for AplConfigVisitor {
             return Ok(());
         };
         let source = format!("global.defaults.{}.apl", entity_type);
+        warn_if_pdp_at_nonglobal_scope(&source, &apl_block);
         let compiled = compile_policy_block_value(&source, &apl_block)
             .map_err(|e| Box::new(e) as VisitorError)?;
         self.state
@@ -368,6 +369,7 @@ impl ConfigVisitor for AplConfigVisitor {
             return Ok(());
         };
         let source = format!("global.policies.{}.apl", tag);
+        warn_if_pdp_at_nonglobal_scope(&source, &apl_block);
         let compiled = compile_policy_block_value(&source, &apl_block)
             .map_err(|e| Box::new(e) as VisitorError)?;
         self.state
@@ -388,6 +390,9 @@ impl ConfigVisitor for AplConfigVisitor {
         // we need for annotate_route. A route without an APL block AND
         // without inherited layers contributes nothing — skip.
         let route_apl = apl_subblock(yaml);
+        if let Some(block) = &route_apl {
+            warn_if_pdp_at_nonglobal_scope("route", block);
+        }
         let (entity_type, entity_names) = match entity_identity(parsed) {
             Some(e) => e,
             None => {
@@ -638,6 +643,24 @@ fn names_of(sol: &cpex_core::config::StringOrList) -> Vec<String> {
     }
 }
 
+/// Warn when an APL block carries a `pdp:` declaration at a scope that
+/// cannot act on it. Only [`AplConfigVisitor::visit_global`] builds PDPs
+/// (they are process-global CPEX wiring); a `pdp:` written under a
+/// default / policy-bundle / route block is folded into the policy body
+/// and silently discarded by `compile_policy_block_value`. Surfacing it
+/// here turns that quiet no-op into an actionable signal. Applies to
+/// both the flat and `apl:`-wrapped forms — neither is processed off the
+/// global scope.
+fn warn_if_pdp_at_nonglobal_scope(scope: &str, apl_block: &serde_yaml::Value) {
+    if apl_block.get("pdp").is_some() {
+        tracing::warn!(
+            scope,
+            "APL visitor: `pdp:` is only honored under the top-level `global:` block; \
+             the declaration at this scope is ignored",
+        );
+    }
+}
+
 /// Strip the `pdp` sub-key from an `apl:` mapping so the remainder can
 /// be handed to `compile_policy_block_value` (which doesn't model PDP
 /// declarations — those are CPEX wiring concerns). Returns a clone of
@@ -790,5 +813,17 @@ mod tests {
             Some("allow"),
             "the explicit apl wrapper takes precedence over flat top-level keys",
         );
+    }
+
+    #[test]
+    fn warn_if_pdp_at_nonglobal_scope_is_a_safe_noop() {
+        use super::warn_if_pdp_at_nonglobal_scope;
+        // The helper only emits a tracing event; it must never panic
+        // whether `pdp` is present or not. (The drop semantics are
+        // exercised end-to-end; here we just guard the helper's contract.)
+        let with_pdp = yaml("policy:\n  - \"deny\"\npdp:\n  - kind: cel\n");
+        let without_pdp = yaml("policy:\n  - \"deny\"\n");
+        warn_if_pdp_at_nonglobal_scope("route", &with_pdp);
+        warn_if_pdp_at_nonglobal_scope("global.defaults.tool.apl", &without_pdp);
     }
 }

--- a/crates/apl-cpex/src/visitor.rs
+++ b/crates/apl-cpex/src/visitor.rs
@@ -328,7 +328,7 @@ impl ConfigVisitor for AplConfigVisitor {
         // accepts maps with `policy:` / `post_policy:` / `args:` /
         // `result:` / `plugins:` (and inert fields it ignores), so a
         // shallow strip on a clone is enough.
-        let policy_only = strip_pdp_key(apl_block);
+        let policy_only = strip_pdp_key(&apl_block);
         let compiled = compile_policy_block_value("global.apl", &policy_only)
             .map_err(|e| Box::new(e) as VisitorError)?;
         self.state
@@ -348,7 +348,7 @@ impl ConfigVisitor for AplConfigVisitor {
             return Ok(());
         };
         let source = format!("global.defaults.{}.apl", entity_type);
-        let compiled = compile_policy_block_value(&source, apl_block)
+        let compiled = compile_policy_block_value(&source, &apl_block)
             .map_err(|e| Box::new(e) as VisitorError)?;
         self.state
             .write()
@@ -368,7 +368,7 @@ impl ConfigVisitor for AplConfigVisitor {
             return Ok(());
         };
         let source = format!("global.policies.{}.apl", tag);
-        let compiled = compile_policy_block_value(&source, apl_block)
+        let compiled = compile_policy_block_value(&source, &apl_block)
             .map_err(|e| Box::new(e) as VisitorError)?;
         self.state
             .write()
@@ -449,7 +449,7 @@ impl ConfigVisitor for AplConfigVisitor {
             }
             drop(state);
 
-            if let Some(block) = route_apl {
+            if let Some(block) = &route_apl {
                 let source = format!("routes.{}.apl", route_key);
                 let route_layer = compile_policy_block_value(&source, block)
                     .map_err(|e| Box::new(e) as VisitorError)?;
@@ -667,14 +667,128 @@ fn on_error_to_string(on_err: &cpex_core::plugin::OnError) -> String {
     on_err.to_string()
 }
 
-/// Pull the `apl:` sub-block out of a section's raw YAML. Returns `None`
-/// when absent or null — callers treat that as "no contribution from
-/// this section" and move on.
-fn apl_subblock(yaml: &serde_yaml::Value) -> Option<&serde_yaml::Value> {
-    let block = yaml.get("apl")?;
-    if block.is_null() {
+/// APL DSL keys recognized directly on a section (route / global /
+/// defaults / policy-bundle) when the `apl:` wrapper is omitted.
+/// `plugins` is intentionally absent here — it is shape-ambiguous (a
+/// structural plugin-ref *list* vs an apl-override *map*) and handled
+/// separately in [`apl_subblock`].
+const FLAT_APL_KEYS: [&str; 5] = ["policy", "post_policy", "args", "result", "pdp"];
+
+/// Pull a section's APL block out of its raw YAML.
+///
+/// The explicit `apl:` wrapper (`route -> apl -> policy`) takes
+/// precedence. When it is absent, APL terms written directly on the
+/// section (`route -> policy`) are accepted too: a synthetic block is
+/// assembled from the recognized [`FLAT_APL_KEYS`] present on the
+/// container, plus `plugins` when (and only when) it is a *mapping* —
+/// the apl-override shape. A structural `plugins:` *list*
+/// (`RouteEntry` / `PolicyGroup`) is left untouched. Returns `None`
+/// when neither a wrapper nor any flat APL key is present — callers
+/// treat that as "no contribution from this section" and move on.
+fn apl_subblock(yaml: &serde_yaml::Value) -> Option<serde_yaml::Value> {
+    // Explicit `apl:` wrapper wins.
+    if let Some(block) = yaml.get("apl") {
+        return if block.is_null() {
+            None
+        } else {
+            Some(block.clone())
+        };
+    }
+
+    // Fallback: APL terms written directly on the section, with no
+    // `apl:` nesting. Copy only the unambiguous APL keys so structural
+    // keys (tool / identity / defaults / ...) are never misread.
+    let mut block = serde_yaml::Mapping::new();
+    for key in FLAT_APL_KEYS {
+        if let Some(value) = yaml.get(key) {
+            block.insert(serde_yaml::Value::String(key.to_string()), value.clone());
+        }
+    }
+    // `plugins` only in its apl-override (map) shape; a list is the
+    // structural plugin-ref form and belongs to the section's own parse.
+    if let Some(value) = yaml.get("plugins") {
+        if value.is_mapping() {
+            block.insert(
+                serde_yaml::Value::String("plugins".to_string()),
+                value.clone(),
+            );
+        }
+    }
+
+    if block.is_empty() {
         None
     } else {
-        Some(block)
+        Some(serde_yaml::Value::Mapping(block))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::apl_subblock;
+
+    fn yaml(s: &str) -> serde_yaml::Value {
+        serde_yaml::from_str(s).expect("valid yaml")
+    }
+
+    #[test]
+    fn apl_wrapper_is_returned_as_is() {
+        let v = yaml("apl:\n  policy:\n    - \"deny\"\n");
+        let block = apl_subblock(&v).expect("wrapper present");
+        assert!(block.get("policy").is_some(), "wrapper block exposes policy");
+    }
+
+    #[test]
+    fn null_apl_wrapper_is_none() {
+        let v = yaml("apl: null\n");
+        assert!(apl_subblock(&v).is_none(), "explicit null apl => no contribution");
+    }
+
+    #[test]
+    fn flat_policy_without_wrapper_is_collected() {
+        let v = yaml("tool: get_weather\npolicy:\n  - \"deny\"\n");
+        let block = apl_subblock(&v).expect("flat policy recognized");
+        assert!(block.get("policy").is_some(), "flat policy lifted into the block");
+        assert!(
+            block.get("tool").is_none(),
+            "structural keys must not leak into the apl block",
+        );
+    }
+
+    #[test]
+    fn flat_plugins_map_included_but_list_excluded() {
+        // Map shape is the apl-override form → kept.
+        let m = yaml("plugins:\n  audit:\n    on_error: ignore\n");
+        let block = apl_subblock(&m).expect("plugins map is an apl term");
+        assert!(block.get("plugins").is_some(), "plugins map is kept");
+
+        // List shape is structural plugin-refs → not an apl block; with no
+        // other APL keys present, the section contributes nothing.
+        let l = yaml("plugins:\n  - audit\n");
+        assert!(
+            apl_subblock(&l).is_none(),
+            "structural plugins list must not be treated as an apl block",
+        );
+    }
+
+    #[test]
+    fn section_without_apl_terms_is_none() {
+        let v = yaml("tool: get_weather\n");
+        assert!(apl_subblock(&v).is_none(), "no APL terms => no contribution");
+    }
+
+    #[test]
+    fn explicit_wrapper_wins_over_flat_keys() {
+        let v = yaml("apl:\n  policy:\n    - \"allow\"\npolicy:\n  - \"deny\"\n");
+        let block = apl_subblock(&v).expect("wrapper present");
+        let policy = block
+            .get("policy")
+            .and_then(|p| p.as_sequence())
+            .expect("policy sequence");
+        assert_eq!(policy.len(), 1);
+        assert_eq!(
+            policy[0].as_str(),
+            Some("allow"),
+            "the explicit apl wrapper takes precedence over flat top-level keys",
+        );
     }
 }

--- a/crates/apl-cpex/tests/visitor_e2e.rs
+++ b/crates/apl-cpex/tests/visitor_e2e.rs
@@ -764,3 +764,145 @@ routes:
     let violation = result.violation.expect("deny path must surface a violation");
     assert_eq!(violation.reason, "deny-gate fired");
 }
+
+// =====================================================================
+// Flat `plugins:` MAP form (no `apl:` wrapper) — regression coverage
+// for the load-path bug where a route/defaults/policy `plugins:` map
+// failed to deserialize into `Vec<PluginRouteRef>` *before* any visitor
+// ran. The structural parse now tolerates the map (treats it as APL
+// per-plugin override data and leaves the structural list empty); the
+// APL visitor consumes the map from the raw YAML. These tests drive the
+// map through the real `load_config_yaml` path the unit tests can't hit.
+// =====================================================================
+
+/// A route with a flat `policy:` AND a flat `plugins:` *map* override
+/// (no `apl:` wrapper) loads through `load_config_yaml` (previously a
+/// hard `invalid type: map, expected a sequence` error) and the policy
+/// still fires — proving the override map and the activating policy
+/// coexist on the same section.
+#[tokio::test]
+async fn flat_route_with_plugins_map_and_policy_loads_and_denies() {
+    const YAML: &str = r#"
+plugins:
+  - name: deny-gate
+    kind: deny-gate
+    hooks: [cmf.tool_pre_invoke]
+routes:
+  - tool: get_weather
+    policy:
+      - "plugin(deny-gate)"
+    plugins:
+      deny-gate:
+        on_error: ignore
+"#;
+    let mgr = build_manager_with_visitor(YAML).await;
+
+    let ext = Extensions {
+        meta: Some(Arc::new(meta_for_tool("get_weather"))),
+        ..Default::default()
+    };
+    let (result, _bg) = mgr
+        .invoke_named::<CmfHook>("cmf.tool_pre_invoke", cmf_payload("hi"), ext, None)
+        .await;
+
+    assert!(
+        !result.continue_processing,
+        "flat plugins-map route should still run its policy and deny"
+    );
+    let violation = result.violation.expect("deny path must surface a violation");
+    assert_eq!(violation.reason, "deny-gate fired");
+}
+
+/// The flat `plugins:` map form must be behaviorally identical to the
+/// `apl: { plugins: {...} }` wrapper form — that equivalence is the
+/// whole point of "the wrapper is optional". An override map alone
+/// declares no phases, so neither form installs an APL handler; whatever
+/// the legacy chain then does, both forms must do the same thing. We
+/// assert the two routes resolve to the same decision rather than
+/// hard-coding the legacy-chain outcome (which this PR doesn't touch).
+#[tokio::test]
+async fn flat_plugins_map_only_matches_wrapped_plugins_map_only() {
+    const FLAT: &str = r#"
+plugins:
+  - name: deny-gate
+    kind: deny-gate
+    hooks: [cmf.tool_pre_invoke]
+routes:
+  - tool: get_weather
+    plugins:
+      deny-gate:
+        on_error: ignore
+"#;
+    const WRAPPED: &str = r#"
+plugins:
+  - name: deny-gate
+    kind: deny-gate
+    hooks: [cmf.tool_pre_invoke]
+routes:
+  - tool: get_weather
+    apl:
+      plugins:
+        deny-gate:
+          on_error: ignore
+"#;
+
+    async fn decide(yaml: &str) -> bool {
+        let mgr = build_manager_with_visitor(yaml).await;
+        let ext = Extensions {
+            meta: Some(Arc::new(meta_for_tool("get_weather"))),
+            ..Default::default()
+        };
+        let (result, _bg) = mgr
+            .invoke_named::<CmfHook>("cmf.tool_pre_invoke", cmf_payload("hi"), ext, None)
+            .await;
+        result.continue_processing
+    }
+
+    assert_eq!(
+        decide(FLAT).await,
+        decide(WRAPPED).await,
+        "flat plugins-map and apl-wrapped plugins-map must resolve identically",
+    );
+}
+
+/// A `plugins:` map at `global.defaults.<entity>` scope loads through
+/// the full pipeline. Before the fix this failed at the structural
+/// `CpexConfig` parse (the defaults group's `plugins` is also a `Vec`).
+/// The default layer contributes the policy; the route inherits it.
+#[tokio::test]
+async fn flat_defaults_plugins_map_loads_through_full_pipeline() {
+    const YAML: &str = r#"
+plugins:
+  - name: deny-gate
+    kind: deny-gate
+    hooks: [cmf.tool_pre_invoke]
+global:
+  defaults:
+    tool:
+      policy:
+        - "plugin(deny-gate)"
+      plugins:
+        deny-gate:
+          on_error: ignore
+routes:
+  - tool: get_weather
+"#;
+    let mgr = build_manager_with_visitor(YAML).await;
+
+    let ext = Extensions {
+        meta: Some(Arc::new(meta_for_tool("get_weather"))),
+        ..Default::default()
+    };
+    let (result, _bg) = mgr
+        .invoke_named::<CmfHook>("cmf.tool_pre_invoke", cmf_payload("hi"), ext, None)
+        .await;
+
+    assert!(
+        !result.continue_processing,
+        "tool default with a flat plugins-map override should still deny via inherited policy"
+    );
+    assert_eq!(
+        result.violation.expect("deny expected").reason,
+        "deny-gate fired"
+    );
+}

--- a/crates/apl-cpex/tests/visitor_e2e.rs
+++ b/crates/apl-cpex/tests/visitor_e2e.rs
@@ -703,3 +703,64 @@ routes:
         msg
     );
 }
+
+/// Flat form: a route may declare `policy:` directly, without the `apl:`
+/// wrapper. The visitor recognizes it identically to the wrapped form.
+/// (Also exercises the `run(...)` plugin alias.)
+#[tokio::test]
+async fn visitor_flat_route_without_apl_wrapper_allows() {
+    const YAML: &str = r#"
+plugins:
+  - name: allow-gate
+    kind: allow-gate
+    hooks: [cmf.tool_pre_invoke]
+routes:
+  - tool: get_weather
+    policy:
+      - "run(allow-gate)"
+"#;
+    let mgr = build_manager_with_visitor(YAML).await;
+
+    let ext = Extensions {
+        meta: Some(Arc::new(meta_for_tool("get_weather"))),
+        ..Default::default()
+    };
+    let (result, _bg) = mgr
+        .invoke_named::<CmfHook>("cmf.tool_pre_invoke", cmf_payload("hi"), ext, None)
+        .await;
+
+    assert!(
+        result.continue_processing,
+        "flat (no-apl-wrapper) allow path should continue: violation = {:?}",
+        result.violation
+    );
+}
+
+/// Flat form deny mirrors the wrapped deny path — the route's `policy:`
+/// is honored without an `apl:` wrapper and the violation propagates.
+#[tokio::test]
+async fn visitor_flat_route_without_apl_wrapper_denies() {
+    const YAML: &str = r#"
+plugins:
+  - name: deny-gate
+    kind: deny-gate
+    hooks: [cmf.tool_pre_invoke]
+routes:
+  - tool: get_weather
+    policy:
+      - "plugin(deny-gate)"
+"#;
+    let mgr = build_manager_with_visitor(YAML).await;
+
+    let ext = Extensions {
+        meta: Some(Arc::new(meta_for_tool("get_weather"))),
+        ..Default::default()
+    };
+    let (result, _bg) = mgr
+        .invoke_named::<CmfHook>("cmf.tool_pre_invoke", cmf_payload("hi"), ext, None)
+        .await;
+
+    assert!(!result.continue_processing, "flat deny path should halt");
+    let violation = result.violation.expect("deny path must surface a violation");
+    assert_eq!(violation.reason, "deny-gate fired");
+}

--- a/crates/cpex-core/src/config.rs
+++ b/crates/cpex-core/src/config.rs
@@ -189,7 +189,7 @@ pub struct PolicyGroup {
     pub metadata: HashMap<String, String>,
 
     /// Plugin references to activate when this group matches.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_plugin_refs")]
     pub plugins: Vec<PluginRouteRef>,
 
     /// Identity dispatch list contributed by this tag bundle.
@@ -241,6 +241,49 @@ impl PluginRouteRef {
     }
 }
 
+/// Deserialize a `plugins:` field that may take either of two YAML
+/// shapes, so the `apl:` wrapper is genuinely optional everywhere.
+///
+/// - A **sequence** is the structural activation list — each item is a
+///   [`PluginRouteRef`] (bare name or single-key override map). It
+///   deserializes into the `Vec` as usual.
+/// - A **mapping** is the APL per-plugin *override* form, written
+///   directly on the section when the `apl:` wrapper is omitted (e.g.
+///   `plugins: { audit: { on_error: ignore } }`). It is **not** a
+///   structural activation list: the override map is consumed
+///   separately by the APL visitor straight from the raw YAML, so here
+///   it deserializes to an empty `Vec`. This mirrors the explicit
+///   `apl: { plugins: {...} }` wrapper form, where the map never
+///   reaches this field at all — keeping the two forms behaviorally
+///   identical (the map supplies overrides; policy steps still do the
+///   activating).
+///
+/// Null / absent → empty `Vec` (same as `#[serde(default)]`).
+fn deserialize_plugin_refs<'de, D>(deserializer: D) -> Result<Vec<PluginRouteRef>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    match serde_yaml::Value::deserialize(deserializer)? {
+        // Structural activation list.
+        serde_yaml::Value::Sequence(items) => items
+            .into_iter()
+            .map(|item| serde_yaml::from_value(item).map_err(D::Error::custom))
+            .collect(),
+        // APL override map — owned by the APL visitor, not the
+        // structural parse. See doc comment above.
+        serde_yaml::Value::Mapping(_) => Ok(Vec::new()),
+        // Null / absent → no structural plugins.
+        serde_yaml::Value::Null => Ok(Vec::new()),
+        other => Err(D::Error::custom(format!(
+            "`plugins:` must be a sequence (activation list) or a mapping \
+             (APL per-plugin overrides), got {:?}",
+            other
+        ))),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Route Entry
 // ---------------------------------------------------------------------------
@@ -278,7 +321,7 @@ pub struct RouteEntry {
     pub when: Option<String>,
 
     /// Plugin references to activate for this route.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_plugin_refs")]
     pub plugins: Vec<PluginRouteRef>,
 
     /// Identity-resolve dispatch list for this route. **Hook-specific**:
@@ -2002,5 +2045,100 @@ routes:
             Some("tenant-b"),
         );
         assert!(non_matching.is_empty());
+    }
+
+    // -----------------------------------------------------------------
+    // `plugins:` accepts both shapes (map-tolerant deserializer)
+    //
+    // A *sequence* is the structural activation list. A *mapping* is the
+    // APL per-plugin override form (consumed by the APL visitor from the
+    // raw YAML), so it deserializes to an empty structural list here.
+    // Before this, a map at route/defaults/policy scope failed the whole
+    // `CpexConfig` parse with "invalid type: map, expected a sequence".
+    //
+    // These exercise deserialization directly (not `parse_config`, which
+    // also runs `validate_config`'s plugin-reference checks) because the
+    // bug being fixed was a *deserialize-time* failure.
+    // -----------------------------------------------------------------
+
+    fn deserialize_cfg(yaml: &str) -> Result<CpexConfig, String> {
+        serde_yaml::from_str(yaml).map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn route_plugins_list_parses_as_activation_list() {
+        let cfg = deserialize_cfg(
+            r#"
+routes:
+  - tool: get_weather
+    plugins:
+      - rate_limiter
+      - pii_scanner:
+          config:
+            sensitivity: high
+"#,
+        )
+        .unwrap();
+        let plugins = &cfg.routes[0].plugins;
+        assert_eq!(plugins.len(), 2);
+        assert_eq!(plugins[0].name(), "rate_limiter");
+        assert_eq!(plugins[1].name(), "pii_scanner");
+    }
+
+    #[test]
+    fn route_plugins_map_loads_as_empty_structural_list() {
+        let cfg = deserialize_cfg(
+            r#"
+routes:
+  - tool: get_weather
+    plugins:
+      audit:
+        on_error: ignore
+"#,
+        )
+        .expect("flat plugins map must deserialize");
+        assert!(
+            cfg.routes[0].plugins.is_empty(),
+            "a plugins map is APL-override data, not a structural activation list",
+        );
+    }
+
+    #[test]
+    fn defaults_and_policies_plugins_map_loads() {
+        let cfg = deserialize_cfg(
+            r#"
+global:
+  defaults:
+    tool:
+      plugins:
+        audit:
+          on_error: ignore
+  policies:
+    sensitive:
+      plugins:
+        pii_scanner:
+          config:
+            sensitivity: high
+"#,
+        )
+        .expect("defaults/policies plugins map must deserialize");
+        assert!(cfg.global.defaults["tool"].plugins.is_empty());
+        assert!(cfg.global.policies["sensitive"].plugins.is_empty());
+    }
+
+    #[test]
+    fn scalar_plugins_value_is_rejected_with_clear_error() {
+        let err = deserialize_cfg(
+            r#"
+routes:
+  - tool: get_weather
+    plugins: nonsense
+"#,
+        )
+        .expect_err("scalar plugins must error");
+        assert!(
+            err.contains("sequence") && err.contains("mapping"),
+            "expected a shape-aware error, got: {err}",
+        );
     }
 }

--- a/crates/cpex-core/src/config.rs
+++ b/crates/cpex-core/src/config.rs
@@ -620,6 +620,16 @@ pub fn parse_config(yaml: &str) -> Result<CpexConfig, Box<PluginError>> {
 // ---------------------------------------------------------------------------
 
 /// Validate a parsed config for structural correctness.
+///
+/// This checks only the *structural* plugin activation lists
+/// (`route.plugins` / `policy_group.plugins` sequences). It deliberately
+/// does NOT validate APL plugin references — neither `plugin(...)` / `run(...)`
+/// policy steps nor the APL per-plugin override *map* (which
+/// [`deserialize_plugin_refs`] folds into an empty structural `Vec`, leaving
+/// it for the APL visitor to consume). Those are resolved and validated at
+/// dispatch-plan build time, where an unknown or unreferenced plugin is logged
+/// and skipped (see `apl-cpex::dispatch_plan`). Keeping cpex-core's validation
+/// free of APL semantics is intentional.
 fn validate_config(config: &CpexConfig) -> Result<(), Box<PluginError>> {
     let mut seen_names = HashSet::new();
     for plugin in &config.plugins {


### PR DESCRIPTION
### Summary

Improves APL ergonomics while maintaining backwards compatibility with original syntax. 

### Changes

#### make the `apl:` wrapper optional

APL config blocks previously had to be nested under an `apl:` key at every level (`route -> apl -> policy`, `global -> apl -> pdp`, ...). The visitor's `apl_subblock` now accepts APL terms written directly on the section when the wrapper is omitted (`route -> policy`), while the explicit `apl:` form still takes precedence.

When `apl:` is absent, a synthetic block is assembled from the recognized APL keys present on the container — `policy`, `post_policy`, `args`, `result`, `pdp` — so structural keys (tool / identity / defaults / ...) are never misread. `plugins` is shape-gated: a map (the apl-override form) is included, a list (structural plugin-refs on RouteEntry / PolicyGroup) is left alone, avoiding a key-shape clash. Empty sections still return None (the "no contribution, skip" path).

Applies uniformly to the global / defaults / policy-bundle / route visit sites. Add unit tests for the shape rules (wrapper precedence, flat keys, plugins map-vs-list, null/empty) and end-to-end tests for a wrapper-less route on both the allow and deny paths.

#### accept `run` as an alias for plugin
`run(name)` now invokes a named plugin everywhere `plugin(name)` does, so policies can read `- run(audit-log)` instead of `- plugin(audit-log)`:

- policy-step / effect form (`parse_step_string`) — covers top-level  `policy:` items and `do:` lists, and `detect_step_kind` recognizes `run(` so misrouted strings still get a clear step-kind error;
- field-pipeline stage form (`args.x: "str | run(name)"`) — mirrors the  step alias for symmetry.

`plugin` remains the long form; both parse to the same `Step::Plugin` / `Stage::Plugin`. Errors name whichever verb the author used.

Add tests for the step alias (string + compile paths), the field-stage alias, and the empty/malformed error path.

#### accept unconditional `deny('reason')` as a bare action

`parse_rule`'s no-colon branch only recognized bare `deny` / `allow` via `try_bare_action`; the `deny('reason')` / `deny('reason', 'code')` call form was reachable only as the action half of a conditional rule (`predicate: deny('reason')`). That made it impossible to attach a reason/code to an unconditional reaction — notably `on_deny:` /`on_allow:` lists on PDP steps, which parse each item through `parse_step -> parse_step_string -> parse_rule`.

Fall through to `try_parse_deny_call` after `try_bare_action` so an unconditional `deny('reason')` / `deny('reason', 'code')` parses to an `Always`-guarded `Deny`. A malformed `deny(...)` surfaces its own error rather than being misread as a predicate downstream.

Add tests covering the reason-only and reason+code forms and the malformed-call error path.
