### PR TITLE
build: bump quinn-proto to 0.11.15 for RUSTSEC-2026-0185

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,9 +3371,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
### Summary

Bump quinn-proto to 0.11.15 for RUSTSEC-2026-0185 quinn-proto < 0.11.15 is flagged by RUSTSEC-2026-0185 (remote memory exhaustion via unbounded out-of-order stream reassembly). It is pinned in the lockfile only as reqwest's optional http3 dependency and is never compiled. Bump the pin to the patched 0.11.15; no build impact.