### PR TITLE
fix: stale HookRef in TaskProcessor, and cmf vs. bare compatibility

### DIFF
--- a/cpex/framework/base.py
+++ b/cpex/framework/base.py
@@ -441,10 +441,13 @@ class HookRef:
         self._plugin_ref = plugin_ref
         self._hook = hook
 
-        # Try convention-based lookup first (method name matches hook type)
+        # Try convention-based lookup first (method name matches hook type).
+        # For namespaced hooks like "cmf.tool_pre_invoke", also try the bare
+        # name "tool_pre_invoke" so convention-named methods are found.
+        bare_hook = hook.rsplit(".", 1)[-1] if "." in hook else hook
         self._func: Callable[[PluginPayload, PluginContext], Awaitable[PluginResult]] | None = getattr(
             plugin_ref.plugin, hook, None
-        )
+        ) or getattr(plugin_ref.plugin, bare_hook, None)
 
         # If not found by convention, scan for @hook decorated methods
         if self._func is None:
@@ -455,7 +458,7 @@ class HookRef:
 
                 # Check for @hook decorator metadata
                 metadata = get_hook_metadata(method)
-                if metadata and metadata.matches(hook):
+                if metadata and (metadata.matches(hook) or metadata.matches(bare_hook)):
                     self._func = method
                     break
 

--- a/cpex/framework/isolated/worker.py
+++ b/cpex/framework/isolated/worker.py
@@ -36,7 +36,7 @@ class TaskProcessor:
 
     config_hash: str
     module_path_hash: str
-    hook_ref: HookRef
+    plugin_ref: PluginRef
     executor: PluginExecutor
     plugin_config: PluginConfig | None = None
 
@@ -55,18 +55,26 @@ class TaskProcessor:
 
     def initialize(
         self,
-        hook_ref: HookRef,
+        plugin_ref: PluginRef,
         executor: PluginExecutor,
         json_config: str,
         module_path: str,
         plugin_config: PluginConfig,
     ):
         """Assign locals, and compute hashes."""
-        self.hook_ref = hook_ref
+        # self.hook_ref = hook_ref
+        self.plugin_ref = plugin_ref
         self.executor = executor
         self.config_hash = self.compute_hash(json_config_or_module_path=json_config)
         self.module_path_hash = self.compute_hash(json_config_or_module_path=module_path)
         self.plugin_config = plugin_config
+
+    def get_hook_ref(self, hook_type: str) -> HookRef:
+        """
+        make sure that the hook ref is not stale for the current task data.
+        """
+        hook_ref = HookRef(hook_type, self.plugin_ref)
+        return hook_ref
 
 
 def get_environment_info():
@@ -112,7 +120,6 @@ async def process_task(task_data, tp: TaskProcessor):
         if tp.config_hash != tp.compute_hash(json_config):
             # pull the resolved plugin path and only add the module path if it has the same root
             config: PluginConfig = PluginConfig(**config_raw)
-            hook_type = task_data.get(HOOK_TYPE)
             cls_name: str = task_data.get("class_name")
             mod_name, n_cls_name = parse_class_name(cls_name)
             module: ModuleType = import_module(mod_name)
@@ -121,12 +128,10 @@ async def process_task(task_data, tp: TaskProcessor):
             plugin_type = cast(Type[Plugin], class_)
             plugin = plugin_type(config)
             await plugin.initialize()
-            # now invoke the hook
             plugin_ref = PluginRef(plugin)
-            hook_ref = HookRef(hook_type, plugin_ref)
             executor = PluginExecutor(None, 30)
             tp.initialize(
-                hook_ref=hook_ref,
+                plugin_ref=plugin_ref,
                 executor=executor,
                 json_config=json_config,
                 module_path=json.dumps(resolved_paths),
@@ -134,11 +139,21 @@ async def process_task(task_data, tp: TaskProcessor):
             )
         # retrieve the context
         context = task_data.get("context")
+        hook_type = task_data.get(HOOK_TYPE)
+        # Normalize namespaced hook names (e.g. "cmf.tool_pre_invoke" →
+        # "tool_pre_invoke") so that convention-named plugin methods are found.
+        # Plugins that use @hook("cmf.tool_pre_invoke") decorators are handled
+        # by the bare-name fallback in HookRef; plugins that rely solely on
+        # method-name convention need the bare name here.
+        if hook_type and "." in hook_type:
+            bare = hook_type.rsplit(".", 1)[-1]
+            if not hasattr(tp.plugin_ref.plugin, hook_type) and hasattr(tp.plugin_ref.plugin, bare):
+                hook_type = bare
         plugin_context = PluginContext(
             state=context.get("state"), global_context=context.get("global_context"), metadata=context.get("metadata")
         )
         result = await tp.executor.execute_plugin(
-            hook_ref=tp.hook_ref,
+            hook_ref=tp.get_hook_ref(hook_type),
             payload=task_data.get("payload"),
             local_context=plugin_context,
             violations_as_exceptions=False,
@@ -224,7 +239,8 @@ async def main():
                 error_response = {
                     "status": "error",
                     "message": f"Unexpected error: {str(e)}",
-                    "request_id": "unknown",
+                    # Use the request_id captured above when available so callers can demux.
+                    "request_id": request_id if "request_id" in locals() else "unknown",
                 }
                 print(json.dumps(error_response), flush=True)
 

--- a/tests/unit/cpex/framework/isolated/test_worker.py
+++ b/tests/unit/cpex/framework/isolated/test_worker.py
@@ -333,7 +333,7 @@ class TestMainFunction:
         output_data = json.loads(printed_output)
         assert output_data["status"] == "error"
         assert "Unexpected error: Unexpected error occurred" in output_data["message"]
-        assert output_data["request_id"] == "unknown"
+        assert output_data["request_id"] == "req-789"
 
     @pytest.mark.asyncio
     @patch("sys.stdin")


### PR DESCRIPTION
### Summary

This PR addresses a bug in isolated_venv 0.1.x and python compatibility with the CPEX 0.2.x framwork (#20)


### Changes
- The TaskProcessor instances cached a HookRef which became stale after  initialization.  The PluginRef is now cached instead, and a fresh HookRef used on each execute_plugin call.
- For compatibility with invocation from CPEX 0.2.0, allow either cmf hook conventions or bare hook names.

### Checks

- [x] `make lint` passes
- [x] `make test` passes
